### PR TITLE
Add key expression formats for secp256r1.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1392,6 +1392,19 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>
           </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1369,7 +1369,7 @@ ed25519
             <td>
 Ed25519 public key values MUST either be encoded as a JWK or be encoded as
 the raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property if they are not encoded in JWK format.
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
           <tr>
@@ -1379,7 +1379,7 @@ secp256k1
             <td>
 Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
 raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property if they are not encoded in JWK format.
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1364,6 +1364,18 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
           </tr>
           <tr>
             <td>
+secp256r1
+            </td>
+            <td>
+Secp256r1 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other secp256r1 public key formats
+MUST NOT be used.
+            </td>
+          </tr>
+          <tr>
+            <td>
 ed25519
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -1405,6 +1405,19 @@ supported by DID Document Processors. The use of other key formats for RSA MUST
 cause the DID Document Processor to raise an error.
             </td>
           </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1395,6 +1395,19 @@ supported by DID Document Processors. The use of other key formats for RSA MUST
 cause the DID Document Processor to raise an error.
             </td>
           </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1397,7 +1397,7 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 Curve25519
             </td>
             <td>
-Curve25519 public key values MUST either be encoded as a JWK or be encoded as
+Curve25519 (also known as X25519) public key values MUST either be encoded as a JWK or be encoded as
 the raw 32-byte public key value in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>

--- a/index.html
+++ b/index.html
@@ -1367,9 +1367,9 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
 ed25519
             </td>
             <td>
-Ed25519 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
-if they are not encoded in JWK format.
+Ed25519 public key values MUST either be encoded as a JWK or be encoded as
+the raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property if they are not encoded in JWK format.
             </td>
           </tr>
           <tr>
@@ -1377,9 +1377,9 @@ if they are not encoded in JWK format.
 secp256k1
             </td>
             <td>
-Secp256k1 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
-property if they are not encoded in JWK format.
+Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
+raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property if they are not encoded in JWK format.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1392,31 +1392,6 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>
           </tr>
-          <tr>
-            <td>
-ed25519
-            </td>
-            <td>
-Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Ed25519 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
-            </td>
-          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1382,6 +1382,19 @@ encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
 property if they are not encoded in JWK format.
             </td>
           </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1382,6 +1382,19 @@ raw 32-byte public key value in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>
           </tr>
+          <tr>
+            <td>
+secp256k1
+            </td>
+            <td>
+Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1367,9 +1367,9 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
 ed25519
             </td>
             <td>
-Ed25519 public key values MUST either be encoded as a JWK or be encoded as the
-raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property.
+Ed25519 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
+if they are not encoded in JWK format.
             </td>
           </tr>
           <tr>
@@ -1377,35 +1377,9 @@ raw 32-byte public key value in Base58 Bitcoin format using the
 secp256k1
             </td>
             <td>
-Secp256k1 public key values MUST either be encoded as a JWK or be encoded as the
-raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property.
-            </td>
-          </tr>
-          <tr>
-            <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
-            </td>
-          </tr>
-          <tr>
-            <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Secp256k1 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
+property if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1407,6 +1407,19 @@ cause the DID Document Processor to raise an error.
           </tr>
           <tr>
             <td>
+ed25519
+            </td>
+            <td>
+ed25519 key values MAY be expressed as the raw 32-byte value encoded in
+base58-btc format using the <code>publicKeyBase58</code> property or
+MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
+property. Both the raw 32-byte base58-btc format and JWK format MUST be
+supported by DID Document Processors. The use of other key formats for RSA MUST
+cause the DID Document Processor to raise an error.
+            </td>
+          </tr>
+          <tr>
+            <td>
 secp256k1
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -1394,28 +1394,14 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
           </tr>
           <tr>
             <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
-            </td>
-          </tr>
-          <tr>
-            <td>
 ed25519
             </td>
             <td>
-ed25519 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other Ed25519 public key formats
+MUST NOT be used.
             </td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -1397,9 +1397,9 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 Curve25519
             </td>
             <td>
-Curve25519 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
-property if they are not encoded in JWK format.
+Curve25519 public key values MUST either be encoded as a JWK or be encoded as
+the raw 32-byte public key value in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1364,18 +1364,6 @@ Privacy Enhanced Mail (PEM) format using the <code>publicKeyPem</code> property.
           </tr>
           <tr>
             <td>
-secp256r1
-            </td>
-            <td>
-Secp256r1 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other secp256r1 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
 ed25519
             </td>
             <td>
@@ -1396,15 +1384,12 @@ property if they are not encoded in JWK format.
           </tr>
           <tr>
             <td>
-secp256k1
+secp256r1
             </td>
             <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Secp256r1 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
+if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1392,19 +1392,6 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
 <code>publicKeyBase58</code> property.
             </td>
           </tr>
-          <tr>
-            <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
-            </td>
-          </tr>
         </tbody>
       </table>
 

--- a/index.html
+++ b/index.html
@@ -1394,39 +1394,12 @@ the raw 32-byte public key value encoded in Base58 Bitcoin format using the
           </tr>
           <tr>
             <td>
-ed25519
-            </td>
-            <td>
-Ed25519 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Ed25519 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
 Curve25519
             </td>
             <td>
-Curve25519 public key values MUST be encoded in either JSON Web Key (JWK)
-format using the <code>publicKeyJwk</code> property or as the raw 32-byte
-public key value encoded in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property. Other Curve25519 public key formats
-MUST NOT be used.
-            </td>
-          </tr>
-          <tr>
-            <td>
-secp256k1
-            </td>
-            <td>
-Secp256k1 key values MAY be expressed as the raw 32-byte value encoded in
-base58-btc format using the <code>publicKeyBase58</code> property or
-MAY be encoded in JSON Web Key (JWK) format using the <code>publicKeyJwk</code>
-property. Both the raw 32-byte base58-btc format and JWK format MUST be
-supported by DID Document Processors. The use of other key formats for RSA MUST
-cause the DID Document Processor to raise an error.
+Curve25519 public key values MUST be encoded as the raw 32-byte public key value
+encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code>
+property if they are not encoded in JWK format.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1399,7 +1399,7 @@ Curve25519
             <td>
 Curve25519 public key values MUST either be encoded as a JWK or be encoded as
 the raw 32-byte public key value in Base58 Bitcoin format using the
-<code>publicKeyBase58</code> property if they are not encoded in JWK format.
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1387,9 +1387,9 @@ raw 32-byte public key value in Base58 Bitcoin format using the
 secp256r1
             </td>
             <td>
-Secp256r1 public key values MUST be encoded as the raw 32-byte public key value
-encoded in Base58 Bitcoin format using the <code>publicKeyBase58</code> property
-if they are not encoded in JWK format.
+Secp256r1 public key values MUST either be encoded as a JWK or be encoded as
+the raw 32-byte public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property.
             </td>
           </tr>
         </tbody>

--- a/index.html
+++ b/index.html
@@ -1406,6 +1406,18 @@ MUST NOT be used.
           </tr>
           <tr>
             <td>
+Curve25519
+            </td>
+            <td>
+Curve25519 public key values MUST be encoded in either JSON Web Key (JWK)
+format using the <code>publicKeyJwk</code> property or as the raw 32-byte
+public key value encoded in Base58 Bitcoin format using the
+<code>publicKeyBase58</code> property. Other Curve25519 public key formats
+MUST NOT be used.
+            </td>
+          </tr>
+          <tr>
+            <td>
 secp256k1
             </td>
             <td>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/109.html" title="Last updated on Dec 6, 2019, 3:45 PM UTC (553639d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/109/12f2ca3...553639d.html" title="Last updated on Dec 6, 2019, 3:45 PM UTC (553639d)">Diff</a>