### PR TITLE
Add `initial-values` matrix parameter to Generic DID Parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
             </td>
             <td>
 Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
-state is propagated within the underlying trust system. To make resolution of a DID possible during this period, <a>DID Methods</a> may require passage of additional values 
+state is propagated within the underlying <a>DID registry</a>. To make resolution of a DID possible during this period, <a>DID methods</a> may require passage of additional values 
 to their resolver logic to ensure correct processing. <a>DID methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
 Note: This parameter may not be required by all <a>DID methods</a>.
             </td>

--- a/index.html
+++ b/index.html
@@ -797,7 +797,8 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
             <td>
 Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
 state is propagated within the underlying <a>DID registry</a>. To make resolution of a DID possible during this period, <a>DID methods</a> may require passage of additional values 
-to their resolver logic to ensure correct processing. <a>DID methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
+be passed to their resolver logic. <a>DID methods</a> SHOULD use the 
+`initial-values` parameter when such values are necessary. 
 Note: This parameter may not be supported by all <a>DID methods</a>.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -796,7 +796,8 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
             </td>
             <td>
 Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
-state is propagated within the underlying <a>DID registry</a>. To make resolution of a DID possible during this period, <a>DID methods</a> may require passage of additional values 
+state are propagated within the underlying <a>DID registry</a>. To enable resolution 
+of a DID during this period, <a>DID methods</a> may require that additional values 
 be passed to their resolver logic. <a>DID methods</a> SHOULD use the 
 `initial-values` parameter when such values are necessary. 
 Note: This parameter may not be supported by all <a>DID methods</a>.

--- a/index.html
+++ b/index.html
@@ -798,7 +798,7 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
 Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
 state is propagated within the underlying <a>DID registry</a>. To make resolution of a DID possible during this period, <a>DID methods</a> may require passage of additional values 
 to their resolver logic to ensure correct processing. <a>DID methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
-Note: This parameter may not be required by all <a>DID methods</a>.
+Note: This parameter may not be supported by all <a>DID methods</a>.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
 <code>initial-values</code>
             </td>
             <td>
-Some <a>DID Methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
+Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
 state is propagated within the underlying trust system. To make resolution of a DID possible during this period, <a>DID Methods</a> may require passage of additional values 
 to their resolver logic to ensure correct processing. <a>DID Methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
 Note: This parameter may not be required by all <a>DID methods</a>.

--- a/index.html
+++ b/index.html
@@ -790,6 +790,17 @@ Identifies a certain version timestamp of a <a>DID document</a> to be resolved
 Note: This parameter may not be supported by all <a>DID methods</a>.
             </td>
           </tr>
+          <tr>
+            <td>
+<code>initial-values</code>
+            </td>
+            <td>
+Some <a>DID Methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
+state is propagated within the underlying trust system. To make resolution of a DID possible during this period, <a>DID Methods</a> may require passage of additional values 
+to their resolver logic to ensure correct processing. <a>DID Methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
+Note: This parameter may not be required by all <a>DID methods</a>.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
             <td>
 Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
 state is propagated within the underlying trust system. To make resolution of a DID possible during this period, <a>DID Methods</a> may require passage of additional values 
-to their resolver logic to ensure correct processing. <a>DID Methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
+to their resolver logic to ensure correct processing. <a>DID methods</a> SHOULD use the `initial-values` parameter if passage of any such values is necessary. 
 Note: This parameter may not be required by all <a>DID methods</a>.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -795,7 +795,8 @@ Note: This parameter may not be supported by all <a>DID methods</a>.
 <code>initial-values</code>
             </td>
             <td>
-Some <a>DID methods</a> may require an interim period of time (e.g. block intervals) before a new identifier and its initial <a>DID document</a> 
+Some <a>DID methods</a> may require an interim period of time (e.g., a block 
+interval) before a new identifier and its initial <a>DID document</a> 
 state are propagated within the underlying <a>DID registry</a>. To enable resolution 
 of a DID during this period, <a>DID methods</a> may require that additional values 
 be passed to their resolver logic. <a>DID methods</a> SHOULD use the 


### PR DESCRIPTION
This PR is intended to start the next phase of discussion around the needs highlighted in issue https://github.com/w3c/did-spec/issues/70, regarding the ability to resolve DIDs for Methods that require a period of time before their inclusion/state has been propagated in an underling trust system (blockchain, ledger, etc.).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csuwildcat/did-spec/pull/84.html" title="Last updated on Nov 26, 2019, 11:09 PM UTC (c569c48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/84/99a0873...csuwildcat:c569c48.html" title="Last updated on Nov 26, 2019, 11:09 PM UTC (c569c48)">Diff</a>