### PR TITLE
Remove "Updated" property section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1607,43 +1607,6 @@ Example:
 
     <section>
       <h2>
-Updated (Optional)
-      </h2>
-
-      <p>
-Standard metadata for identifier records includes a timestamp of the
-most recent change. The rules for including an updated timestamp are:
-      </p>
-
-      <ol start="1">
-        <li>
-A DID Document MUST have zero or one property representing an
-updated timestamp. It is RECOMMENDED to include this property.
-        </li>
-
-        <li>
-The key for this property MUST be updated.
-        </li>
-
-        <li>
-The value of this key MUST follow the formatting rules (3, 4, 5)
-from Section <a href="#created-optional"></a>.
-        </li>
-      </ol>
-
-      <p>
-Example:
-      </p>
-
-      <pre class="example nohighlight">
-{
-  "updated": "2016-10-17T02:41:00Z"
-}
-</pre>
-    </section>
-
-    <section>
-      <h2>
 Proof (Optional)
       </h2>
 


### PR DESCRIPTION
This PR removes the updated property from the DID Document as I don't think anyone is using the property, and it almost certainly belongs in a DID Resolver response rather than a DID Document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/pull/27.html" title="Last updated on Sep 26, 2019, 2:23 PM UTC (64b324c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-spec/27/0c41898...64b324c.html" title="Last updated on Sep 26, 2019, 2:23 PM UTC (64b324c)">Diff</a>