### PR TITLE
Add public key value expression goals. Add key expression formats for RSA, secp256k1, secp256r1, ed25519, and curve25519.

### DIFF
--- a/common.js
+++ b/common.js
@@ -116,6 +116,17 @@ var ccg = {
       status: "Internet-Draft",
       publisher: "IETF"
     },
+    "BASE58": {
+      title: "The Base58 Encoding Scheme",
+      date: "December 2019",
+      href: "https://tools.ietf.org/html/draft-msporny-base58",
+      authors: [
+        "Satoshi Nakamoto",
+        "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
+    },
     "DNS-DID": {
       title: "The Decentralized Identifier (DID) in the DNS",
       date: "February 2019",

--- a/common.js
+++ b/common.js
@@ -121,7 +121,6 @@ var ccg = {
       date: "December 2019",
       href: "https://tools.ietf.org/html/draft-msporny-base58",
       authors: [
-        "Satoshi Nakamoto",
         "Manu Sporny"
       ],
       status: "Internet-Draft",

--- a/index.html
+++ b/index.html
@@ -1389,11 +1389,9 @@ the <code>publicKeyBase58</code> property.
 ed25519
             </td>
             <td>
-Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Ed25519 public key formats
-MUST NOT be used.
+Ed25519 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
+if they are not encoded in JWK format.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1340,7 +1340,9 @@ detail how revocation is performed and tracked.
       </p>
 
       <p>
-The following table summarizes the key formats supported by this specification:
+All public key formats MUST be expressed in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or one of the native
+formats listed in the table below. All other key formats MUST NOT be used.
       </p>
 
       <table class="simple">
@@ -1361,10 +1363,9 @@ Support
 RSA
             </td>
             <td>
-RSA public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or Privacy Enhanced Mail
-(PEM) format using the <code>publicKeyPem</code> property. Other RSA public
-key formats MUST NOT be used.
+RSA public key values MUST be encoded in Privacy Enhanced Mail
+(PEM) format using the <code>publicKeyPem</code> property if they are not
+encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1330,24 +1330,10 @@ All public key properties MUST be from the Linked Data Cryptographic Suite Regis
 A registry of key types and formats is available in Appendix <a href="#registries"></a>
       </p>
 
-      <p class="note">
-        The following is a non-exhaustive list of public key
-        properties used by the community:
-        <code>publicKeyPem</code>, <code>publicKeyJwk</code>,
-        <code>publicKeyHex</code>, <code>publicKeyBase64</code>,
-        <code>publicKeyBase58</code>, <code>publicKeyMultibase</code>,
-        <code>ethereumAddress</code>.
-      </p>
 
       <p>
-If a public key does not exist in the <a>DID document</a>, it MUST be
-assumed the key has been revoked or is invalid. The <a>DID document</a> MAY
-contain revoked keys. A <a>DID document</a> that contains a revoked key MUST
-also contain or refer to the revocation information for the key (e.g.,
-a revocation list). Each <a>DID method</a> specification is expected to
-detail how revocation is performed and tracked.
+The following table summarizes the key formats supported by this specification:
       </p>
-
       <p>
 Example:
       </p>

--- a/index.html
+++ b/index.html
@@ -1409,7 +1409,7 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 Curve25519
             </td>
             <td>
-Curve25519 public key values MUST either be encoded as a JWK or be encoded as
+Curve25519 (also known as X25519) public key values MUST either be encoded as a JWK or be encoded as
 the raw 32-byte public key value in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>

--- a/index.html
+++ b/index.html
@@ -664,7 +664,7 @@ that depend on the type of key it is. For more information, see Section
 
       <p>
 This specification strives to limit the number of formats for expressing public
-key material in a DID Document to the fewest possible, to increase  the
+key material in a DID Document to the fewest possible, to increase the
 likelihood of interoperability. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
 approach attempts to strike a delicate balance between ease of implementation

--- a/index.html
+++ b/index.html
@@ -1352,11 +1352,10 @@ Support
 RSA
             </td>
             <td>
-RSA public key values MAY be encoded in Privacy Enhanced Mail (PEM) format using
-the <code>publicKeyPem</code> property or MAY be encoded in JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property. At least PEM format or
-JWK format MUST be supported by DID Document Processors. The use of other
-key formats for RSA public keys MUST NOT be used.
+RSA public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or Privacy Enhanced Mail
+(PEM) format using the <code>publicKeyPem</code> property. Other RSA public
+key formats MUST NOT be used.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1345,6 +1345,13 @@ format using the <code>publicKeyJwk</code> property or one of the native
 formats listed in the table below. All other key formats MUST NOT be used.
       </p>
 
+      <p class="issue">
+The Working Group is still debating whether the default base encoding format
+will be Base58 (Bitcoin) or base64url. The entries in the table below
+currently assume Base58 (Bitcoin), but may change to base64url once the
+group achieves consensus on this particular issue.
+      </p>
+
       <table class="simple">
         <thead>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1347,7 +1347,7 @@ formats listed in the table below. Public key expression MUST NOT use any other 
 
       <p class="issue">
 The Working Group is still debating whether the base encoding format used
-will be Base58 (Bitcoin) [[BASE58]], base64url [[RFC4648]] or base16 (hex) [[RFC4648]]. The entries in the
+will be Base58 (Bitcoin) [[BASE58]], base64url [[RFC7515]] or base16 (hex) [[RFC4648]]. The entries in the
 table below currently assume PEM and Base58 (Bitcoin), but may change to base64url and/or base16 (hex) once
 the group achieves consensus on this particular issue.
       </p>

--- a/index.html
+++ b/index.html
@@ -1379,12 +1379,11 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
 secp256k1
             </td>
             <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Secp256k1 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other Secp256k1 public key formats
+MUST NOT be used.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1399,9 +1399,34 @@ raw 32-byte public key value in Base58 Bitcoin format using the
 secp256r1
             </td>
             <td>
-Secp256r1 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
-if they are not encoded in JWK format.
+Secp256r1 public key values MUST either be encoded as a JWK or be encoded as
+the raw 32-byte public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property.
+            </td>
+          </tr>
+          <tr>
+            <td>
+ed25519
+            </td>
+            <td>
+Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other Ed25519 public key formats
+MUST NOT be used.
+            </td>
+          </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1406,39 +1406,12 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
           </tr>
           <tr>
             <td>
-ed25519
-            </td>
-            <td>
-Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Ed25519 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
 Curve25519
             </td>
             <td>
-Curve25519 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Curve25519 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Curve25519 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
+property if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -662,8 +662,20 @@ that depend on the type of key it is. For more information, see Section
     </p>
   </section>
 
-  <section>
-    <h2>
+      <p>
+When expressing public key material in a DID Document, this specification
+strives to provide as few formats as possible to increase the likelihood of
+interoperability. The fewer formats that implementers have to implement, the
+more likely it will be that they will support all of them. This approach
+attempts to strike a delicate balance between ease of implementation and
+supporting formats that have historically had broad deployment. The specific
+types of key formats that are supported in this specification are listed in <a
+href="#public-keys"></a>.
+      </p>
+    </section>
+
+    <section>
+      <h2>
 Services
     </h2>
 

--- a/index.html
+++ b/index.html
@@ -1376,18 +1376,6 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
           </tr>
           <tr>
             <td>
-secp256r1
-            </td>
-            <td>
-Secp256r1 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other secp256r1 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
 ed25519
             </td>
             <td>
@@ -1408,15 +1396,12 @@ property if they are not encoded in JWK format.
           </tr>
           <tr>
             <td>
-secp256k1
+secp256r1
             </td>
             <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Secp256r1 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
+if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1376,16 +1376,6 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
           </tr>
           <tr>
             <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 public key values MUST either be encoded as a JWK or be encoded
-as the raw 32-byte public key value encoded in Base58 Bitcoin format using
-the <code>publicKeyBase58</code> property.
-            </td>
-          </tr>
-          <tr>
-            <td>
 ed25519
             </td>
             <td>
@@ -1399,12 +1389,9 @@ if they are not encoded in JWK format.
 secp256k1
             </td>
             <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
+raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -215,11 +215,11 @@ Introduction
     <p>
 Conventional <a href="https://en.wikipedia.org/wiki/Identity_management">identity management</a>
 systems are based on centralized authorities such as corporate
-<a href="https://en.wikipedia.org/wiki/Directory_service">directory services</a>, 
+<a href="https://en.wikipedia.org/wiki/Directory_service">directory services</a>,
 <a href="https://en.wikipedia.org/wiki/Certificate_authority">certificate authorities</a>,
 or <a href="https://en.wikipedia.org/wiki/Domain_name_registry">domain name registries</a>.
 From the standpoint of cryptographic trust verification, each of these
-centralized authorities serves as its own 
+centralized authorities serves as its own
 <a href="https://en.wikipedia.org/wiki/Trust_anchor">root of trust</a>. To make
 identity management work across these systems requires implementing
 <a href="https://en.wikipedia.org/wiki/Federated_identity">federated identity management</a>.
@@ -345,7 +345,7 @@ A Simple Example
     <p>
 A <a>DID</a> is a simple text string consisting of three parts, the:
     </p>
-      <ul> 
+      <ul>
         <li>
 URL scheme identifier (<code>did</code>)
         </li>
@@ -355,7 +355,7 @@ Identifier for the <a>DID method</a>
         <li>
 DID method-specific identifier.
         </li>
-      </ul> 
+      </ul>
 
     <pre class="example nohighlight" title="A simple example of a decentralized identifier (DID)">
 did:example:123456789abcdefghi
@@ -553,7 +553,7 @@ Specification contains sections describing security and privacy considerations.
 
     <p>
 Interoperability for producers and consumers of <a>DIDs</a> and
-<a>DID documents</a> is provided by ensuring the <a>DIDs</a> and 
+<a>DID documents</a> is provided by ensuring the <a>DIDs</a> and
 <a>DID documents</a> conform. Interoperability for <a>DID method</a>
 specifications is provided by the details in each <a>DID method</a>
 specification. It is understood that, in the same way that a web browser is not
@@ -965,7 +965,7 @@ Path
       </h2>
 
       <p>
-A generic <a>DID path</a> is identical to a URI path and MUST conform to the 
+A generic <a>DID path</a> is identical to a URI path and MUST conform to the
 <code>path-abempty</code> ABNF rule in [[!RFC3986]]. A <a>DID path</a> SHOULD be
 used to address resources available through a <a>service endpoint</a>. For more
 information, see Section <a href="#service-endpoints"></a>.
@@ -1292,7 +1292,7 @@ keys may play a role in authorization mechanisms of <a>DID</a> CRUD
 operations (see Section <a href="#did-operations"></a>), which can be
 defined by <a>DID method</a> specifications.
       </p>
-      
+
       <p>
 A <a>DID document</a> MAY include a <code>publicKey</code> property. If so:
       </p>
@@ -1328,6 +1328,15 @@ controller of the corresponding private key, MUST be a valid DID.
       <p>
 All public key properties MUST be from the Linked Data Cryptographic Suite Registry.
 A registry of key types and formats is available in Appendix <a href="#registries"></a>
+      </p>
+
+      <p>
+If a public key does not exist in the <a>DID document</a>, it MUST be
+assumed the key has been revoked or is invalid. The <a>DID document</a> MAY
+contain revoked keys. A <a>DID document</a> that contains a revoked key MUST
+also contain or refer to the revocation information for the key (e.g.,
+a revocation list). Each <a>DID method</a> specification is expected to
+detail how revocation is performed and tracked.
       </p>
 
       <p>
@@ -2135,7 +2144,7 @@ generated without the use of a centralized registry service. The
       </p>
 
       <p>
-If needed, a method-specific <a>DID scheme</a> MAY define multiple 
+If needed, a method-specific <a>DID scheme</a> MAY define multiple
 <code>method-specific-id</code> formats. It is RECOMMENDED that a
 method-specific <a>DID scheme</a> define as few <code>method-specific-id</code>
 formats as possible.

--- a/index.html
+++ b/index.html
@@ -1374,6 +1374,19 @@ RSA public key values MUST either be encoded as a JWK or be encoded in
 Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
             </td>
           </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1409,9 +1409,9 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 Curve25519
             </td>
             <td>
-Curve25519 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
-property if they are not encoded in JWK format.
+Curve25519 public key values MUST either be encoded as a JWK or be encoded as
+the raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1381,7 +1381,7 @@ ed25519
             <td>
 Ed25519 public key values MUST either be encoded as a JWK or be encoded as
 the raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property if they are not encoded in JWK format.
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
           <tr>
@@ -1391,7 +1391,7 @@ secp256k1
             <td>
 Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
 raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property if they are not encoded in JWK format.
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1347,8 +1347,8 @@ formats listed in the table below. Public key expression MUST NOT use any other 
 
       <p class="issue">
 The Working Group is still debating whether the base encoding format used
-will be Base58 (Bitcoin) [[BASE58]] or base64url [[RFC4648]]. The entries in the
-table below currently assume Base58 (Bitcoin), but may change to base64url once
+will be Base58 (Bitcoin) [[BASE58]], base64url [[RFC4648]] or base16 (hex) [[RFC4648]]. The entries in the
+table below currently assume PEM and Base58 (Bitcoin), but may change to base64url and/or base16 (hex) once
 the group achieves consensus on this particular issue.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,18 @@ MUST NOT be used.
           </tr>
           <tr>
             <td>
+Curve25519
+            </td>
+            <td>
+Curve25519 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other Curve25519 public key formats
+MUST NOT be used.
+            </td>
+          </tr>
+          <tr>
+            <td>
 secp256k1
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -1376,6 +1376,18 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
           </tr>
           <tr>
             <td>
+secp256r1
+            </td>
+            <td>
+Secp256r1 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other secp256r1 public key formats
+MUST NOT be used.
+            </td>
+          </tr>
+          <tr>
+            <td>
 ed25519
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -1341,7 +1341,7 @@ detail how revocation is performed and tracked.
 
       <p>
 All public key formats MUST be expressed in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or one of the 
+format using the <code>publicKeyJwk</code> property or one of the
 formats listed in the table below. Public key expression MUST NOT use any other key format.
       </p>
 
@@ -1350,6 +1350,13 @@ The Working Group is still debating whether the base encoding format used
 will be Base58 (Bitcoin) [[BASE58]], base64url [[RFC4648]] or base16 (hex) [[RFC4648]]. The entries in the
 table below currently assume PEM and Base58 (Bitcoin), but may change to base64url and/or base16 (hex) once
 the group achieves consensus on this particular issue.
+      </p>
+
+
+      <p class="issue">
+The Working Group is still debating whether secp256k1 Schnorr public key values
+will be elaborated upon in this specification and if so, how they will be
+expressed and encoded.
       </p>
 
       <table class="simple">
@@ -1386,11 +1393,11 @@ the raw 32-byte public key value in Base58 Bitcoin format using the
           </tr>
           <tr>
             <td>
-secp256k1
+secp256k1-koblitz
             </td>
             <td>
-Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
-raw 32-byte public key value in Base58 Bitcoin format using the
+Secp256k1 Koblitz public key values MUST either be encoded as a JWK or be
+encoded as the raw 33-byte public key value in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -1341,12 +1341,12 @@ detail how revocation is performed and tracked.
 
       <p>
 All public key formats MUST be expressed in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or one of the native
-formats listed in the table below. All other key formats MUST NOT be used.
+format using the <code>publicKeyJwk</code> property or one of the 
+formats listed in the table below. Public key expression MUST NOT use any other key format.
       </p>
 
       <p class="issue">
-The Working Group is still debating whether the default base encoding format
+The Working Group is still debating whether the base encoding format used
 will be Base58 (Bitcoin) [[BASE58]] or base64url [[RFC4648]]. The entries in the
 table below currently assume Base58 (Bitcoin), but may change to base64url once
 the group achieves consensus on this particular issue.

--- a/index.html
+++ b/index.html
@@ -1389,9 +1389,22 @@ if they are not encoded in JWK format.
 secp256k1
             </td>
             <td>
-Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
-raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property.
+Secp256k1 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
+property if they are not encoded in JWK format.
+            </td>
+          </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1379,9 +1379,9 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
 ed25519
             </td>
             <td>
-Ed25519 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
-if they are not encoded in JWK format.
+Ed25519 public key values MUST either be encoded as a JWK or be encoded as
+the raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property if they are not encoded in JWK format.
             </td>
           </tr>
           <tr>
@@ -1389,9 +1389,9 @@ if they are not encoded in JWK format.
 secp256k1
             </td>
             <td>
-Secp256k1 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
-property if they are not encoded in JWK format.
+Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
+raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property if they are not encoded in JWK format.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1379,11 +1379,9 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
 secp256k1
             </td>
             <td>
-Secp256k1 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Secp256k1 public key formats
-MUST NOT be used.
+Secp256k1 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
+property if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1379,9 +1379,35 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
 secp256k1
             </td>
             <td>
-Secp256k1 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
-property if they are not encoded in JWK format.
+Secp256k1 public key values MUST either be encoded as a JWK or be encoded
+as the raw 32-byte public key value encoded in Base58 Bitcoin format using
+the <code>publicKeyBase58</code> property.
+            </td>
+          </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -663,12 +663,12 @@ that depend on the type of key it is. For more information, see Section
   </section>
 
       <p>
-When expressing public key material in a DID Document, this specification
-strives to provide as few formats as possible to increase the likelihood of
-interoperability. The fewer formats that implementers have to implement, the
-more likely it will be that they will support all of them. This approach
-attempts to strike a delicate balance between ease of implementation and
-supporting formats that have historically had broad deployment. The specific
+This specification strives to limit the number of formats for expressing public
+key material in a DID Document to the fewest possible, to increase  the
+likelihood of interoperability. The fewer formats that implementers have to
+implement, the more likely it will be that they will support all of them. This
+approach attempts to strike a delicate balance between ease of implementation
+and supporting formats that have historically had broad deployment. The specific
 types of key formats that are supported in this specification are listed in <a
 href="#public-keys"></a>.
       </p>

--- a/index.html
+++ b/index.html
@@ -1399,6 +1399,19 @@ cause the DID Document Processor to raise an error.
           </tr>
           <tr>
             <td>
+ed25519
+            </td>
+            <td>
+ed25519 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
+          <tr>
+            <td>
 secp256k1
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -1386,28 +1386,14 @@ the <code>publicKeyBase58</code> property.
           </tr>
           <tr>
             <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
-            </td>
-          </tr>
-          <tr>
-            <td>
 ed25519
             </td>
             <td>
-ed25519 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other Ed25519 public key formats
+MUST NOT be used.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1347,9 +1347,9 @@ formats listed in the table below. All other key formats MUST NOT be used.
 
       <p class="issue">
 The Working Group is still debating whether the default base encoding format
-will be Base58 (Bitcoin) or base64url. The entries in the table below
-currently assume Base58 (Bitcoin), but may change to base64url once the
-group achieves consensus on this particular issue.
+will be Base58 (Bitcoin) [[BASE58]] or base64url [[RFC4648]]. The entries in the
+table below currently assume Base58 (Bitcoin), but may change to base64url once
+the group achieves consensus on this particular issue.
       </p>
 
       <table class="simple">
@@ -1370,9 +1370,8 @@ Support
 RSA
             </td>
             <td>
-RSA public key values MUST be encoded in Privacy Enhanced Mail
-(PEM) format using the <code>publicKeyPem</code> property if they are not
-encoded in JWK format.
+RSA public key values MUST either be encoded as a JWK or be encoded in
+Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1330,10 +1330,38 @@ All public key properties MUST be from the Linked Data Cryptographic Suite Regis
 A registry of key types and formats is available in Appendix <a href="#registries"></a>
       </p>
 
-
       <p>
 The following table summarizes the key formats supported by this specification:
       </p>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>
+Key&nbsp;Type
+            </th>
+            <th>
+Support
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+RSA
+            </td>
+            <td>
+RSA public key values MAY be encoded in Privacy Enhanced Mail (PEM) format using
+the <code>publicKeyPem</code> property or MAY be encoded in JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property. At least PEM format or
+JWK format MUST be supported by DID Document Processors. The use of other
+key formats for RSA public keys MUST NOT be used.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
       <p>
 Example:
       </p>

--- a/index.html
+++ b/index.html
@@ -1411,7 +1411,7 @@ Curve25519
             <td>
 Curve25519 public key values MUST either be encoded as a JWK or be encoded as
 the raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property if they are not encoded in JWK format.
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
This PR attempts to partially resolve issue #67 by stating that public key formats will be limited. It also adds a suggestion for how RSA keys are expressed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/100.html" title="Last updated on Dec 10, 2019, 7:53 PM UTC (5287f42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/100/02b8613...5287f42.html" title="Last updated on Dec 10, 2019, 7:53 PM UTC (5287f42)">Diff</a>