### PR TITLE
Remove "Proof" property section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1644,65 +1644,6 @@ Example:
 
     <section>
       <h2>
-Proof (Optional)
-      </h2>
-
-      <p>
-A <code>proof</code> on a DID Document is cryptographic proof of the
-integrity of the DID Document according to either:
-      </p>
-
-      <ol start="1">
-        <li>
-The subject as defined in Section <a href="#did-subject"></a>, or:
-        </li>
-
-        <li>
-The controller as defined in Section <a href="#authorization-and-delegation"></a>, if present.
-        </li>
-      </ol>
-
-      <p>
-This proof is NOT proof of the binding between a DID and a DID
-Document. See Section <a href="#binding-of-identity"></a>. The rules
-for a proof are:
-      </p>
-
-      <ol start="1">
-        <li>
-A DID Document MAY have exactly one property representing a
-proof.
-        </li>
-
-        <li>
-The key for this property MUST be <code>proof</code>.
-        </li>
-
-        <li>
-The value of this key MUST be a valid JSON-LD proof as defined by
-<a href="https://w3c-dvcg.github.io/ld-signatures/">Linked Data
-Proofs</a>.
-        </li>
-      </ol>
-
-      <p>
-Example:
-      </p>
-
-      <pre class="example nohighlight" title="A signature-based proof">
-{
-  "proof": {
-    "type": "LinkedDataSignature2015",
-    "created": "2016-02-08T16:02:20Z",
-    "creator": "did:example:8uQhQMGzWxR8vw5P3UWH1ja#keys-1",
-    "signatureValue": "QNB13Y7Q9...1tzjn4w=="
-  }
-}
-</pre>
-    </section>
-
-    <section>
-      <h2>
 Extensibility
       </h2>
 


### PR DESCRIPTION
This PR removes the proof property from the DID Document data model as I don't think anyone is using it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/pull/26.html" title="Last updated on Sep 26, 2019, 2:30 PM UTC (2014a47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/26/0c41898...2014a47.html" title="Last updated on Sep 26, 2019, 2:30 PM UTC (2014a47)">Diff</a>