### PR TITLE
Added support for ethereumAddress in context - fixed #55

### DIFF
--- a/contexts/did-v0.11.jsonld
+++ b/contexts/did-v0.11.jsonld
@@ -38,6 +38,7 @@
     "delegator": {"@id": "sec:delegator", "@type": "@id"},
     "domain": "sec:domain",
     "expirationDate": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "ethereumAddress": "sec:ethereumAddress",
     "invocationTarget": {"@id": "sec:invocationTarget", "@type": "@id"},
     "invoker": {"@id": "sec:invoker", "@type": "@id"},
     "jws": "sec:jws",


### PR DESCRIPTION
Added support for ethereumAddress in context - fixed #55

The final community specification allows for ethereumAddress public key types. We have to add the respective key type to the context to be recognized by 3rd party applications, e.g., uniresolver.io.

After following the discussion in w3c-ccg/did-spec#270, it seems like we should at least support all public key types that were mentioned in the W3C CCG DID spec.