### PR TITLE
Move security and privacy requirements into DID methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -2186,8 +2186,8 @@ specified in [[DID-RESOLUTION]].
 Security Considerations
     </h1>
 
-    <p>
-NOTE TO IMPLEMENTERS: During the Implementer’s Draft stage, this
+    <p class="note" title="Note to implementers">
+During the Implementer’s Draft stage, this
 section focuses on security topics that should be important in early
 implementations. The editors are also seeking feedback on threats and
 threat mitigations that should be reflected in this section or
@@ -2373,7 +2373,7 @@ SHOULD explain and specify their implementation if applicable.
         </p>
 
         <p>
-It is RECOMMENDED to combine timestamps with signatures.
+It is good practice to combine timestamps with signatures.
         </p>
       </section>
 
@@ -2417,9 +2417,7 @@ A <a>DID</a> and <a>DID document</a> do not inherently carry any
 PII</a> (personally-identifiable information). The process of
 binding a <a>DID</a> to something in the real-world such as a person or company,
 for example with credentials with the same subject as that <a>DID</a>, is out
-of scope for this specification. However this topic is the focus of the
-<a href="https://w3c.github.io/vctf/">verifiable claims</a>
-standardization work at the W3C (where the term "DID" originated).
+of scope for this specification. See the [[VC-DATA-MODEL]] instead.
         </p>
       </section>
     </section>
@@ -2469,24 +2467,24 @@ This is analogous to helping prevent account takeover on conventional
 username/password accounts by sending password reset notifications to
 the email addresses on file. In the case of a <a>DID</a>, where there is no
 intermediary registrar or account provider to generate the
-notification, the following approaches are RECOMMENDED:
+notification, the following approaches are suggested:
       </p>
 
       <ol start="1">
         <li>
 Subscriptions. If the <a>DID registry</a> on which the <a>DID</a> is
 registered directly supports change notifications, this service can
-be offered to <a>DID controllers</a>. Notifications MAY be sent directly to the
+be offered to <a>DID controllers</a>. Notifications could be sent directly to the
 relevant <a>service endpoints</a> listed in an existing <a>DID</a>.
         </li>
 
         <li>
-Self-monitoring. A <a>DID subject</a> MAY employ their own local or online
+Self-monitoring. A <a>DID subject</a> can employ their own local or online
 agent to periodically monitor for changes to a <a>DID document</a>.
         </li>
 
         <li>
-Third-party monitoring. A <a>DID subject</a> MAY rely on a third party
+Third-party monitoring. A <a>DID subject</a> could rely on a third party
 monitoring service, however this introduces another vector of attack.
         </li>
       </ol>
@@ -2500,11 +2498,11 @@ Key and Signature Expiration
       <p>
 In a <a>decentralized identifier</a> architecture, there are no centralized
 authorities to enforce key or signature expiration policies.
-Therefore <a>DID resolvers</a> and other client applications SHOULD validate
+Therefore <a>DID resolvers</a> and other client applications need to validate
 that keys were not expired at the time they were used. Since some use cases
 may have legitimate reasons why already-expired keys can be extended, a key
-expiration SHOULD NOT prevent any further use of the key, and implementations
-of a resolver SHOULD be compatible with such extension behavior.
+expiration shouldn't prevent any further use of the key, and implementations
+of a resolver ought to be compatible with such extension behavior.
       </p>
     </section>
 
@@ -2521,13 +2519,13 @@ document</a>. In general, checking for key revocation on <a>DLT</a>-based
 methods is expected to be handled in a manner similar to checking the
 balance of a cryptocurrency account on a <a>distributed ledger</a>: if the
 balance is empty, the entire <a>DID</a> is deactivated. <a>DID method</a>
-specifications SHOULD enable support for a quorum of trusted parties
+specifications are expected to enable support for a quorum of trusted parties
 to enable key recovery. Some of the facilities to do so are suggested
-in section 6.5, Authorization. Note that not all <a>DID method</a>
+in section <a href="#authorization-and-delegation"></a>. Not all <a>DID method</a>
 specifications will recognize control from <a>DIDs</a> registered using
-other <a>DID methods</a> and they MAY restrict third-party control to <a>DIDs</a>
+other <a>DID methods</a> and they might restrict third-party control to <a>DIDs</a>
 that use the same method. Access control and key recovery in a <a>DID
-method</a> specification MAY also include a time lock feature to protect
+method</a> specification can also include a time lock feature to protect
 against key compromise by maintaining a second track of control for
 recovery. Further specification of this type of control is a matter
 for future work (see Section <a href="#time-locks-and-did-document-recovery"></a>).
@@ -2672,7 +2670,7 @@ Keep Personally-Identifiable Information (PII) Private
       <p>
 If a <a>DID method</a> specification is written for a public <a>DID
 registry</a> where all <a>DIDs</a> and <a>DID documents</a> will be publicly available,
-it is STRONGLY RECOMMENDED that <a>DID documents</a> contain no PII. All PII
+it is <em>critical</em> that <a>DID documents</a> contain no PII. All PII
 should be kept behind <a>service endpoints</a> under the control
 of the <a>DID subject</a>. With this privacy architecture, PII may be exchanged
 on a private, peer-to-peer basis using communications channels identified and
@@ -2714,7 +2712,7 @@ defeated if the data in the corresponding <a>DID documents</a> can be
 correlated. For example, using same <a>public key descriptions</a> or
 bespoke <a>service endpoints</a> in multiple <a>DID documents</a> can provide
 as much correlation information as using the same <a>DID</a>. Therefore the <a>DID
-document</a> for a pseudonymous <a>DID</a> SHOULD also use pairwise-unique
+document</a> for a pseudonymous <a>DID</a> also needs to use pairwise-unique
 public keys.
 
 It might seem natural to also use pairwise-unique <a>service endpoints</a>
@@ -2736,7 +2734,7 @@ Herd Privacy
 When a <a>DID subject</a> is indistinguishable from others in the herd, privacy
 is available. When the act of engaging privately with another party
 is by itself a recognizable flag, privacy is greatly diminished. <a>DIDs</a>
-and <a>DID methods</a> SHOULD work to improve herd privacy, particularly for
+and <a>DID methods</a> need to work to improve herd privacy, particularly for
 those who legitimately need it most. Choose technologies and human
 interfaces that default to preserving anonymity and pseudonymity. In
 order to reduce <a href="https://en.wikipedia.org/wiki/Device_fingerprint">digital
@@ -2841,9 +2839,10 @@ Smart Signatures
       </h2>
 
       <p>
-Not all <a>DLTs</a> can support the Authorization logic in section 6.5.
+Not all <a>DLTs</a> can support the Authorization logic in section
+<a href="#authorization-and-delegation"></a>.
 Therefore, in this version of the specification, all Authorization
-logic MUST be delegated to <a>DID method</a> specifications. A potential
+logic is delegated to <a>DID method</a> specifications. A potential
 future solution is a <a href="http://www.weboftrust.info/downloads/smart-signatures.pdf">Smart
 Signature</a> specification that specifies the code any conformant
 <a>DLT</a> may implement to process signature control logic.
@@ -2874,10 +2873,8 @@ Alternate Serializations and Graph Models
       <p>
 This version of the specification relies on JSON-LD and the RDF graph
 model for expressing a <a>DID document</a>. Future versions of this
-specification MAY specify other semantic graph formats for a <a>DID
-document</a>, such as JXD (JSON XDI Data), a serialization format for the
-XDI graph model as defined by the <a href="http://docs.oasis-open.org/xdi/xdi-core/v1.0/csd01/xdi-core-v1.0-csd01.xml">
-OASIS XDI Core 1.0 specification</a>.
+specification might specify other semantic graph formats for a <a>DID
+document</a>.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -1676,7 +1676,7 @@ A <a>DID document</a> SHOULD include an <code>updated</code> property. If so:
       <dl>
           <dt><dfn>updated</dfn></dt>
           <dd>
-The value <code>updated</code> MUST follow the same formatting rules as the
+The <code>updated</code> value MUST follow the same formatting rules as the
 <code>created</code> property (see Section <a href="#created"></a>).
           </dd>
       </dl>
@@ -2074,8 +2074,8 @@ key replacement, key rotation, key recovery, and key expiration.
 
       </p>
       <p>
-Any <a>DID method</a> specification that does not support specific operations,
-such as Update and Deactivate, MUST clearly state these limitations.
+Any <a>DID method</a> specification that does not support a specific operation,
+such as Update or Deactivate, MUST clearly state these limitations.
       </p>
 
       <section>
@@ -2123,7 +2123,7 @@ Deactivate
         <p>
 The <a>DID method</a> specification MUST specify how a client can deactivate a
 <a>DID</a> on the <a>DID registry</a>, including all cryptographic
-operations necessary to establish proof of deactivation <em>or</em> state that
+operations necessary to establish proof of deactivation, <em>or</em> state that
 deactivation is not possible.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -2490,7 +2490,7 @@ and (2) the subject has had adequate opportunity to revert malicious updates
 according to the <a>DID method</a>'s access control mechanism (section
 <a href="#authentication"></a>).
 This capability is further supported if timestamps are included (sections
-<a href="#created-optional"></a> and <a href="#updated-optional"></a>) and the
+<a href="#created"></a> and <a href="#updated"></a>) and the
 target <a>DLT</a> system supports timestamps.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -141,22 +141,22 @@
 <body>
   <section id='abstract'>
     <p>
-<a>Decentralized identifiers</a> (DIDs) are a new type of identifier for
-verifiable, decentralized digital identity. These new identifiers
-are designed to enable the controller of a <a>DID</a> to prove control over
-it and to be implemented independently of any centralized registry,
-identity provider, or certificate authority. <a>DIDs</a> are URLs that relate
-a <a>DID subject</a> to means for trustable interactions with that subject by way
-of a <a>DID document</a>. <a>DID documents</a> are simple documents that describe how
-to use that specific <a>DID</a>. Each <a>DID document</a> may express cryptographic
-material, verification methods, and/or <a>service endpoints</a>. These provide
-a set of mechanisms which enable a <a>DID controller</a> to prove control of the
-<a>DID</a>. <a>Service endpoints</a> enable trusted interactions with the <a>DID
-subject</a>.
+<a>Decentralized identifiers</a> (DIDs) are a new type of identifier to
+provide verifiable, decentralized digital identity. These new identifiers are
+designed to enable the controller of a <a>DID</a> to prove control over
+it and to be implemented independently of any centralized registry, identity
+provider, or certificate authority. <a>DIDs</a> are URLs that relate a
+<a>DID subject</a> to a <a>DID document</a> allowing trustable interactions with
+that subject. <a>DID documents</a> are simple documents describing how to use
+that specific <a>DID</a>. Each <a>DID document</a> can express cryptographic
+material, verification methods, or <a>service endpoints</a>, which. provide a
+set of mechanisms enabling a <a>DID controller</a> to prove control of the
+<a>DID</a>. <a>Service endpoints</a> enable trusted interactions with the
+<a>DID subject</a>.
     </p>
     <p>
-This document specifies a common data model, a URL format, and a set of operations for
-<a>DIDs</a>, DID documents, and DID methods.
+This document specifies a common data model, a URL format, and a set of
+operations for <a>DIDs</a>, <a>DID documents</a>, and <a>DID methods</a>.
     </p>
   </section>
 
@@ -212,127 +212,127 @@ Heather Vescent.
 Introduction
     </h1>
 
-      <p>
-Conventional <a href="https://en.wikipedia.org/wiki/Identity_management">identity
-management</a> systems are based on centralized authorities such as
-corporate <a href="https://en.wikipedia.org/wiki/Directory_service">directory
-services</a>, <a href="https://en.wikipedia.org/wiki/Certificate_authority">certificate
-authorities</a>, or <a href="https://en.wikipedia.org/wiki/Domain_name_registry">domain name
-registries</a>. From the standpoint of cryptographic trust
-verification, each of these centralized authorities serves as its own
-<a href="https://en.wikipedia.org/wiki/Trust_anchor">root of
-trust</a>. To make identity management work across these systems
-requires implementing <a href="https://en.wikipedia.org/wiki/Federated_identity">federated identity
-management</a>.
-      </p>
+    <p>
+Conventional <a href="https://en.wikipedia.org/wiki/Identity_management">identity management</a>
+systems are based on centralized authorities such as corporate
+<a href="https://en.wikipedia.org/wiki/Directory_service">directory services</a>, 
+<a href="https://en.wikipedia.org/wiki/Certificate_authority">certificate authorities</a>,
+or <a href="https://en.wikipedia.org/wiki/Domain_name_registry">domain name registries</a>.
+From the standpoint of cryptographic trust verification, each of these
+centralized authorities serves as its own 
+<a href="https://en.wikipedia.org/wiki/Trust_anchor">root of trust</a>. To make
+identity management work across these systems requires implementing
+<a href="https://en.wikipedia.org/wiki/Federated_identity">federated identity management</a>.
+    </p>
 
-      <p>
-The emergence of <a>distributed ledger technology</a> (DLT), sometimes
-referred to as <a>blockchain technology</a>, provides the opportunity for
-fully <a>decentralized identity management</a>. In a decentralized
-identity system, entities (in the sense of discrete identifiable units
-such as &mdash; but not limited to &mdash; people, organizations, and
-things) are free to use any shared root of trust.
+    <p>
+The emergence of <a>distributed ledger technology</a> (DLT) and
+<a>blockchain technology</a> provides the opportunity for fully
+<a>decentralized identity management</a>. In a decentralized identity system,
+entities (that is, discrete identifiable units such as, but not limited to,
+people, organizations, and things) are free to use any shared root of trust.
 Globally distributed ledgers, decentralized P2P networks, or other systems
 with similar capabilities, provide the means for managing a root of
 trust without introducing a centralized authority or a single point of
-failure. In combination, <a>DLTs</a> and <a>decentralized identity management</a>
-systems enable any entity to create and manage their own identifiers on any
-number of distributed, independent roots of trust.
-      </p>
+failure. In combination, <a>DLTs</a> and
+<a>decentralized identity management</a> systems enable any entity to create and
+manage their own identifiers on any number of distributed, independent roots of
+trust.
+    </p>
 
-      <p>
-Entities are identified by <a>decentralized identifiers</a> (DIDs), and
-may authenticate via proofs (e.g., digital signatures,
-privacy-preserving biometric protocols, etc.). <a>DIDs</a> point to <a>DID
-documents</a>. A <a>DID document</a> contains a set of <a>service endpoints</a>
-for interacting with the entity the <a>DID</a> identifies (aka the <a>DID
-subject</a>). Following the dictums of
+    <p>
+Entities are identified by <a>decentralized identifiers</a> (<a>DIDs</a>), and
+can authenticate using proofs (for example, digital signatures,
+privacy-preserving biometric protocols, and so on). <a>DIDs</a> point to
+<a>DID documents</a>. A <a>DID document</a> contains a set of
+<a>service endpoints</a> for interacting with the entity that the <a>DID</a>
+identifies (that is, the <a>DID subject</a>). Following the guidelines of
 <a href="https://en.wikipedia.org/wiki/Privacy_by_design">Privacy by
-Design</a>, any entity may have as many <a>DIDs</a> as necessary (and
-corresponding <a>DID documents</a> and <a>service endpoints</a>), to respect the
-entity’s desired separation of identities, personas, and contexts
-(in the everyday sense of these words).
-      </p>
+Design</a>, any entity can have as many <a>DIDs</a> (and corresponding
+<a>DID documents</a> and <a>service endpoints</a>) as necessary to respect the
+entity’s desired separation of identities, personas, and contexts (in the
+everyday sense of these words).
+    </p>
 
-      <p>
-<a>DID methods</a> are the mechanism by which a <a>DID</a> and its associated <a>DID
-document</a> are created, read, updated, and deactivated on a specific
-<a>distributed ledger</a> or network. <a>DID methods</a> are defined using separate
-<a>DID method</a> specifications.
-      </p>
+    <p>
+<a>DID methods</a> are the mechanism by which a <a>DID</a> and its associated
+<a>DID document</a> are created, read, updated, and deactivated on a specific
+<a>distributed ledger</a> or network. <a>DID methods</a> are defined using
+separate <a>DID method</a> specifications.
+    </p>
 
-      <p>
+    <p>
 This design eliminates dependence on centralized registries for
 identifiers as well as centralized certificate authorities for key
-management &mdash; the standard pattern in hierarchical
-<a href="https://en.wikipedia.org/wiki/Public_key_infrastructure">PKI
-(public key infrastructure</a>). In cases where the <a>DID registry</a>
-is a <a>distributed ledger</a>, each entity may serve as its own root authority
-&mdash; an architecture referred to as
-<a href="https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust/blob/master/final-documents/dpki.pdf">DPKI
-(decentralized PKI)</a>.
-      </p>
+management, which is the standard in hierarchical
+<a href="https://en.wikipedia.org/wiki/Public_key_infrastructure">PKI (public key infrastructure</a>).
+In cases where the <a>DID registry</a> is a <a>distributed ledger</a>, each
+entity can serve as its own root authority. This architecture is referred to as
+<a href="https://github.com/WebOfTrustInfo/rebooting-the-web-of-trust/blob/master/final-documents/dpki.pdf">DPKI (decentralized PKI)</a>.
+    </p>
 
-      <p>
-Note that <a>DID methods</a> may also be developed for identifiers
-registered in federated or centralized identity management systems.
-For their part, all types of identifier systems may add support for
-<a>DIDs</a>. This creates an interoperability bridge between the worlds of
-centralized, federated, and <a>decentralized identifiers</a>.
-      </p>
+    <p class="note">
+<a>DID methods</a> can also be developed for identifiers registered in federated
+or centralized identity management systems. Indeed, all types of identifier
+systems can add support for <a>DIDs</a>. This creates an interoperability bridge
+between the worlds of centralized, federated, and
+<a>decentralized identifiers</a>.
+    </p>
 
-      <p>
+    <p>
 The first purpose of this specification is to define the generic
 <a>DID scheme</a> and a generic set of operations on <a>DID documents</a> that
-can be implemented for any <a>DID registry</a>. The second
-purpose of this specification is to
-define the conformance requirements for a <a>DID method</a>
-specification &mdash; a separate specification that defines a specific <a>DID
-scheme</a> and specific set of <a>DID document</a> operations for a specific
-<a>DID registry</a>.
-      </p>
+can be implemented for any <a>DID registry</a>. The second purpose of this
+specification is to define the conformance requirements for a <a>DID method</a>
+specification. The <a>DID method</a> specification is a separate document that
+defines a specific <a>DID scheme</a> and specific set of <a>DID document</a>
+operations for a specific <a>DID registry</a>.
+    </p>
 
-      <p class="note">
-Conceptually, the relationship of this specification and a <a>DID
-method</a> specification is similar to the relationship of the IETF
+    <p class="note">
+Conceptually, the relationship between this specification and a
+<a>DID method</a> specification is similar to the relationship between the IETF
 generic <a>URI</a> specification ([[RFC3986]]) and a specific <a>URI</a> scheme
-          ([[IANA-URI-SCHEMES]] (such as the http: and https: schemes
-specified in [[RFC7230]]). It is also similar to the relationship
-of the IETF generic URN specification ([[RFC8141]]) and a specific URN
-namespace definition (such as the <a>UUID</a> URN namespace defined in
-[[RFC4122]]). The difference is that a <a>DID method</a> specification, in
-addition to defining a specific <a>DID scheme</a>, also specifies the
-methods for resolving and deactivating <a>DIDs</a> on, and writing <a>DID
-documents</a> to, the appropriate <a>DID registry</a>.
-      </p>
-      <p>
-The hierarchical design of a generic <a>DID</a> specification with specific <a>DID method</a>
-specifications introduces some of the same concepts as the <a>URI</a> specification:
-      </p>
-        <ul>
-          <li>
-<a>DIDs</a> from different <a>DID methods</a> may not be interoperable, just as
-<a>URIs</a> from different URI schemes may not be interoperable.
-          </li>
-          <li>
-Entities may need multiple <a>DIDs</a> to support different relationships, as the other
-party may only support certain <a>DID methods</a>, just as some browsers may only
-support certain URI schemes.
-          </li>
-          <li>
-Entities may need multiple <a>DIDs</a> to support the different cryptographic schemes
-of different <a>DID methods</a>, as not all parties will support the same cryptographic
-schemes, just as not all browsers support the same URI schemes.
-          </li>
-          <li>
-Managing multiple <a>DIDs</a>, and tracking which <a>DID</a> belongs to which relationship,
-under which cryptographic scheme, introduces similar logistical challenges as
-managing multiple web addresses and tracking which address belongs to which
-website, or tracking which email address belongs to which relationship.
-          </li>
-        </ul>
-      <p>
+([[IANA-URI-SCHEMES]] (such as the http: and https: schemes specified in
+[[RFC7230]]). It is also similar to the relationship between the IETF generic
+URN specification ([[RFC8141]]) and a specific URN namespace definition, (such
+as the <a>UUID</a> URN namespace defined in [[RFC4122]]). The difference is that
+a <a>DID method</a> specification, as well as defining a specific
+<a>DID scheme</a>, also specifies the methods for resolving and deactivating
+<a>DIDs</a> on, and writing <a>DID documents</a> to, the appropriate
+<a>DID registry</a>.
+    </p>
+
+    <p>
+The hierarchical design of a generic <a>DID</a> specification with specific
+<a>DID method</a> specifications introduces some of the same concepts as the
+<a>URI</a> specification:
+    </p>
+      <ul>
+        <li>
+<a>DIDs</a> from different <a>DID methods</a> might not be interoperable, just
+as <a>URIs</a> from different URI schemes might not be interoperable.
+        </li>
+        <li>
+Entities might need multiple <a>DIDs</a> to support different relationships
+because the other party might only support certain <a>DID methods</a>, in the
+same way that some browsers might only support certain URI schemes.
+        </li>
+        <li>
+Entities might need multiple <a>DIDs</a> to support the different cryptographic
+schemes of different <a>DID methods</a> because not all parties will support the
+same cryptographic schemes, in the same way that not all browsers support the
+same URI schemes.
+        </li>
+        <li>
+Managing multiple <a>DIDs</a>, and tracking which <a>DID</a> belongs to which
+relationship, under which cryptographic scheme, introduces similar logistical
+challenges as managing multiple web addresses and tracking which address belongs
+to which website, or tracking which email address belongs to which relationship.
+        </li>
+      </ul>
+
+    <p>
 For a list of <a>DID methods</a> and their corresponding specifications,
 see the DID Method Registry [[DID-METHOD-REGISTRY]].
       </p>
@@ -343,20 +343,29 @@ A Simple Example
     </h2>
 
     <p>
-A <a>DID</a> is a simple text string that consists of three parts: 1) the URL scheme
-identifier (<code>did</code>), 2) the identifier for the
-<a>DID method</a>, and 3) the DID method-specific identifier.
+A <a>DID</a> is a simple text string consisting of three parts, the:
     </p>
+      <ul> 
+        <li>
+URL scheme identifier (<code>did</code>)
+        </li>
+        <li>
+Identifier for the <a>DID method</a>
+        </li>
+        <li>
+DID method-specific identifier.
+        </li>
+      </ul> 
 
     <pre class="example nohighlight" title="A simple example of a decentralized identifier (DID)">
 did:example:123456789abcdefghi
     </pre>
 
     <p>
-The <a>DID</a> above resolves to a <a>DID document</a>. A <a>DID document</a>
-contains information associated with the <a>DID</a> such as ways to cryptographically
-authenticate the entity in control of the <a>DID</a>, as well as services that can be
-used to interact with the entity.
+The example <a>DID</a> above resolves to a <a>DID document</a>. A
+<a>DID document</a> contains information associated with the <a>DID</a>, such as
+ways to cryptographically authenticate the entity in control of the <a>DID</a>,
+as well as services that can be used to interact with the entity.
     </p>
 
     <pre class="example nohighlight" title="Minimal self-managed DID document">
@@ -377,162 +386,182 @@ used to interact with the entity.
     "serviceEndpoint": "https://example.com/vc/"
   }]
 }
-      </pre>
-    </section>
+    </pre>
+  </section>
 
-    <section class="informative">
-      <h2>
+  <section class="informative">
+    <h2>
 Design Goals
-      </h2>
+    </h2>
 
-      <p>
+    <p>
 <a>Decentralized Identifiers</a> are a component of larger systems, such as
-the Verifiable Credentials ecosystem [[?VC-DATA-MODEL]], which have driven
-the design goals for this specification. This section summarizes the
-primary design goals for this specification.
-      </p>
+the Verifiable Credentials ecosystem [[?VC-DATA-MODEL]], which drove the design
+goals for this specification. This section summarizes the primary design goals
+for this specification.
+    </p>
 
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>
+    <table class="simple">
+      <thead>
+        <tr>
+          <th>
 Goal
-            </th>
-            <th>
+          </th>
+          <th>
 Description
-            </th>
-          </tr>
-        </thead>
+          </th>
+        </tr>
+      </thead>
 
-        <tbody>
-          <tr>
-            <td>
+      <tbody>
+        <tr>
+          <td>
 Decentralization
-            </td>
-            <td>
-Eliminate the requirement for
-centralized authorities or single points of failure in
-identifier management, including the registration of globally
-unique identifiers, public verification keys, <a>service
-endpoints</a>, and other metadata.
-            </td>
-          </tr>
+          </td>
+          <td>
+Eliminate the requirement for centralized authorities or single point
+failure in identifier management, including the registration of globally unique
+identifiers, public verification keys, <a>service endpoints</a>, and other
+metadata.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Control
-            </td>
-            <td>
-Give entities, both human and
-non-human, the power to directly control their digital
-identifiers without the need to rely on external authorities.
-            </td>
-          </tr>
+          </td>
+          <td>
+Give entities, both human and non-human, the power to directly control their
+digital identifiers without the need to rely on external authorities.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Privacy
-            </td>
-            <td>
-Enable entities to control the privacy
-of their information, including minimal, selective, and
-progressive disclosure of attributes or other data.
-            </td>
-          </tr>
+          </td>
+          <td>
+Enable entities to control the privacy of their information, including minimal,
+selective, and progressive disclosure of attributes or other data.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Security
-            </td>
-            <td>
-Enable sufficient security for relying
-parties to depend on <a>DID documents</a> for their required level of
-assurance.
-            </td>
-          </tr>
+          </td>
+          <td>
+Enable sufficient security for relying parties to depend on <a>DID documents</a>
+for their required level of assurance.
+          </td>
+        </tr>
 
-          <tr>
+        <tr>
             <td>
 Proof-based
-            </td>
-            <td>
-Enable the <a>DID subject</a> to provide
-cryptographic proof when interacting with other entities.
-            </td>
-          </tr>
+          </td>
+          <td>
+Enable <a>DID subjects</a> to provide cryptographic proof when interacting with
+other entities.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Discoverability
-            </td>
-            <td>
-Make it possible for entities to
-discover <a>DIDs</a> for other entities to learn more about or
-interact with those entities.
-            </td>
-          </tr>
+          </td>
+          <td>
+Make it possible for entities to discover <a>DIDs</a> for other entities to
+learn more about or interact with those entities.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Interoperability
-            </td>
-            <td>
-Use interoperable standards so <a>DID</a>
-infrastructure can make use of existing tools and software
-libraries designed for interoperability.
-            </td>
-          </tr>
+          </td>
+          <td>
+Use interoperable standards so <a>DID</a> infrastructure can make use of
+existing tools and software libraries designed for interoperability.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Portability
-            </td>
-            <td>
-Be system and network-independent and
-enable entities to use their digital identifiers with any
-system that supports <a>DIDs</a> and <a>DID methods</a>.
-            </td>
-          </tr>
+          </td>
+          <td>
+Be system and network-independent and enable entities to use their digital
+identifiers with any system that supports <a>DIDs</a> and <a>DID methods</a>.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Simplicity
-            </td>
-            <td>
-Favor a reduced set of simple features in order to make the technology
-easier to understand, implement, and deploy.
-            </td>
-          </tr>
+          </td>
+          <td>
+Favor a reduced set of simple features to make the technology easier to
+understand, implement, and deploy.
+          </td>
+        </tr>
 
-          <tr>
-            <td>
+        <tr>
+          <td>
 Extensibility
-            </td>
-            <td>
-When possible, enable extensibility
-provided it does not greatly hinder interoperability,
-portability, or simplicity.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+          </td>
+          <td>
+Where possible, enable extensibility provided it does not greatly hinder
+interoperability, portability, or simplicity.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
 
-    <section>
-      <h3>Interoperability</h3>
-          <p>Interoperability of implementations for <a>DIDs</a> and <a>DID documents</a> will be tested by evaluating an implementation's ability to create and parse <a>DIDs</a> and <a>DID documents</a> that conform to the specification. Interoperability for <a>DID methods</a> will be determined by evaluating each <a>DID method</a>'s specification to determine, at a minimum, </p>
-          <ol>
-              <li> the <a>DID method</a> name is unique and not used by an existing, incompatible <a>DID method</a>, </li>
-              <li> the required operations are supported,</li>
-              <li> operations requiring descriptions are described,</li>
-              <li> the specification is specific, detailed, and complete enough for independent implementation, and</li>
-              <li> the specification contains sections describing security and privacy considerations.</li>
-          </ol>
+  <section>
+    <h3>
+Interoperability
+    </h3>
 
+    <p>
+Interoperability of implementations for <a>DIDs</a> and <a>DID documents</a>
+will be tested by evaluating an implementation's ability to create and parse
+<a>DIDs</a> and <a>DID documents</a> that conform to the specification.
+Interoperability for <a>DID methods</a> will be determined by evaluating each
+<a>DID method</a> specification to determine, at a minimum, that the:
+    </p>
+      <ul>
+        <li>
+<a>DID method</a> name is unique and not used by an existing, incompatible
+<a>DID method</a>.
+        </li>
+        <li>
+Required operations are supported.
+        </li>
+        <li>
+Operations requiring descriptions are described.
+        </li>
+        <li>
+Specification is specific, detailed, and complete enough for independent
+implementation.
+        </li>
+        <li>
+Specification contains sections describing security and privacy considerations.
+        </li>
+      </ul>
 
-          <p>Interoperability for producers and consumers of <a>DIDs</a> and <a>DID documents</a> is provided by ensuring the <a>DIDs</a> and <a>DID documents</a> conform. Interoperability for method specifications is provided by the details in each method specification. It is understood that, just like a web browser is not required to implement all known URI schemes, conformant software that works with <a>DIDs</a> is not required to implement all known <a>DID methods</a>. However, all implementations of a given <a>DID method</a> must be interoperable for that method.</p>
-
-</section>
+    <p>
+Interoperability for producers and consumers of <a>DIDs</a> and
+<a>DID documents</a> is provided by ensuring the <a>DIDs</a> and 
+<a>DID documents</a> conform. Interoperability for <a>DID method</a>
+specifications is provided by the details in each <a>DID method</a>
+specification. It is understood that, in the same way that a web browser is not
+required to implement all known URI schemes, conformant software that works
+with <a>DIDs</a> is not required to implement all known <a>DID methods</a>.
+However, all implementations of a given <a>DID method</a> must be interoperable
+for that method.
+    </p>
   </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     subtitle: "Core Data Model and Syntaxes",
 
     // if you wish the publication date to be other than today, set this
-    publishDate:  "2019-11-07",
+    //publishDate:  "2019-11-07",
 
     // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
     // and its maturity status

--- a/index.html
+++ b/index.html
@@ -1439,12 +1439,12 @@ Authentication
       </h2>
 
       <p>
-Authentication is the mechanism by which the <a>DID controller(s)</a> can
-cryptographically prove that they are associated with that DID (see Section
-<a href="#binding-of-identity"></a>).
-Authentication is separate from Authorization because the
-<a>DID controller(s)</a> may wish to enable others to update their DID Document
-(for example, to assist with key recovery as discussed in Section
+Authentication is the mechanism by which <a>DID controllers</a> can
+cryptographically prove that they are associated with a <a>DID</a>. For more
+information, see Section <a href="#binding-of-identity"></a>. Note that
+Authentication is separate from Authorization because <a>DID controllers</a>
+might wish to enable others to update their <a>DID document</a> (for example, to
+assist with key recovery, as discussed in Section
 <a href="#key-revocation-and-recovery"></a>) without enabling them to prove
 control (and thus be able to impersonate the <a>DID controller(s)</a>).
       </p>

--- a/index.html
+++ b/index.html
@@ -1054,7 +1054,7 @@ DID Documents
     <p>
 A <a>DID</a> points to a <a>DID document</a>. <a>DID documents</a> are the
 serialization of the <a href="#data-model"></a>.
-The following sections define the properties of the <a>DID document</a>,
+The following sections define the properties in a <a>DID document</a>,
 including whether these properties are required or optional.
     </p>
 
@@ -1062,11 +1062,20 @@ including whether these properties are required or optional.
       <h2>Contexts</h2>
 
         <p>
-When two software systems need to exchange data, they must use terminology and
-a protocol that both systems understand. As an analogy, consider how two
-people communicate. Both people must use the same language and the words they
-use must mean the same thing to each other. This specification uses the
-<code>@context</code> property to express the context of a conversation.
+When two software systems need to exchange data, they need to use terminology
+and a protocol that both systems understand. The <code>@context</code>
+property ensures that two systems operating on the same DID document are using
+mutually agreed terminology.
+        </p>
+
+        <p>
+<a>DID documents</a> MUST include the <code>@context</code> property.
+        </p>
+
+        <p class="note" title="The JSON-LD Context">
+More information about the
+<a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD Context</a>
+in general can be found in the [[!JSON-LD]] specification.
         </p>
 
         <dl>
@@ -1082,29 +1091,7 @@ containing machine-readable information about the context.
         </dl>
 
       <p>
-<a>DID documents</a> MUST include the <code>@context</code> property. The
-<a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD Context</a>
-is described in detail in the [[!JSON-LD]] specification. The rules for this
-statement are:
-      </p>
-
-      <ol start="1">
-        <li>
-A <a>DID document</a> MUST have exactly one top-level context statement.
-        </li>
-
-        <li>
-The key for this property MUST be <code>@context</code>.
-        </li>
-
-        <li>
-The value of this key MUST be the URL for the generic <a>DID</a> context:
-<code>https://www.w3.org/ns/did/v1</code>.
-        </li>
-      </ol>
-
-      <p>
-Example (using an example URL):
+Example:
       </p>
 
       <pre class="example nohighlight">
@@ -1126,30 +1113,21 @@ DID Subject
       </h2>
 
       <p>
-The <a>DID subject</a> is the entity that the <a>DID document</a> is about, i.e.,
+The <a>DID subject</a> is denoted with the <code>id</code> property.
+This is the entity that the <a>DID document</a> is about, i.e.,
 it is the entity identified by the <a>DID</a> and described by the <a>DID document</a>.
-The rules for a <a>DID subject</a> are:
       </p>
 
-      <ol start="1">
-        <li>
-A <a>DID document</a> MUST have exactly one <a>DID subject</a>.
-        </li>
+      <p>
+<a>DID documents</a> MUST include the <code>id</code> property.
+      </p>
 
-        <li>
-The key for this property MUST be id.
-        </li>
-
-        <li>
-The value of this key MUST be a valid <a>DID</a>.
-        </li>
-
-        <li>
-When this <a>DID document</a> is registered with the target <a>DID
-registry</a>, the registered <a>DID</a> MUST match this <a>DID subject</a>
-value.
-        </li>
-      </ol>
+      <dl>
+          <dt><dfn>id</dfn></dt>
+          <dd>
+The value of <code>id</code> MUST be a single valid <a>DID</a>.
+          </dd>
+      </dl>
 
       <p>
 Example:
@@ -1159,12 +1137,14 @@ Example:
 {
   "id": "did:example:21tDAKCERh95uGgKbJNHYp"
 }
-</pre>
+      </pre>
       <p class="note">
-<a>DID method</a> specifications MAY create intermediate representations of
+<a>DID method</a> specifications can create intermediate representations of
 a <a>DID document</a> that do not contain the <code>id</code> key, such as
 when a <a>DID resolver</a> is performing resolution. However, the fully
-resolved <a>DID document</a> MUST contain a valid <code>id</code> property.
+resolved <a>DID document</a> always contains a valid <code>id</code> property.
+The value of <code>id</code> in the resolved <a>DID document</a> is expected
+to match the <a>DID</a> that was resolved.
       </p>
     </section>
     <!-- section>
@@ -1246,8 +1226,54 @@ such as authentication (see Section <a href="#authentication"></a>)
 or establishing secure communication with <a>service endpoints</a>
 (see Section <a href="#service-endpoints"></a>). In addition, public
 keys may play a role in authorization mechanisms of <a>DID</a> CRUD
-operations (see Section <a href="#did-operations"></a>). This may be
+operations (see Section <a href="#did-operations"></a>), which can be
 defined by <a>DID method</a> specifications.
+      </p>
+      
+      <p>
+A <a>DID document</a> MAY include a <code>publicKey</code> property. If so:
+      </p>
+
+      <dl>
+          <dt><dfn>publicKey</dfn></dt>
+          <dd>
+The value of the <code>publicKey</code> property MUST be an array of
+public key objects. Each public key object MUST have the
+<code>type</code>, <code>controller</code>, and specific public key
+properties, and SHOULD have an <code>id</code> property. The object
+MAY include additional properties.
+          </dd>
+      </dl>
+
+      <p>
+The value of the <code>id</code> property (if present) MUST be a URI. The array
+of public keys MUST NOT contain multiple entries with the same
+<code>id</code>. A <a>DID document</a> processor MUST produce an error in that
+case.
+      </p>
+
+      <p>
+The value of the <code>type</code> property MUST be exactly one public key value
+(see available key types in Appendix <a href="#registries"></a>).
+      </p>
+
+      <p>
+The value of the <code>controller</code> property, which identifies the
+controller of the corresponding private key, MUST be a valid DID.
+      </p>
+
+      <p>
+All public key properties MUST be from the Linked Data Cryptographic Suite Registry.
+A registry of key types and formats is available in Appendix <a href="#registries"></a>
+      </p>
+
+      <p class="note">
+        The following is a non-exhaustive list of public key
+        properties used by the community:
+        <code>publicKeyPem</code>, <code>publicKeyJwk</code>,
+        <code>publicKeyHex</code>, <code>publicKeyBase64</code>,
+        <code>publicKeyBase58</code>, <code>publicKeyMultibase</code>,
+        <code>ethereumAddress</code>.
       </p>
 
       <p>
@@ -1259,52 +1285,6 @@ a revocation list). Each <a>DID method</a> specification is expected to
 detail how revocation is performed and tracked.
       </p>
 
-      <p>
-The rules for public keys are:
-      </p>
-
-      <ol start="1">
-        <li>
-A <a>DID document</a> MAY include a <code>publicKey</code> property.
-        </li>
-
-        <li>
-The value of the <code>publicKey</code> property MUST be an array of
-public keys, and every public key property MUST be in the
-<a href="https://w3c-ccg.github.io/ld-cryptosuite-registry">Linked Data
-Cryptographic Suite Registry</a>.
-        </li>
-
-        <li>
-Each public key SHOULD include an <code>id</code> property. The array
-of public keys MUST NOT contain multiple entries with the same
-<code>id</code>. A <a>DID document</a> processor MUST produce an error in that
-case.
-        </li>
-
-        <li>
-Each public key MUST include a <code>type</code> property
-and exactly one public key value, and MAY include additional properties.
-        </li>
-
-        <li>
-Each public key MUST include a <code>controller</code> property, which
-identifies the controller of the corresponding private key.
-        </li>
-
-        <li>
-A registry of key types and formats is available in Appendix
-<a href="#registries"></a>.
-        </li>
-      </ol>
-      <p class="note">
-        The following is a non-exhaustive list of public key
-        properties used by the community:
-        <code>publicKeyPem</code>, <code>publicKeyJwk</code>,
-        <code>publicKeyHex</code>, <code>publicKeyBase64</code>,
-        <code>publicKeyBase58</code>, <code>publicKeyMultibase</code>,
-        <code>ethereumAddress</code>.
-      </p>
       <p>
 Example:
       </p>
@@ -1431,9 +1411,9 @@ Authentication
 
       <p>
 Authentication is the mechanism by which the <a>DID controller(s)</a> can
-cryptographically prove that they are associated with that DID.
-See Section <a href="#binding-of-identity"></a>. Note
-that Authentication is separate from Authorization because the
+cryptographically prove that they are associated with that DID (see Section
+<a href="#binding-of-identity"></a>).
+Authentication is separate from Authorization because the
 <a>DID controller(s)</a> may wish to enable others to update their DID Document
 (for example, to assist with key recovery as discussed in Section
 <a href="#key-revocation-and-recovery"></a>) without enabling them to prove
@@ -1441,25 +1421,18 @@ control (and thus be able to impersonate the <a>DID controller(s)</a>).
       </p>
 
       <p>
-The rules for Authentication are:
-      </p>
-
-      <ol start="1">
-        <li>
 A <a>DID document</a> MAY include an <code>authentication</code>
-property.
-        </li>
-
-        <li>
+property. If so:
+      </p>
+      <dl>
+          <dt><dfn>authentication</dfn></dt>
+          <dd>
 The value of the <code>authentication</code> property SHOULD be
-an array of verification methods.
-        </li>
-
-        <li>
-Each verification method MAY be embedded or referenced. An example of
-a verification method is a public key (see Section <a href="#public-keys"></a>).
-        </li>
-      </ol>
+an array of verification methods. Each verification method MAY be embedded
+or referenced. An example of a verification method is a public key (see
+Section <a href="#public-keys"></a>).
+          </dd>
+      </dl>
 
       <p>
 Example:
@@ -1498,7 +1471,7 @@ Authorization and Delegation
       <p>
 Authorization is the mechanism used to state how operations may be
 performed on behalf of the <a>DID subject</a>. Delegation is the
-mechanism that the subject may use to authorize others to act
+mechanism that the subject uses to authorize others to act
 on their behalf. Note that Authorization is separate from
 Authentication as explained in Section <a href="#authentication"></a>.
 This is particularly important for key
@@ -1557,50 +1530,46 @@ Service Endpoints
       </h2>
 
       <p>
-In addition to publication of authentication and authorization
-mechanisms, the other primary purpose of a <a>DID document</a> is to enable
-discovery of <a>service endpoints</a> for the <a>DID subject</a>. A <a>service
-endpoint</a> MAY represent any type of service the <a>DID subject</a> wishes to
+One of the primary purposes of a <a>DID document</a> is to enable
+discovery of <a>service endpoints</a>. A <a>service
+endpoint</a> can be any type of service the <a>DID subject</a> wishes to
 advertise, including <a>decentralized identity management</a> services for
-further discovery, authentication, authorization, or interaction. The
-rules for <a>service endpoints</a> are:
+further discovery, authentication, authorization, or interaction.
       </p>
 
-      <ol start="1">
-        <li>
-A <a>DID document</a> MAY include a <code>service</code> property.
-        </li>
+      <p>
+A <a>DID document</a> MAY include a <code>service</code> property. If so:
+      </p>
 
-        <li>
+      <dl>
+          <dt><dfn>service</dfn></dt>
+          <dd>
 The value of the <code>service</code> property SHOULD be an array
-of <a>service endpoints</a>.
-        </li>
+of <a>service endpoint</a> objects. Each service endpoint MUST
+have <code>type</code> and <code>serviceEndpoint</code> properties,
+SHOULD have an <code>id</code> property, and MAY include additional
+properties.
+          </dd>
+      </dl>
 
-        <li>
-Each <a>service endpoint</a> SHOULD include an <code>id</code> property.
+      <p>
+The value of the <code>id</code> property (if present) MUST be a URI.
 The array of <a>service endpoints</a> MUST NOT contain multiple entries
 with the same <code>id</code>. A <a>DID document</a> processor MUST
 produce an error in that case.
-        </li>
+      </p>
 
-        <li>
-Each service endpoint MUST include <code>type</code> and
-<code>serviceEndpoint</code> properties, and MAY include additional
-properties.
-        </li>
-
-        <li>
-The <a>service endpoint</a> protocol SHOULD be published in an open
-standard specification.
-        </li>
-
-        <li>
+      <p>
 The value of the <code>serviceEndpoint</code> property MUST be a
 JSON-LD object or a valid <a>URI</a> conforming to [[RFC3986]] and
 normalized according to the rules in section 6 of [[RFC3986]] and to
 any normalization rules in its applicable URI scheme specification.
-        </li>
-      </ol>
+      </p>
+
+      <p>
+It is expected that the <a>service endpoint</a> protocol is
+published in an open standard specification.
+      </p>
 
       <p>
 Example:
@@ -1662,42 +1631,22 @@ considerations regarding authentication <a>service endpoints</a>.
 
     <section>
       <h2>
-Created (Optional)
+Created
       </h2>
 
       <p>
-Standard metadata for identifier records includes a timestamp of the
-original creation. The rules for including a creation timestamp are:
+A <a>DID document</a> SHOULD include a <code>created</code> property. If so:
       </p>
 
-      <ol start="1">
-        <li>
-A <a>DID document</a> MUST have zero or one property representing a
-creation timestamp. It is RECOMMENDED to include this property.
-        </li>
-
-        <li>
-The key for this property MUST be created.
-        </li>
-
-        <li>
-The value of this key MUST be a valid XML datetime value as
-defined in section 3.3.7 of <a href="https://www.w3.org/TR/xmlschema11-2/">W3C XML Schema Definition
-Language (XSD) 1.1 Part 2: Datatypes</a> [[!XMLSCHEMA11-2]].
-        </li>
-
-        <li>
-This datetime value MUST be normalized to UTC 00:00 as indicated
-by the trailing "Z".
-        </li>
-
-        <li>
-Method specifications that rely on <a>DLTs</a> SHOULD require time
-values that are after the known <a href="https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki">"median
-time past" (defined in Bitcoin BIP 113)</a>, when the <a>DLT</a> supports
-such a notion.
-        </li>
-      </ol>
+      <dl>
+          <dt><dfn>created</dfn></dt>
+          <dd>
+The value of <code>created</code> MUST be a valid XML datetime value as
+defined in section 3.3.7 of <a href="https://www.w3.org/TR/xmlschema11-2/">
+W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes</a> [[!XMLSCHEMA11-2]].
+This datetime value MUST be normalized to UTC 00:00 as indicated by the trailing "Z".
+          </dd>
+      </dl>
 
       <p>
 Example:
@@ -1712,29 +1661,25 @@ Example:
 
     <section>
       <h2>
-Updated (Optional)
+Updated
       </h2>
 
       <p>
 Standard metadata for identifier records includes a timestamp of the
-most recent change. The rules for including an updated timestamp are:
+most recent change.
       </p>
 
-      <ol start="1">
-        <li>
-A <a>DID document</a> MUST have zero or one property representing an
-updated timestamp. It is RECOMMENDED to include this property.
-        </li>
+      <p>
+A <a>DID document</a> SHOULD include an <code>updated</code> property. If so:
+      </p>
 
-        <li>
-The key for this property MUST be updated.
-        </li>
-
-        <li>
-The value of this key MUST follow the formatting rules (3, 4, 5)
-from Section <a href="#created-optional"></a>.
-        </li>
-      </ol>
+      <dl>
+          <dt><dfn>updated</dfn></dt>
+          <dd>
+The value <code>updated</code> MUST follow the same formatting rules as the
+<code>created</code> property (see Section <a href="#created"></a>).
+          </dd>
+      </dl>
 
       <p>
 Example:
@@ -1749,7 +1694,7 @@ Example:
 
     <section>
       <h2>
-Proof (Optional)
+Proof
       </h2>
 
       <p>
@@ -1769,26 +1714,20 @@ The <a>DID controller</a> as defined in Section <a href="#authorization-and-dele
 
       <p>
 This proof is NOT proof of the binding between a <a>DID</a> and a <a>DID
-document</a>. See Section <a href="#binding-of-identity"></a>. The rules
-for a proof are:
+document</a> (see Section <a href="#binding-of-identity"></a>).
       </p>
 
-      <ol start="1">
-        <li>
-A <a>DID document</a> MAY have exactly one property representing a
-proof.
-        </li>
+      <p>
+A <a>DID document</a> MAY include a <code>proof</code> property. If so:
+      </p>
 
-        <li>
-The key for this property MUST be <code>proof</code>.
-        </li>
-
-        <li>
-The value of this key MUST be a valid JSON-LD proof as defined by
-<a href="https://w3c-dvcg.github.io/ld-signatures/">Linked Data
-Proofs</a>.
-        </li>
-      </ol>
+      <dl>
+          <dt><dfn>proof</dfn></dt>
+          <dd>
+The value of <code>proof</code> MUST be a valid JSON-LD proof as defined by
+<a href="https://w3c-dvcg.github.io/ld-signatures/">Linked Data Proofs</a>.
+          </dd>
+      </dl>
 
       <p>
 Example:
@@ -2090,20 +2029,20 @@ DID Method Schemes
       </h2>
 
       <p>
-A <a>DID method</a> specification MUST define exactly one specific <a>DID
+A <a>DID method</a> specification MUST define exactly one method-specific <a>DID
 scheme</a> identified by exactly one method name (the <code>method-name</code> rule in
 Section <a href="#generic-did-syntax"></a>).
       </p>
 
       <p>
-Since the method name is part of the <a>DID</a>, it SHOULD be as short as
-practical. A method name of five characters or less is RECOMMENDED.
-The method name MAY reflect the name of the <a>DID
-registry</a> to which the <a>DID method</a> specification applies.
+Since the method name is part of the <a>DID</a>, short method names are preferred;
+the method name SHOULD be five characters or less. The method name might reflect the name
+of the <a>DID registry</a> to which the <a>DID method</a> specification applies.
+See also Section <a href="#unique-did-method-names"></a>.
       </p>
 
       <p>
-The <a>DID method</a> specification for the specific <a>DID scheme</a> MUST specify
+The <a>DID method</a> specification for the method-specific <a>DID scheme</a> MUST specify
 how to generate the <code>method-specific-id</code> component of a <a>DID</a>. The
 <code>method-specific-id</code> value MUST be able to be generated without the use
 of a centralized registry service. The <code>method-specific-id</code> value SHOULD
@@ -2112,9 +2051,9 @@ in Section <a href="#generic-did-syntax"></a> MUST be globally unique.
       </p>
 
       <p>
-If needed, a specific <a>DID scheme</a> MAY define multiple specific
-<code>method-specific-id</code> formats. It is RECOMMENDED that a specific <a>DID
-scheme</a> define as few <code>method-specific-id</code> formats as possible.
+If needed, a method-specific <a>DID scheme</a> MAY define multiple 
+<code>method-specific-id</code> formats. It is RECOMMENDED that a method-specific
+<a>DID scheme</a> define as few <code>method-specific-id</code> formats as possible.
       </p>
     </section>
 
@@ -2125,40 +2064,19 @@ DID Operations
 
       <p>
 To enable the full functionality of <a>DIDs</a> and <a>DID documents</a> on a
-particular <a>DID registry</a>, a
-<a>DID method</a> specification MUST specify how each of the following
-<a href="https://en.wikipedia.org/wiki/Create,_read,_update_and_delete">
-CRUD</a> operations is performed by a client. Each operation MUST be
-specified to the level of detail necessary to build and test
-interoperable client implementations with the target system.
-The specification document for a <a>DID method</a> that does not support
-specific operations such as Update and Deactivate MUST clearly specify these
-limitations. Note that, due to the specified contents of <a>DID documents</a>,
-these operations can effectively be used to perform all the operations
-required of a CKMS (cryptographic key management system), e.g.,:
+particular <a>DID registry</a>, a <a>DID method</a> specification MUST specify how
+each of the following <abbr title="Create, Read, Update, Delete">CRUD</abbr>
+operations is performed by a client. Each operation ought to be specified to the level
+of detail necessary to build and test interoperable client implementations with the
+<a>DID registry</a>. These operations can effectively be used to perform all the operations
+required of a CKMS (cryptographic key management system), e.g.: key registration,
+key replacement, key rotation, key recovery, and key expiration.
+
       </p>
-
-      <ul>
-        <li>
-Key registration
-        </li>
-
-        <li>
-Key replacement
-        </li>
-
-        <li>
-Key rotation
-        </li>
-
-        <li>
-Key recovery
-        </li>
-
-        <li>
-Key expiration
-        </li>
-      </ul>
+      <p>
+Any <a>DID method</a> specification that does not support specific operations,
+such as Update and Deactivate, MUST clearly state these limitations.
+      </p>
 
       <section>
         <h3>
@@ -2203,8 +2121,7 @@ Deactivate
         </h3>
 
         <p>
-Although a core feature of <a>distributed ledgers</a> is immutability, the
-<a>DID method</a> specification MUST specify how a client can deactivate a
+The <a>DID method</a> specification MUST specify how a client can deactivate a
 <a>DID</a> on the <a>DID registry</a>, including all cryptographic
 operations necessary to establish proof of deactivation <em>or</em> state that
 deactivation is not possible.

--- a/index.html
+++ b/index.html
@@ -687,25 +687,31 @@ Decentralized Identifiers (DIDs)
     </h1>
 
     <p>
-The concept of a globally unique <a>decentralized identifier</a> is not
-new; <a>Universally
-Unique Identifiers</a> (UUIDs) were first developed in the 1980s and
-later became a standard feature of the Open Software Foundation’s
-<a href="https://en.wikipedia.org/wiki/Distributed_Computing_Environment">Distributed
-Computing Environment</a>. <a>UUIDs</a> achieve global uniqueness without a
-centralized registry service by using an algorithm that generates
-128-bit values with sufficient entropy that the chance of collision are
-infinitesimally small. <a>UUIDs</a> are formally specified in [[RFC4122]] as a
-specific type of Unified Resource Name (URN).
+The concept of a globally unique <a>decentralized identifier</a> is not new.
+<a>Universally Unique Identifiers</a> (UUIDs) were first developed in the 1980s
+and later became a standard feature of the Open Software Foundation’s
+<a href="https://en.wikipedia.org/wiki/Distributed_Computing_Environment">Distributed Computing Environment</a>.
+<a>UUIDs</a> achieve global uniqueness without a centralized registry service by
+using an algorithm that generates 128-bit values with sufficient entropy that
+the chance of collision are infinitesimally small. <a>UUIDs</a> are formally
+specified in [[RFC4122]] as a specific type of Unified Resource Name (URN).
     </p>
 
     <p>
-A <a>DID</a> is similar to a <a>UUID</a> except: (a) like a URL, it can be resolved
-or dereferenced to a standard resource describing the subject (a <a>DID
-document</a> &mdash; see Section <a href="#did-documents"></a>), and (b) unlike
-a URL, the <a>DID document</a> typically contains cryptographic material that
-enables authentication of the <a>DID subject</a>.
+A <a>DID</a> is similar to a <a>UUID</a> except that:
     </p>
+      <ul>
+        <li>
+Like a URL, it can be resolved or dereferenced to a standard resource describing
+the subject. That is, a <a>DID document</a>. For more information, see Section
+<a href="#did-documents"></a>.
+        </li>
+        <li>
+Unlike most resources returned when dereferencing URLs, a <a>DID document</a>
+usually contains cryptographic material enabling authentication of the
+<a>DID subject</a>.
+        </li>
+      <ul>
 
     <section>
       <h2>
@@ -713,28 +719,26 @@ Generic DID Syntax
       </h2>
 
       <p>
-The generic <a>DID scheme</a> is a URI scheme conformant with
-[[!RFC3986]]. The <a>DID scheme</a> specializes only the scheme and
-authority components of a <a>DID URL</a> &mdash; the <code>path-abempty</code>,
-<code>query</code>, and <code>fragment</code> components are
-identical to the ABNF rules defined
-in [[!RFC3986]].
+The generic <a>DID scheme</a> is a URI scheme conformant with [[!RFC3986]]. The
+<a>DID scheme</a> specializes only the scheme and authority components of a
+<a>DID URL</a>. The <code>path-abempty</code>, <code>query</code>, and
+<code>fragment</code> components are identical to the ABNF rules defined in
+[[!RFC3986]].
       </p>
 
       <p class="note">
-The term <a>DID</a> refers only to the <a>URI</a>
-conforming to the <code>did</code> rule in the ABNF below. A
-<a>DID</a> always identifies the <a>DID subject</a>. The term <a>DID URL</a>,
-defined by the <code>did-url</code> rule,
-refers to a URL that begins with a <a>DID</a> followed by one or more
+The term <a>DID</a> refers only to the <a>URI</a> conforming to the
+<code>did</code> rule in the ABNF below. A <a>DID</a> always identifies the
+<a>DID subject</a>. The term <a>DID URL</a>, defined by the <code>did-url</code>
+rule, refers to a URL that begins with a <a>DID</a> followed by one or more
 additional components. A <a>DID URL</a> always identifies the resource to
 be located.
       </p>
 
       <p>
-The following is the ABNF definition using the syntax in [[!RFC5234]]
-which defines <code>ALPHA</code> and <code>DIGIT</code>. All other
-rule names not defined in this ABNF are defined in [[RFC3986]].
+The following is the ABNF definition using the syntax in [[!RFC5234]], which
+defines <code>ALPHA</code> and <code>DIGIT</code>. All other rule names not
+defined in this ABNF are defined in [[RFC3986]].
       </p>
 
       <pre class="nohighlight">
@@ -750,7 +754,7 @@ param-name         = 1*param-char
 param-value        = *param-char
 param-char         = ALPHA / DIGIT / "." / "-" / "_" / ":" /
                      pct-encoded
-</pre>
+      </pre>
 
       <p class="issue" data-number="34">
 The grammar currently allows an empty <code>method-specific-id</code>,
@@ -768,7 +772,8 @@ Method-Specific Syntax
       <p>
 A <a>DID method</a> specification MUST further restrict the generic <a>DID</a>
 syntax by defining its own <code>method-name</code> and its own
-<code>method-specific-id</code> syntax. See Section <a href="#did-methods"></a>.
+<code>method-specific-id</code> syntax. For more information, see Section
+<a href="#did-methods"></a>.
       </p>
     </section>
 
@@ -778,32 +783,34 @@ Generic DID Parameter Names
       </h2>
 
       <p>
-<a>DID URL</a> syntax supports a simple, generalized format for parameters based on the
-matrix parameter syntax ([[MATRIX-URIS]]).
-The ABNF above does not specify any parameter names (the <code>param-name</code>
-rule).
+The <a>DID URL</a> syntax supports a simple, generalized format for parameters
+based on the matrix parameter syntax ([[MATRIX-URIS]]). The ABNF above does not
+specify any parameter names (the <code>param-name</code> rule).
       </p>
       <p>
-Some generic DID parameter names (e.g., for service selection) are completely
-independent of any specific <a>DID method</a> and MUST always function the same way
-for all <a>DIDs</a>.
-Others (e.g., for versioning) MAY be supported by
-certain <a>DID methods</a>, but MUST operate uniformly across those <a>DID methods</a>
-that do support them.
+Some generic DID parameter names (for example, for service selection) are
+completely independent of any specific <a>DID method</a> and MUST always
+function the same way for all <a>DIDs</a>. Other DID parameter names (for
+example, for versioning) MAY be supported by certain <a>DID methods</a>, but
+MUST operate uniformly across those <a>DID methods</a> that do support them.
       </p>
       <p>
-Parameter names that are completely method-specific are covered in
+Parameter names that are completely method-specific are described in Section
 <a href="#method-specific-did-parameter-names"></a>.
       </p>
       <p>
-The following table defines a set of generic DID parameter names:
+The following table defines a set of generic DID parameter names.
       </p>
 
       <table class="simple">
         <thead>
           <tr>
-            <th>Generic DID Parameter Name</th>
-            <th>Description</th>
+            <th>
+Generic DID Parameter Name
+            </th>
+            <th>
+Description
+            </th>
           </tr>
         </thead>
 
@@ -813,8 +820,8 @@ The following table defines a set of generic DID parameter names:
 <code>hl</code>
             </td>
             <td>
-A resource hash of the <a>DID document</a> to add integrity
-protection, as specified in [[HASHLINK]].
+A resource hash of the <a>DID document</a> to add integrity protection, as
+specified in [[HASHLINK]].
             </td>
           </tr>
           <tr>
@@ -830,9 +837,9 @@ Identifies a service from the <a>DID document</a> by service ID.
 <code>version-id</code>
             </td>
             <td>
-Identifies a specific version of a <a>DID document</a> to be resolved (the version ID
-could be sequential, or a <a>UUID</a>, or method-specific). Note: This parameter may
-not be supported by all <a>DID methods</a>.
+Identifies a specific version of a <a>DID document</a> to be resolved (the
+version ID could be sequential, or a <a>UUID</a>, or method-specific). Note that
+this parameter might not be supported by all <a>DID methods</a>.
             </td>
           </tr>
 
@@ -841,27 +848,28 @@ not be supported by all <a>DID methods</a>.
 <code>version-time</code>
             </td>
             <td>
-Identifies a certain version timestamp of a <a>DID document</a> to be resolved
-(i.e., the <a>DID document</a> that was valid for a <a>DID</a> at a certain time).
-Note: This parameter may not be supported by all <a>DID methods</a>.
+Identifies a certain version timestamp of a <a>DID document</a> to be resolved.
+That is, the <a>DID document</a> that was valid for a <a>DID</a> at a certain
+time. Note that this parameter might not be supported by all <a>DID methods</a>.
             </td>
           </tr>
         </tbody>
       </table>
 
       <p>
-The exact processing rules for these parameters are specified in [[DID-RESOLUTION]].
+The exact processing rules for these parameters are specified in
+[[DID-RESOLUTION]].
       </p>
 
       <p class="note">
-Note that there may be additional parameters or options that are not part
-of the DID URL but instead passed to a <a>DID resolver</a> "out of band", i.e.,
-using a resolution protocol or some other mechanism. Such options could
-for example control caching or the desired format of a resolution result.
-This is similar to HTTP, where caching or result format are expressed as
-HTTP headers rather than as part of an HTTP URL. The important distinction
-is that DID parameters that are part of the <a>DID URL</a> specify what resource
-is being identified, whereas <a>DID resolver</a> options that are not part of the
+There might be additional parameters or options that are not part of the DID
+URL, but instead passed to a <a>DID resolver</a> <em>out-of-band</em>, that is,
+using a resolution protocol or some other mechanism. Such options could for
+example, control caching or the desired format of a resolution result. This is
+similar to HTTP, where caching or result format are expressed as HTTP headers
+instead of as part of an HTTP URL. The important distinction is that DID
+parameters that are part of the <a>DID URL</a> specify what resource is being
+identified, whereas <a>DID resolver</a> options that are not part of the
 <a>DID URL</a> control how that resource is dereferenced.
       </p>
     </section>
@@ -872,20 +880,20 @@ Method-Specific DID Parameter Names
       </h2>
 
       <p>
-A <a>DID method</a> specification MAY specify additional method-specific parameter
-names. A method-specific parameter name MUST be prefixed by the method name
-as defined by the <code>method-name</code> rule.
+A <a>DID method</a> specification MAY specify additional method-specific
+parameter names. A method-specific parameter name MUST be prefixed by the method
+name, as defined by the <code>method-name</code> rule.
       </p>
 
       <p>
-For example, if the method <code>did:foo:</code> defines the parameter bar,
-the parameter name must be <code>foo:bar</code>. An example <a>DID URL</a> using
-this method and this method-specific parameter would be:
+For example, if the method <code>did:foo:</code> defines the parameter bar, the
+parameter name must be <code>foo:bar</code>. An example <a>DID URL</a> using
+this method and this method-specific parameter would be as shown below.
       </p>
 
-      <p>
-<code>did:foo:21tDAKCERh95uGgKbJNHYp;foo:bar=high</code>
-      </p>
+      <pre class="example nohighlight">
+did:foo:21tDAKCERh95uGgKbJNHYp;foo:bar=high
+      </pre>
 
       <p class="issue" data-number="35">
 Consider using kebab-case style instead of colon separator,
@@ -893,33 +901,33 @@ e.g., <code>foo-bar</code> instead of <code>foo:bar</code>.
       </p>
 
       <p>
-A method-specific parameter name defined by one <a>DID method</a> MAY
-be used by other <a>DID methods</a>. For example:
+A method-specific parameter name defined by one <a>DID method</a> MAY be used by
+other <a>DID methods</a>.
       </p>
 
-      <p>
-<code>did:example:21tDAKCERh95uGgKbJNHYp;foo:bar=low</code>
-      </p>
+      <pre class="example nohighlight">
+did:example:21tDAKCERh95uGgKbJNHYp;foo:bar=low
+      </pre>
 
       <p>
-Method-specific parameter names MAY be combined with generic parameter
-names in any order.
+Method-specific parameter names MAY be combined with generic parameter names in
+any order.
       </p>
 
-      <p>
-<code>did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high</code>
-      </p>
+      <pre class="example nohighlight">
+did:example:21tDAKCERh95uGgKbJNHYp;service=agent;foo:bar=high
+      </pre>
 
       <p>
-Both <a>DID method</a> namespaces and method-specific parameter
-namespaces MAY include colons, so they may be partitioned hierarchically
-as defined by a <a>DID method</a> specification. Here is an example <a>DID
-URL</a> that illustrates both:
+Both <a>DID method</a> namespaces and method-specific parameter namespaces MAY
+include colons, so they might be partitioned hierarchically, as defined by a
+<a>DID method</a> specification. The following example <a>DID URL</a>
+illustrates both.
       </p>
 
-      <p>
-<code>did:foo:baz:21tDAKCERh95uGgKbJNHYp;foo:baz:hex=b612</code>
-      </p>
+      <pre class="example nohighlight">
+did:foo:baz:21tDAKCERh95uGgKbJNHYp;foo:baz:hex=b612
+      </pre>
     </section>
 
       <p class="issue" data-number="36">
@@ -934,16 +942,17 @@ Path
       </h2>
 
       <p>
-A generic <a>DID path</a> is identical to a URI path and MUST
-conform to the <code>path-abempty</code> ABNF rule in [[!RFC3986]]. A
-<a>DID path</a> SHOULD be used to address resources available via a
-<a>service endpoint</a>. See Section <a href="#service-endpoints"></a>.
+A generic <a>DID path</a> is identical to a URI path and MUST conform to the 
+<code>path-abempty</code> ABNF rule in [[!RFC3986]]. A <a>DID path</a> SHOULD be
+used to address resources available through a <a>service endpoint</a>. For more
+information, see Section <a href="#service-endpoints"></a>.
       </p>
 
       <p>
-A specific <a>DID scheme</a> MAY specify ABNF rules for <a>DID paths</a> that are
-more restrictive than the generic rules in this section.
+A specific <a>DID scheme</a> MAY specify ABNF rules for <a>DID paths</a> that
+are more restrictive than the generic rules in this section.
       </p>
+
       <pre class="example nohighlight">
 did:example:123456/path
       </pre>
@@ -955,16 +964,17 @@ Query
       </h2>
 
       <p>
-A generic <a>DID query</a> is identical to a URI query and MUST
-conform to the <code>query</code> ABNF rule in [[!RFC3986]]. A
-<a>DID query</a> SHOULD be used to address resources available via a
-<a>service endpoint</a>. See Section <a href="#service-endpoints"></a>.
+A generic <a>DID query</a> is identical to a URI query and MUST conform to the
+<code>query</code> ABNF rule in [[!RFC3986]]. A <a>DID query</a> SHOULD be used
+to address resources available through a <a>service endpoint</a>. For more
+information, see Section <a href="#service-endpoints"></a>.
       </p>
 
       <p>
-A specific <a>DID scheme</a> MAY specify ABNF rules for <a>DID queries</a> that are
-more restrictive than the generic rules in this section.
+A specific <a>DID scheme</a> MAY specify ABNF rules for <a>DID queries</a> that
+are more restrictive than the generic rules in this section.
       </p>
+
       <pre class="example nohighlight">
 did:example:123456?query=true
       </pre>
@@ -976,31 +986,34 @@ Fragment
       </h2>
 
       <p>
-A generic <a>DID fragment</a> is identical to a URI
-fragment and MUST conform to the <code>fragment</code> ABNF rule in
-[[RFC3986]]. Implementers are strongly discouraged from using a <a>DID fragment</a>
-for anything other than a method-independent
-reference into the <a>DID document</a> to identify a component of a <a>DID
-document</a> (e.g., a unique <a>public key description</a> or <a>service endpoint</a>). To resolve
-this reference, the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be used as
-input to the <a>DID URL</a> dereferencing algorithm (see [[DID-RESOLUTION]]) for the
-target component in the <a>DID document</a> object.
+A generic <a>DID fragment</a> is identical to a URI fragment and MUST conform to
+the <code>fragment</code> ABNF rule in [[RFC3986]]. Implementers are strongly
+discouraged from using a <a>DID fragment</a> for anything other than a
+method-independent reference into the <a>DID document</a> to identify a
+component of a <a>DID document</a> (for example, a unique
+<a>public key description</a> or <a>service endpoint</a>). To resolve this
+reference, the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be
+used as input to the <a>DID URL</a> dereferencing algorithm for the
+target component in the <a>DID document</a> object. For more information, see
+[[DID-RESOLUTION]].
       </p>
 
       <p>
-A specific <a>DID scheme</a> MAY specify ABNF rules for <a>DID fragments</a> that
-are more restrictive than the generic rules in this section.
+A specific <a>DID scheme</a> MAY specify ABNF rules for <a>DID fragments</a>
+that are more restrictive than the generic rules in this section.
       </p>
 
       <p>
 Implementations need not rely on graph-based processing of <a>DID documents</a>
-to locate metadata contained in the <a>DID document</a> when the <a>DID</a> includes
-a <a>DID fragment</a>. Tree-based processing can be used instead.
+to locate metadata contained in the <a>DID document</a> when the <a>DID</a>
+includes a <a>DID fragment</a>. Tree-based processing can be used instead.
       </p>
 
       <p>
-Implementations SHOULD NOT prevent the use of <a>JSON Pointer</a> ([[!RFC6901]]).
+Implementations SHOULD NOT prevent the use of <a>JSON Pointer</a>
+([[!RFC6901]]).
       </p>
+
       <pre class="example nohighlight">
 did:example:123456#oidc
       </pre>
@@ -1012,25 +1025,25 @@ Normalization
       </h2>
 
       <p>
-For the broadest interoperability, <a>DID</a> normalization should be as
-simple and universal as possible. Therefore:
+For the broadest interoperability, make <a>DID</a> normalization as simple and
+universal as possible:
       </p>
+        <ul>
+          <li>
+The <a>DID scheme</a> name MUST be lowercase.
+          </li>
 
-      <ol start="1">
-        <li>
-The did: scheme name MUST be lowercase.
-        </li>
+          <li>
+The <a>DID method</a> name MUST be lowercase.
+          </li>
 
-        <li>
-The method name MUST be lowercase.
-        </li>
-
-        <li>
+          <li>
 Case sensitivity and normalization of the value of the
-<code>method-specific-id</code> rule in Section <a href="#generic-did-syntax">
-          </a> MUST be defined by the governing <a>DID method</a> specification.
-        </li>
-      </ol>
+<code>method-specific-id</code> rule in Section
+<a href="#generic-did-syntax"></a> MUST be defined by the governing
+<a>DID method</a> specification.
+          </li>
+        </ul>
     </section>
 
     <section>
@@ -1039,38 +1052,36 @@ Persistence
       </h2>
 
       <p>
-A <a>DID</a> is expected to be persistent and immutable, i.e., bound exclusively
-and permanently to its one and only subject. Even after a <a>DID</a> has been
-deactivated, it is intended that it never be repurposed.
+A <a>DID</a> is expected to be persistent and immutable. That is, a <a>DID</a>
+is bound exclusively and permanently to its one and only subject. Even after a
+<a>DID</a> is deactivated, it is intended that it never be repurposed.
       </p>
 
       <p>
-Ideally a <a>DID</a> would be a completely
-abstract decentralized identifier (like a <a>UUID</a>) that could be bound
-to multiple underlying <a>DID registries</a> over time,
-thus maintaining its persistence independent of any particular system.
-However registering the same identifier on multiple
+Ideally, a <a>DID</a> would be a completely abstract decentralized identifier
+(like a <a>UUID</a>) that could be bound to multiple underlying
+<a>DID registries</a> over time, thus maintaining its persistence independent of
+any particular system. However, registering the same identifier on multiple
 <a>DID registries</a> introduces extremely hard entityship and
 <a href="https://en.wikipedia.org/wiki/List_of_DNS_record_types%23SOA">start-of-authority</a>
-(SOA) problems. It also greatly increases implementation complexity
-for developers.
+(SOA) problems. It also greatly increases implementation complexity for
+developers.
       </p>
 
       <p>
-To avoid these issues, it is RECOMMENDED that <a>DID method</a>
-specifications only produce <a>DIDs</a> and <a>DID methods</a> bound to strong,
-stable <a>DID registries</a> capable of making the highest level of
-commitment to persistence of the <a>DID</a> and <a>DID method</a> over time.
+To avoid these issues, it is RECOMMENDED that <a>DID method</a> specifications
+only produce <a>DIDs</a> and <a>DID methods</a> bound to strong, stable
+<a>DID registries</a> capable of making the highest level of commitment to
+persistence of the <a>DID</a> and <a>DID method</a> over time.
       </p>
 
       <p class="note">
-Although not included in this version, future versions of this
-specification may support a <a>DID document</a> <code>equivID</code> property
-to establish verifiable equivalence relations between <a>DIDs</a>
-representing the same subject on multiple <a>DID
-registries</a>. Such equivalence relations can produce the practical
-equivalent of a single persistent abstract <a>DID</a>. See Future Work
-(Section <a href="#future-work"></a>).
+Although not included in this version, future versions of this specification
+might support a <a>DID document</a> <code>equivID</code> property to establish
+verifiable equivalence relations between <a>DIDs</a> representing the same
+subject on multiple <a>DID registries</a>. Such equivalence relations can
+produce the practical equivalent of a single persistent abstract <a>DID</a>. For
+more information, see Section <a href="#future-work"></a>.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -2887,7 +2887,6 @@ The list of issues below are under active discussion and are likely to
 result in changes to this specification.
     </p>
 
-    <div class="issue" data-number="86">Editorial updates</div>
     <div class="issue" data-number="85">Syntactially differentiate data about the DID versus application data</div>
     <div class="issue" data-number="84">Add `initial-values` matrix parameter to Generic DID Parameters</div>
     <div class="issue" data-number="80">Define conformance classes such as "DID document processor"</div>
@@ -2916,7 +2915,6 @@ result in changes to this specification.
     <div class="issue" data-number="48">Some comments by Steven Rowat</div>
     <div class="issue" data-number="46">It would be useful to have `services` as a mapping instead of an `array`</div>
     <div class="issue" data-number="45">Is method-specific-id supposed to be equivalent to param-char?</div>
-    <div class="issue" data-number="44">DID Test Suite and untestable normative statements</div>
   </section>
 
   <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -2231,7 +2231,7 @@ If the protocol incorporates cryptographic protection mechanisms,
 it should be clearly indicated which portions
 of the data are protected and what the protections are (i.e.,
 integrity only, confidentiality, and/or endpoint authentication,
-etc.). Some indication should also be given of to what sorts of attacks
+etc.). Some indication should also be given of the sorts of attacks to which
 the cryptographic protection is susceptible. Data which should be
 held secret (keying material, random seeds, etc.) should be clearly
 labeled. If the technology involves authentication, particularly

--- a/index.html
+++ b/index.html
@@ -2345,7 +2345,7 @@ designed to operate under the general Internet threat model used by
 many IETF standards. We assume uncompromised endpoints, but allow
 messages to be read or corrupted on the network. Protecting against an
 attack when a system is compromised requires external key-signing
-hardware. See also Section <a href="#key-revocation-and-recovery"></a>
+hardware. See also <a href="#key-revocation-and-recovery"></a>.
 regarding key revocation and recovery. For their part, the <a>DLTs</a> hosting
 <a>DIDs</a> and <a>DID documents</a> have special security properties for preventing
 active attacks. Their design uses public/private key cryptography to

--- a/index.html
+++ b/index.html
@@ -2200,6 +2200,111 @@ inclusion are documented in the [[DID-METHOD-REGISTRY]].
       </p>
     </section>
 
+    <section class='normative'>
+      <h2>
+Security Requirements
+      </h2>
+
+      <p class="issue">
+Discussions at Rebooting the Web of Trust 5 resulted in consensus to
+move Authorization to <a>DID method</a> specifications. It is currently
+expected that there will be an attempt to create a generalized
+authorization mechanism that is build on object capabilities.
+      </p>
+
+      <p>
+<a>DID method</a> specifications MUST include their own Security
+Considerations sections.
+      </p>
+
+      <p>
+This section MUST consider all the requirements mentioned in
+section 5 of [[RFC3552]] (page 27) for the <a>DID</a> operations defined in
+the specification. At least the following forms of attack MUST be considered:
+eavesdropping, replay, message insertion, deletion, modification, and
+man-in-the-middle. Potential denial of service attacks MUST be
+identified as well. 
+      </p>
+
+      <p>
+If the protocol incorporates cryptographic protection mechanisms,
+it should be clearly indicated which portions
+of the data are protected and what the protections are (i.e.,
+integrity only, confidentiality, and/or endpoint authentication,
+etc.). Some indication should also be given of to what sorts of attacks
+the cryptographic protection is susceptible. Data which should be
+held secret (keying material, random seeds, etc.) should be clearly
+labeled. If the technology involves authentication, particularly
+user-host authentication, the security of the authentication method
+MUST be clearly specified.
+      </p>
+
+      <p>
+This section MUST also discuss, per Section 5 of [[RFC3552]],
+residual risks (such as the risks from compromise in a related
+protocol, incorrect implementation, or cipher) after threat
+mitigation has been deployed.
+      </p>
+
+      <p>
+This section MUST provide integrity protection and update
+authentication for all operations required by
+Section <a href="#did-operations"></a>.
+      </p>
+
+      <p>
+Where <a>DID methods</a> make use of peer-to-peer computing resources
+(such as with all known <a>DLTs</a>), the expected burdens of those
+resources SHOULD be discussed in relation to denial of service.
+      </p>
+
+      <p>
+Method-specific endpoint authentication MUST be discussed. Where
+<a>DID methods</a> make use of <a>DLTs</a> with varying network topology, sometimes
+offered as "light node" or "<a href="https://en.bitcoin.it/wiki/Thin_Client_Security">thin client</a>"
+implementations to reduce required computing resources, the security
+assumptions of the topology available to implementations of the <a>DID
+method</a> MUST be discussed.
+      </p>
+
+      <p>
+<a>DID methods</a> MUST discuss the policy mechanism by which <a>DIDs</a> are
+proven to be uniquely assigned. A <a>DID</a> fits the functional definition
+of a URN as defined in [[RFC8141]] &mdash; a persistent identifier that is
+assigned once to a resource and never reassigned. In a security
+context this is particularly important since a <a>DID</a> may be used to
+identify a specific party subject to a specific set of authorization
+rights.
+      </p>
+
+      <p>
+<a>DID methods</a> that introduce new authentication <a>service endpoint</a>
+types (see <a href="#service-endpoints"></a>) SHOULD consider the
+security requirements of the supported authentication protocol.
+      </p>
+
+    </section>
+
+    <section class='normative'>
+      <h2>
+Privacy Requirements
+      </h2>
+      <p>
+<a>DID method</a> specifications MUST include their own Privacy
+Considerations sections, if only to point to
+<a href="#privacy-considerations"></a>.
+      </p>
+
+      <p>
+The <a>DID method</a> specification's Privacy Considerations section
+MUST discuss any subsection of
+section 5 of [[RFC6973]] that could apply in a method-specific
+manner. The subsections to consider are: surveillance, stored data
+compromise, unsolicited traffic, misattribution, correlation,
+identification, secondary use, disclosure, exclusion.    
+      </p>
+    </section>
+
   </section>
 
   <section class='normative'>
@@ -2248,94 +2353,6 @@ allow operation on passively monitored networks without risking
 compromise of private keys. This is what makes <a>DID</a> architecture and
 decentralized identity possible.
     </p>
-
-    <section>
-      <h2>
-Requirements of DID Method Specifications
-      </h2>
-
-      <ol start="1">
-        <li>
-<a>DID method</a> specifications MUST include their own Security
-Considerations sections.
-        </li>
-
-        <li>
-This section MUST consider all the requirements mentioned in
-section 5 of [[RFC3552]] (page 27) for the <a>DID</a> operations defined in
-the specification. In particular:
-        </li>
-      </ol>
-
-      <p class="issue">
-Discussions at Rebooting the Web of Trust 5 resulted in consensus to
-move Authorization to <a>DID method</a> specifications. It is currently
-expected that there will be an attempt to create a generalized
-authorization mechanism that is build on object capabilities.
-      </p>
-
-      <p>
-At least the following forms of attack MUST be considered:
-eavesdropping, replay, message insertion, deletion, modification, and
-man-in-the-middle. Potential denial of service attacks MUST be
-identified as well. If the protocol incorporates cryptographic
-protection mechanisms, it should be clearly indicated which portions
-of the data are protected and what the protections are (i.e.,
-integrity only, confidentiality, and/or endpoint authentication,
-etc.). Some indication should also be given to what sorts of attacks
-the cryptographic protection is susceptible. Data which should be
-held secret (keying material, random seeds, etc.) should be clearly
-labeled. If the technology involves authentication, particularly
-user-host authentication, the security of the authentication method
-MUST be clearly specified.
-      </p>
-
-      <ol start="3">
-        <li>
-This section MUST also discuss, per Section 5 of [[RFC3552]],
-residual risks (such as the risks from compromise in a related
-protocol, incorrect implementation, or cipher) after threat
-mitigation has been deployed.
-        </li>
-
-        <li>
-This section MUST provide integrity protection and update
-authentication for all operations required by
-Section <a href="#did-operations"></a>.
-        </li>
-
-        <li>
-Where <a>DID methods</a> make use of peer-to-peer computing resources
-(such as with all known <a>DLTs</a>), the expected burdens of those
-resources SHOULD be discussed in relation to denial of service.
-        </li>
-
-        <li>
-Method-specific endpoint authentication MUST be discussed. Where
-<a>DID methods</a> make use of <a>DLTs</a> with varying network topology, sometimes
-offered as "light node" or "<a href="https://en.bitcoin.it/wiki/Thin_Client_Security">thin client</a>"
-implementations to reduce required computing resources, the security
-assumptions of the topology available to implementations of the <a>DID
-method</a> MUST be discussed.
-        </li>
-
-        <li>
-<a>DID methods</a> MUST discuss the policy mechanism by which <a>DIDs</a> are
-proven to be uniquely assigned. A <a>DID</a> fits the functional definition
-of a URN as defined in [[RFC8141]] &mdash; a persistent identifier that is
-assigned once to a resource and never reassigned. In a security
-context this is particularly important since a <a>DID</a> may be used to
-identify a specific party subject to a specific set of authorization
-rights.
-        </li>
-
-        <li>
-<a>DID methods</a> that introduce new authentication <a>service endpoint</a>
-types (Section <a href="#service-endpoints"></a>) SHOULD consider the
-security requirements of the supported authentication protocol.
-        </li>
-      </ol>
-    </section>
 
     <section>
       <h2>
@@ -2678,29 +2695,6 @@ embodies principle #7, "Respect for user privacy &mdash; keep it user-centric."
 This section lists additional privacy considerations that implementers,
 delegates, and <a>DID subjects</a> should bear in mind.
     </p>
-
-    <section>
-      <h2>
-Requirements of DID Method Specifications
-      </h2>
-
-      <ol start="1">
-        <li>
-<a>DID method</a> specifications MUST include their own Privacy
-Considerations sections, if only to point to the general privacy
-considerations in this section.
-        </li>
-
-        <li>
-The <a>DID method</a> specification's Privacy Considerations section
-MUST discuss any subsection of
-section 5 of [[RFC6973]] that could apply in a method-specific
-manner. The subsections to consider are: surveillance, stored data
-compromise, unsolicited traffic, misattribution, correlation,
-identification, secondary use, disclosure, exclusion.
-        </li>
-      </ol>
-    </section>
 
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -2346,7 +2346,7 @@ many IETF standards. We assume uncompromised endpoints, but allow
 messages to be read or corrupted on the network. Protecting against an
 attack when a system is compromised requires external key-signing
 hardware. See also <a href="#key-revocation-and-recovery"></a>.
-regarding key revocation and recovery. For their part, the <a>DLTs</a> hosting
+For their part, the <a>DLTs</a> hosting
 <a>DIDs</a> and <a>DID documents</a> have special security properties for preventing
 active attacks. Their design uses public/private key cryptography to
 allow operation on passively monitored networks without risking

--- a/terms.html
+++ b/terms.html
@@ -1,254 +1,225 @@
 <p>
 This document attempts to communicate the concepts outlined in the
-<a>decentralized identifier</a> space by using specialized terms to discuss specific
-concepts. This terminology is included below and linked to throughout the
-document to aid the reader:
+<a>decentralized identifier</a> space by using specialized terms to discuss
+specific concepts. This terminology is included below and linked to throughout
+the document to aid the reader:
 </p>
 
 <dl class="termlist">
 
-  <dt><dfn data-lt="blockchain|blockchain technology">blockchain</dfn></dt>
+  <dt><dfn data-lt="blockchains|blockchain technology">blockchain</dfn></dt>
 
   <dd>
-A specific type of <a>distributed ledger technology</a> (DLT) that
-stores ledger entries in blocks of transactions that are grouped
-together and hashed into a cryptographic chain. Because this type of <a>DLT</a>
-was introduced by
-<a href="https://en.wikipedia.org/wiki/Bitcoin">Bitcoin</a>,
-the term "blockchain" is sometimes used to refer specifically to the Bitcoin
+A specific type of <a>distributed ledger technology</a> (DLT) that stores ledger
+entries in blocks of transactions, which are grouped together and hashed into a
+cryptographic chain. Because this type of <a>DLT</a> was introduced by
+<a href="https://en.wikipedia.org/wiki/Bitcoin">Bitcoin</a>, the term
+<em>blockchain</em> is sometimes used to refer specifically to the Bitcoin
 ledger.
   </dd>
 
-
-  <dt><dfn data-lt="DID|DIDs">decentralized identifier</dfn> (DID)</dt>
+  <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn> (DID)</dt>
 
   <dd>
-A globally unique identifier that does
-not require a centralized registration authority because it is
-registered with <a>distributed ledger technology</a> (DLT) or other form of
-decentralized network. The generic format of a DID is defined in this
-specification. A specific <a>DID scheme</a> is defined in a
+A globally unique identifier that does not require a centralized registration
+authority because it is registered with <a>distributed ledger technology</a>
+(DLT) or other form of decentralized network. The generic format of a DID is
+defined in this specification. A specific <a>DID scheme</a> is defined in a
 <a>DID method</a> specification.
   </dd>
 
-
-  <dt><dfn data-lt="">decentralized identity management</dfn></dt>
+  <dt><dfn>decentralized identity management</dfn></dt>
 
   <dd>
 <a href="https://en.wikipedia.org/wiki/Identity_management">Identity
-management</a> based on <a>decentralized identifiers</a>.
-Decentralized identity management extends the identifier creation authority
-beyond the traditional roots of trust
-required by <a href="https://en.wikipedia.org/wiki/X.500">X.500
-directory services</a>, the <a href=
-  "https://en.wikipedia.org/wiki/Domain_Name_System">Domain Name
-System</a>, and most national ID systems.
+management</a> based on <a>decentralized identifiers</a>. Decentralized identity
+management extends the identifier creation authority beyond the traditional
+roots of trust required by
+<a href="https://en.wikipedia.org/wiki/X.500">X.500 directory services</a>,
+the <a href="https://en.wikipedia.org/wiki/Domain_Name_System">Domain Name System</a>,
+and most national identification systems.
   </dd>
 
-
-  <dt><dfn data-lt="">decentralized public key infrastructure</dfn> (DPKI)</dt>
+  <dt><dfn>decentralized public key infrastructure</dfn> (DPKI)</dt>
 
   <dd>
-Public key infrastructure based on <a>decentralized identifiers</a>
-and identity records (e.g., <a>DID documents</a>) containing verifiable
+Public key infrastructure based on <a>decentralized identifiers</a> and identity
+records (for example, <a>DID documents</a>) containing verifiable
 <a>public key descriptions</a>.
   </dd>
 
-
-  <dt><dfn data-lt="">delegate</dfn></dt>
+  <dt><dfn data-lt="delegates">delegate</dfn></dt>
 
   <dd>
-An entity who creates a <a>DID</a> and associated <a>DID document</a>
-for a <a>dependent</a> who does not yet have the capacity to control
-the private keys. The dependent is expected to rely on the delegate to safeguard
-the private keys until the dependent can assume control as the <a>DID
-subject</a>.
+An entity who creates a <a>DID</a> and associated <a>DID document</a> for a
+<a>dependent</a> who does not yet have the capacity to control the private keys.
+The <a>dependent</a> is expected to rely on the delegate to safeguard the
+private keys until the <a>dependent</a> can assume control as the
+<a>DID subject</a>.
   </dd>
 
-
-  <dt><dfn data-lt="">dependent</dfn></dt>
+  <dt><dfn data-lt="dependents">dependent</dfn></dt>
 
   <dd>
-A person, organization, or thing whose <a>DID</a> is
-registered and maintained by a delegate because the dependent is not in
-a position to control the private keys. A dependent becomes an
-<a>identity owner</a> when the dependent takes control of the private keys.
+A person, organization, or thing whose <a>DID</a> is registered and maintained
+by a <a>delegate</a> because the dependent is not in a position to control the
+private keys. A dependent becomes an <a>identity owner</a> when the dependent
+takes control of the private keys.
   </dd>
 
-
-  <dt><dfn data-lt="did controller(s)">DID controller</dfn></dt>
+  <dt><dfn data-lt="did controllers|did controller(s)">DID controller</dfn></dt>
 
   <dd>
-The entity, or a group of entities, in control of a DID and/or <a>DID document</a>.
-Note that the <a>DID controller</a> might include the <a>DID subject</a>.
+The entity, or a group of entities, in control of a <a>DID</a> or
+<a>DID document</a>. Note that the <a>DID controller</a> might include the
+<a>DID subject</a>.
   </dd>
 
-
-  <dt><dfn data-lt="">DID document</dfn></dt>
+  <dt><dfn data-lt="DID documents">DID document</dfn></dt>
 
   <dd>
-A set of data that describes the <a>DID subject</a>,
-including mechanisms, such as public keys and
-pseudonymous biometrics, that the <a>DID subject</a> can use to authenticate itself
-and prove their association with the DID. A DID document MAY also contain other
+A set of data describing the <a>DID subject</a>, including mechanisms, such as
+public keys and pseudonymous biometrics, that the <a>DID subject</a> can use to
+authenticate itself and prove their association with the <a>DID</a>. A DID
+document might also contain other
 <a href="https://en.wikipedia.org/wiki/Attribute_(computing)">attributes</a> or
 <a href="https://en.wikipedia.org/wiki/Claims-based_identity">claims</a>
 describing the subject. These documents are graph-based data structures that
-are typically expressed using [[JSON-LD]], but may be expressed using other
+are typically expressed using [[JSON-LD]], but can be expressed using other
 compatible graph-based data formats.
   </dd>
 
-
-  <dt><dfn data-lt="">DID fragment</dfn></dt>
-
-  <dd>
-The portion of a <a>DID URL</a> that follows the first hash
-sign character (<code>#</code>). DID fragment syntax is identical to URI
-fragment syntax.
-  </dd>
-
-
-  <dt><dfn data-lt="">DID method</dfn></dt>
+  <dt><dfn data-lt="DID fragments">DID fragment</dfn></dt>
 
   <dd>
-A definition of how a specific <a>DID scheme</a> can be implemented
-on a specific <a>distributed ledger</a> or network, including the precise
-method(s) by which <a>DIDs</a> are resolved and deactivated and <a>DID
-documents</a> are written and updated.
+The portion of a <a>DID URL</a> that follows the first hash sign character
+(<code>#</code>). DID fragment syntax is identical to the URI fragment syntax.
   </dd>
 
+  <dt><dfn data-lt="DID methods">DID method</dfn></dt>
 
-  <dt><dfn data-lt="">DID path</dfn></dt>
+  <dd>
+A definition of how a specific <a>DID scheme</a> can be implemented on a
+specific <a>distributed ledger</a> or network, including the precise methods by
+which <a>DIDs</a> are resolved and deactivated and <a>DID documents</a> are
+written and updated.
+  </dd>
+
+  <dt><dfn data-lt="DID paths">DID path</dfn></dt>
 
   <dd>
 The portion of a <a>DID URL</a> that begins with and includes the first forward
-slash character (<code>/</code>). DID path syntax is identical to URI path syntax.
+slash character (<code>/</code>). DID path syntax is identical to the URI path
+syntax.
   </dd>
 
+  <dt><dfn data-lt="DID queries">DID query</dfn></dt>
 
-  <dt><dfn data-lt="decentralized identifier registry|decentralized identifier registries">DID registry</dfn></dt>
+  <dd>
+The portion of a <a>DID URL</a> that follows the first question mark character
+(<code>?</code>). DID query syntax is identical to the URI query syntax.
+  </dd>
+
+  <dt><dfn data-lt="decentralized identifier registry|decentralized identifier registries|DID registries">DID registry</dfn></dt>
 
   <dd>
 A role a system performs to mediate the creation, verification, updating, and
-deactivation of <a>decentralized identifiers</a>.
-A DID registry is a type of verifiable data registry (see [[VC-DATA-MODEL]]).
+deactivation of <a>decentralized identifiers</a>. A DID registry is a type of
+verifiable data registry. For more information, see [[VC-DATA-MODEL]].
   </dd>
 
-
-  <dt><dfn data-lt="">DID query</dfn></dt>
-
-  <dd>
-The portion of a <a>DID URL</a> that follows the first question
-mark character (<code>?</code>). DID query syntax is identical to URI query syntax.
-  </dd>
-
-  <dt><dfn data-lt="">DID resolver</dfn></dt>
+  <dt><dfn data-lt="DID resolvers">DID resolver</dfn></dt>
 
   <dd>
-A system that is capable of retrieving a <a>DID document</a> for a given <a>DID</a>.
-These systems are specified in the DID Resolution specification
+A system that is capable of retrieving a <a>DID document</a> for a given
+<a>DID</a>. These systems are specified in the DID Resolution specification
 [[DID-RESOLUTION]].
   </dd>
   </dt>
 
-  <dt><dfn data-lt="">DID subject</dfn></dt>
+  <dt><dfn data-lt="DID schemes">DID scheme</dfn></dt>
 
   <dd>
-The DID subject is the entity that the <a>DID document</a> is about, i.e.,
-it is the entity identified by the <a>DID</a> and described by the <a>DID
-document</a>.
-  </dd>
-
-  <dt><dfn data-lt="">DID URL</dfn></dt>
-
-  <dd>
-A DID plus an optional <a>DID path</a>, optional <code>?</code> character followed by a
-<a>DID query</a>, and optional <code>#</code> character followed by a <a>DID fragment</a>.
-  </dd>
-
-
-  <dt><dfn data-lt="">DID scheme</dfn></dt>
-
-  <dd>
-The formal syntax of a <a>decentralized identifier</a>. The generic DID
-scheme is defined in this specification. Separate <a>DID method</a> specifications
+The formal syntax of a <a>decentralized identifier</a>. The generic DID scheme
+is defined in this specification. Separate <a>DID method</a> specifications
 define a specific DID scheme that works with that specific <a>DID method</a>.
   </dd>
 
+  <dt><dfn data-lt="DID subjects">DID subject</dfn></dt>
+
+  <dd>
+The entity the <a>DID document</a> is about. That is, the entity identified by
+the <a>DID</a> and described by the <a>DID document</a>.
+  </dd>
+
+  <dt><dfn data-lt="DID URLs">DID URL</dfn></dt>
+
+  <dd>
+A <a>DID</a> plus an optional <a>DID path</a>, optional <code>?</code> character
+followed by a <a>DID query</a>, and optional <code>#</code> character followed
+by a <a>DID fragment</a>.
+  </dd>
 
   <dt><dfn data-lt="distributed ledger technology|DLT">distributed ledger</dfn> (DLT)</dt>
 
   <dd>
-A <a href=
-  "https://en.wikipedia.org/wiki/Distributed_database">distributed
-database</a> in which the various nodes use a <a href=
-  "https://en.wikipedia.org/wiki/Consensus_(computer_science)">consensus
-protocol</a> to maintain a shared ledger in which each transaction is
-cryptographically signed and chained to the previous transaction.
+A <a href="https://en.wikipedia.org/wiki/Distributed_database">distributed database</a>
+in which the various nodes use a
+<a href="https://en.wikipedia.org/wiki/Consensus_(computer_science)">consensus protocol</a>
+to maintain a shared ledger in which each transaction is cryptographically
+signed and chained to the previous transaction.
   </dd>
-
-
-  <dt><dfn data-lt="">identity owner</dfn></dt>
-
-  <dd>
-The natural person, party, organization, or thing whose
-identity is represented by a <a>DID</a> and who directly controls the
-private keys to control the <a>DID document</a>.
-(Note: this specification avoids the term "user" since a <a>DID subject</a>
-is not always an individual person.)
-  </dd>
-
-
-  <dt><dfn data-lt="">JSON Pointer</dfn></dt>
-
-  <dd>
-JSON Pointer defines a string syntax for identifying a specific value
-within a JavaScript Object Notation (JSON) document as defined in [[RFC6901]]
-  </dd>
-
-
-  <dt><dfn data-lt="">public key description</dfn></dt>
-
-  <dd>
-A JSON object contained inside a <a>DID document</a> that contains all
-the metadata necessary to use a public key or verification key.
-  </dd>
-
-
-  <dt><dfn data-lt="">service endpoint</dfn></dt>
-
-  <dd>
-A network address at which a service operates on
-behalf of a <a>DID subject</a>. Examples of specific services include
-discovery services, social networks, file storage services, and
-verifiable claim repository services. Service endpoints may also be provided
-by a generalized data interchange protocol such as
-<a>extensible data interchange</a>.
-  </dd>
-
-
-  <dt><dfn data-lt="URI">Uniform Resource Identifier</dfn> (URI)</dt>
-
-  <dd>
-An identifier as defined by [[RFC3986]].
-  </dd>
-
-
-  <dt><dfn data-lt="UUID">Universally Unique Identifier</dfn> (UUID)</dt>
-
-  <dd>
-An identifier as defined by [[RFC4122]].
-  </dd>
-
 
   <dt><dfn data-lt="XDI">extensible data interchange</dfn> (XDI)</dt>
 
   <dd>
-A semantic
-graph format and semantic data interchange protocol defined by the
-  <a href="https://www.oasis-open.org/committees/xdi/">OASIS XDI Technical
-Committee</a>.
+A semantic graph format and semantic data interchange protocol defined by the
+<a href="https://www.oasis-open.org/committees/xdi/">OASIS XDI Technical Committee</a>.
   </dd>
 
+  <dt><dfn data-lt="identity owners">identity owner</dfn></dt>
+
+  <dd>
+The natural person, party, organization, or thing whose identity is represented
+by a <a>DID</a> and who directly controls the private keys to control the
+<a>DID document</a>. Note that this specification avoids the term <em>user</em>
+since a <a>DID subject</a> is not always an individual person.
+  </dd>
+
+  <dt><dfn>JSON Pointer</dfn></dt>
+
+  <dd>
+Defines a string syntax for identifying a specific value within a JavaScript
+Object Notation (JSON) document, as defined in [[RFC6901]].
+  </dd>
+
+  <dt><dfn>public key description</dfn></dt>
+
+  <dd>
+A JSON object contained inside a <a>DID document</a> that contains all the
+metadata necessary to use a public key or verification key.
+  </dd>
+
+  <dt><dfn data-lt="service endpoints">service endpoint</dfn></dt>
+
+  <dd>
+A network address at which a service operates on behalf of a <a>DID subject</a>.
+Examples of specific services include discovery services, social networks, file
+storage services, and verifiable claim repository services. Service endpoints
+might also be provided by a generalized data interchange protocol, such as
+<a>extensible data interchange</a>.
+  </dd>
+
+  <dt><dfn data-lt="URI|URIs">Uniform Resource Identifier</dfn> (URI)</dt>
+
+  <dd>
+An identifier, as defined by [[RFC3986]].
+  </dd>
+
+  <dt><dfn data-lt="UUID|UUIDs">Universally Unique Identifier</dfn> (UUID)</dt>
+
+  <dd>
+An identifier, as defined by [[RFC4122]].
+  </dd>
 
 </dl>


### PR DESCRIPTION
Normative language about security and privacy requirements for DID methods is now in Security Requirements and Privacy Requirements subsections of the DID methods section, rather than in the (non-normative) Security Considerations section. 

Fixes #107


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/112.html" title="Last updated on Nov 27, 2019, 9:12 AM UTC (9917b12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/112/a8d0c28...9917b12.html" title="Last updated on Nov 27, 2019, 9:12 AM UTC (9917b12)">Diff</a>