### PR TITLE
Rewrite authentication section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1366,7 +1366,7 @@ The semantics of the <code>controller</code> property are the same when the
 subject of the relationship is the <a>DID document</a> as when the subject
 of the relationship is a key. Since a key can't control itself, and the
 key controller cannot be inferred from the <a>DID document</a>, it is
-necessary to expicitly express the controller of the key is a
+necessary to explicitly express the identity of the controller of the key
 (which may be the <a>DID controller</a> or <a>DID subject</a>). The
 difference is that the value of <code>controller</code> on a key is not
 necessarily a <a>DID controller</a>. <a>DID controller(s)</a> are

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
     // previousPublishDate:  "1977-03-15",
     // previousMaturity:  "WD",
 
+    pluralize: true,
+
     // extend the bibliography entries
     localBiblio: ccg.localBiblio,
     github: {

--- a/index.html
+++ b/index.html
@@ -1304,6 +1304,7 @@ Public Keys
       </h2>
 
       <p>
+A public key is a <a>verification method</a>.
 Public keys are used for digital signatures, encryption and other cryptographic
 operations, which in turn are the basis for purposes such as authentication
 (see Section <a href="#authentication"></a>) or establishing secure
@@ -1312,6 +1313,19 @@ communication with <a>service endpoints</a> (see Section
 authorization mechanisms of <a>DID</a> CRUD operations (see Section
 <a href="#did-operations"></a>), which can be defined by <a>DID method</a>
 specifications.
+      </p>
+
+      <p class="note" title="Verification methods">
+A public key is just one type of <a>verification method</a>. Ideally,
+public keys are expressed in a <a>DID document</a> according to what
+they are authorized for: <code>authentication</code>, <code>
+capabilityInvocation</code>, <code>capabilityDelegation</code>,
+<code>keyAgreement</code>, <code>assertionMethod</code>, and <em>not</em>
+just listed using the <code>publicKey</code> property. The latter
+implies the <a>DID controller</a> has authorized any key therein for any
+purpose. It's an ambient authority model which is dangerous. Instead, the
+<a>DID controller</a> should be explicit about what the keys can be used
+for using these relations; see <a href="#authentication"></a>.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1347,6 +1347,19 @@ The value of the <code>controller</code> property, which identifies the
 controller of the corresponding private key, MUST be a valid <a>DID</a>.
       </p>
 
+      <p class="note" title="This is not the DID Controller">
+The <code>controller</code> property denotes a <a>DID controller</a>
+only when it appears at the <em>top level</em> of the <a>DID document</a>.
+The <code> controller</code> property when it appears as part of a <a>public
+key description</a> denotes the controller of the <em>corresponding
+private key</em> only, which may or may not be described in another
+<a>DID document</a>. A default <code>controller</code> field cannot
+be inferred by using a key's position in a tree, and so is explicitly
+included for each key. Linked Data Proof libraries typically expect the
+<code>controller</code> field to always exist and may throw an exception
+if it is missing.
+      </p>
+
       <p>
 All public key properties MUST be from the Linked Data Cryptographic Suite
 Registry. For a registry of key types and formats, see Appendix
@@ -1544,17 +1557,6 @@ property of <em>result</em>, throw an error.
       </ol>
 
       <p class="note">
-While the <code>controller</code> field might seem redundant in some of the
-examples above, keys can be expressed in a <a>DID document</a> where the
-controller is described in another <a>DID document</a>. Linked Data Proof
-libraries typically expect the <code>controller</code> field to always
-exist and might throw an exception if it is missing. Furthermore, as described
-by the requirement that <a>DID documents</a> be interpretable as either a graph
-or a tree, a default <code>controller</code> field cannot be inferred by using a
-key's position in a tree.
-      </p>
-
-      <p class="note">
 Caching and expiration of the keys in a <a>DID document</a> is entirely the
 responsibility of <a>DID resolvers</a> and other clients. For more information,
 see Section <a href="#did-resolvers"></a>.
@@ -1639,6 +1641,22 @@ access to their keys, or key compromise, where the <a>DID controller</a>'s
 trusted third parties need to override malicious activity by an attacker. For
 more information, see Section <a href="#security-considerations"></a>.
       </p>
+
+      <p>
+A DID document MAY include a <code>controller</code> property to indicate
+that there are <a>DID controller(s)</a> other than the <a>DID subject</a>.
+If so:
+      </p>
+
+      <dl>
+          <dt><dfn>controller</dfn></dt>
+          <dd>
+The value of the <code>controller</code> property MUST be a valid <a>DID</a>
+or an array of valid <a>DIDs</a>. The corresponding <a>DID document</a>(s)
+SHOULD contain authorization relations that explicitly permit the use of
+certain verification methods for specific purposes.
+          </dd>
+      </dl>
 
       <p>
 Each <a>DID method</a> MUST define how authorization and delegation are

--- a/index.html
+++ b/index.html
@@ -1583,17 +1583,23 @@ Authentication
       </h2>
 
       <p>
-Authentication is the mechanism by which <a>DID controllers</a> can
-cryptographically prove that they are associated with a <a>DID</a>. For more
-information, see Section <a href="#binding-of-identity"></a>. 
+Authentication is a mechanism by which a <a>DID method</a> can establish
+the authority of the party attempting to authenticate. The
+<em>verifier</em> of an authentication attempt can check if the
+authenticating party is presenting a valid proof of authentication, that is,
+that they are who they say they are.
       </p>
 
-      <p class="note">
-Authentication is separate from authorization because <a>DID controllers</a>
-might wish to enable others to update their <a>DID document</a> (for example, to
-assist with key recovery, as discussed in Section
-<a href="#key-revocation-and-recovery"></a>) without enabling them to prove
-control (and thus be able to impersonate the <a>DID controller(s)</a>).
+      <p class="note" title="Uses of authentication">
+If authority is established, it is up to the <a>DID method</a> to decide
+what to do with that information. A particular <a>DID method</a> could
+decide that authenticating as a <a>DID controller</a> is sufficient to,
+for example, update or delete the <a>DID document</a>. Another <a>DID
+method</a> could require different keys, or a different verification method
+entirely, to be presented in order to update or delete the <a>DID document</a>
+than that used to authenticate. In other words, what is done <em>after</em>
+the authentication check is out of scope for the DID data model, but <a>DID
+methods</a> are expected to define this themselves.
       </p>
 
       <p>
@@ -1601,14 +1607,45 @@ A <a>DID document</a> MAY include an <code>authentication</code> property.
       </p>
 
       <dl>
-        <dt><dfn>authentication</dfn></dt>
-        <dd>
-If a <a>DID document</a> includes an <code>authentication</code> property, the
-value of the property SHOULD be an array of verification methods. Each
-verification method MAY be embedded or referenced. An example verification
-method is a public key (see Section <a href="#public-keys"></a>).
-        </dd>
+          <dt><dfn>authentication</dfn></dt>
+          <dd>
+The <code>authentication</code> property is a relationship between the
+<a>DID subject</a> and a set of verification methods (such as, but not
+limited to, public keys). It means that the <a>DID subject</a> has authorized
+some set of <a>verification methods</a> (per the value of the
+<code>authentication</code> property) for the purpose of authentication. The value
+of the <code>authentication</code> property SHOULD be an array of
+<a>verification methods</a>. Each <a>verification method</a> MAY be embedded
+or referenced. An example of a <a>verification method</a> is a public key
+(see Section <a href="#public-keys"></a>).
+          </dd>
       </dl>
+
+      <p>
+This statement is useful to any "authentication verifier" that needs to check
+to see if an entity that is attempting to authenticate is, in fact, presenting
+a valid proof of authentication. When a verifier receives some data (in some
+protocol-specific format) that contains a proof that was made for the purpose
+of "authentication", and that says that an entity is identified by the <a>DID</a>,
+then that verifier checks to ensure that the proof can be verified using a
+<a>verification method</a> (e.g., public key) listed under
+<code>authentication</code> in the <a>DID Document</a>.
+      </p>
+
+      <p>
+The <a>verification method</a> indicated by the <code>authentication</code>
+property of a <a>DID document</a> can only be used to authenticate the
+<a>DID subject</a>. To authenticate the <a>DID controller</a> (in cases
+where the <a>DID controller</a> is not <em>also</em> the <a>DID subject</a>)
+the entity associated with the value of <code>controller</code> (see
+Section <a href="#authorization-and-delegation"></a>) needs to
+authenticate itself with its <em>own</em> <a>DID document</a> and attached
+<code>authentication</code> <a>verification method</a> relationship.
+      </p>
+
+      <p>
+Example:
+      </p>
 
       <pre class="example nohighlight" title="Authentication field containing three verification methods">
 {
@@ -1647,13 +1684,12 @@ mechanism that the subject uses to authorize others to act
 on their behalf.
       </p>
 
-      <p class="note">
-Authorization is separate from authentication, as explained in
-Section <a href="#authentication"></a>. This is particularly important for key
-recovery, in the case of key loss, when the subject no longer has
-access to their keys, or key compromise, where the <a>DID controller</a>'s
-trusted third parties need to override malicious activity by an attacker. For
-more information, see Section <a href="#security-considerations"></a>.
+      <p class="note" title="Authorization vs authentication">
+Note that Authorization is separate from <a href="#authentication"></a>.
+This is particularly important for key recovery in the case of key loss,
+when the subject no longer has access to their keys, or key compromise,
+where the <a>DID controller</a>'s trusted third parties need to override
+malicious activity by an attacker. See Section <a href="#security-considerations"></a>.
       </p>
 
       <p>
@@ -2257,6 +2293,22 @@ expiration.
 Any <a>DID method</a> specification that does not support a specific operation,
 such as update or deactivate, MUST clearly state these limitations.
       </p>
+
+      <p>
+Determining the authority of a party to carry out the operations is method-specific.
+For example, a <a>DID method</a> MAY:
+      </p>
+      <ul>
+        <li>
+use the <a>verification methods</a> listed under <a>authentication</a> to decide whether an update/deactivate operation is allowed; or
+        </li>
+        <li>
+use other constructs in the <a>DID Document</a> to decide this; or
+        </li>
+        <li>
+not use the <a>DID Document</a> at all to decide this, but have rules that are are "built into" the method.
+        </li>
+      </ul>
 
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -1361,14 +1361,17 @@ The value of the <code>controller</code> property, which identifies the
 controller of the corresponding private key, MUST be a valid <a>DID</a>.
       </p>
 
-      <p class="note" title="This is not the DID Controller">
-The <code>controller</code> property denotes a <a>DID controller</a>
-only when it appears at the <em>top level</em> of the <a>DID document</a>.
-The <code>controller</code> property when it appears as part of a <a>public
-key description</a> denotes the controller of the <em>corresponding
-private key</em> only, which may or may not be <em>also</em> be the
-<a>DID controller</a> or <a>DID subject</a>, and may described in another
-<a>DID document</a>.
+      <p class="note" title="Key controller(s) and DID controller(s)">
+The semantics of the <code>controller</code> property are the same when the
+subject of the relationship is the <a>DID document</a> as when the subject
+of the relationship is a key. Since a key can't control itself, and the
+key controller cannot be inferred from the <a>DID document</a>, it is
+necessary to expicitly express the controller of the key is a
+(which may be the <a>DID controller</a> or <a>DID subject</a>). The
+difference is that the value of <code>controller</code> on a key is not
+necessarily a <a>DID controller</a>. <a>DID controller(s)</a> are
+expressed using the <code>controller</code> property on the top level of
+the <a>DID document</a>; see Section <a href="#authorization-and-delegation"></a>.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1364,14 +1364,11 @@ controller of the corresponding private key, MUST be a valid <a>DID</a>.
       <p class="note" title="This is not the DID Controller">
 The <code>controller</code> property denotes a <a>DID controller</a>
 only when it appears at the <em>top level</em> of the <a>DID document</a>.
-The <code> controller</code> property when it appears as part of a <a>public
+The <code>controller</code> property when it appears as part of a <a>public
 key description</a> denotes the controller of the <em>corresponding
-private key</em> only, which may or may not be described in another
-<a>DID document</a>. A default <code>controller</code> field cannot
-be inferred by using a key's position in a tree, and so is explicitly
-included for each key. Linked Data Proof libraries typically expect the
-<code>controller</code> field to always exist and may throw an exception
-if it is missing.
+private key</em> only, which may or may not be <em>also</em> be the
+<a>DID controller</a> or <a>DID subject</a>, and may described in another
+<a>DID document</a>.
       </p>
 
       <p>
@@ -1583,23 +1580,25 @@ Authentication
       </h2>
 
       <p>
-Authentication is a mechanism by which a <a>DID method</a> can establish
-the authority of the party attempting to authenticate. The
-<em>verifier</em> of an authentication attempt can check if the
-authenticating party is presenting a valid proof of authentication, that is,
-that they are who they say they are.
+Authentication is a mechanism by which an entity can prove it is the
+<a>DID subject</a>. The <em>verifier</em> of an authentication attempt
+can check if the authenticating party is presenting a valid proof of
+authentication, that is, that they are who they say they are. Note that
+a successful authentication on its own may or may not confer authority;
+that is up to the verifying application. 
       </p>
 
       <p class="note" title="Uses of authentication">
-If authority is established, it is up to the <a>DID method</a> to decide
-what to do with that information. A particular <a>DID method</a> could
-decide that authenticating as a <a>DID controller</a> is sufficient to,
-for example, update or delete the <a>DID document</a>. Another <a>DID
-method</a> could require different keys, or a different verification method
-entirely, to be presented in order to update or delete the <a>DID document</a>
-than that used to authenticate. In other words, what is done <em>after</em>
-the authentication check is out of scope for the DID data model, but <a>DID
-methods</a> are expected to define this themselves.
+If authentication is established, it is up to the <a>DID method</a> or other
+application to decide what to do with that information. A particular <a>DID
+method</a> could decide that authenticating as a <a>DID controller</a> is
+sufficient to, for example, update or delete the <a>DID document</a>. Another
+<a>DID method</a> could require different keys, or a different verification
+method entirely, to be presented in order to update or delete the <a>DID
+document</a> than that used to authenticate. In other words, what is done
+<em>after</em> the authentication check is out of scope for the DID data
+model, but <a>DID methods</a> and applications are expected to define this
+themselves.
       </p>
 
       <p>
@@ -2279,15 +2278,13 @@ DID Operations
 
       <p>
 To enable the full functionality of <a>DIDs</a> and <a>DID documents</a> on a
-particular <a>DID registry</a>, a <a>DID method</a> specification MUST specify
-how each of the following <abbr title="Create, Read, Update, Delete">CRUD</abbr>
-operations is performed by a client. Specify each operation to the level of
-detail necessary to build and test interoperable client implementations with the
+particular <a>DID registry</a>, a <a>DID method</a> specification MUST specify how
+each of the following <abbr title="Create, Read, Update, Delete">CRUD</abbr>
+operations is performed by a client. Each operation ought to be specified to the level
+of detail necessary to build and test interoperable client implementations with the
 <a>DID registry</a>. These operations can effectively be used to perform all the
-operations required of a CKMS (cryptographic key management system). For
-example, key registration, key replacement, key rotation, key recovery, and key
-expiration.
-      </p>
+operations required of a CKMS (cryptographic key management system), e.g.: key
+registration, key replacement, key rotation, key recovery, and key expiration.
 
       <p>
 Any <a>DID method</a> specification that does not support a specific operation,
@@ -2300,13 +2297,17 @@ For example, a <a>DID method</a> MAY:
       </p>
       <ul>
         <li>
-use the <a>verification methods</a> listed under <a>authentication</a> to decide whether an update/deactivate operation is allowed; or
+use the <a>verification methods</a> listed under <a>authentication</a> to
+decide whether an update/deactivate operation is allowed; or
         </li>
         <li>
-use other constructs in the <a>DID Document</a> to decide this; or
+use other constructs in the <a>DID Document</a> to decide this, for example,
+a verification method specified under capabilityInvocation could be used to
+verify the invocation of a capability to update the DID Document.; or
         </li>
         <li>
-not use the <a>DID Document</a> at all to decide this, but have rules that are are "built into" the method.
+not use the <a>DID Document</a> at all to decide this, but have rules that are
+are "built into" the method.
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -1199,7 +1199,7 @@ DID Subject
       </h2>
 
       <p>
-The <a>DID subject</a> is denoted with the <code>id</code> property. The 
+The <a>DID subject</a> is denoted with the <code>id</code> property. The
 <a>DID subject</a> is the entity that the <a>DID document</a> is about. That is,
 it is the entity identified by the <a>DID</a> and described by the
 <a>DID document</a>.
@@ -1316,16 +1316,18 @@ specifications.
       </p>
 
       <p class="note" title="Verification methods">
-A public key is just one type of <a>verification method</a>. Ideally,
-public keys are expressed in a <a>DID document</a> according to what
-they are authorized for: <code>authentication</code>, <code>
-capabilityInvocation</code>, <code>capabilityDelegation</code>,
-<code>keyAgreement</code>, <code>assertionMethod</code>, and <em>not</em>
-just listed using the <code>publicKey</code> property. The latter
-implies the <a>DID controller</a> has authorized any key therein for any
-purpose. It's an ambient authority model which is dangerous. Instead, the
-<a>DID controller</a> should be explicit about what the keys can be used
-for using these relations; see <a href="#authentication"></a>.
+A public key is just one type of <a>verification method</a>.  A <a>DID
+document</a> expresses the relationship between the <a>DID subject</a> and a
+<a>verification method</a> using a <dfn>verification relationship</dfn>.
+Examples of <a>verification relationship<a>s include:
+<code>authentication</code>, <code> capabilityInvocation</code>,
+<code>capabilityDelegation</code>, <code>keyAgreement</code>, and
+<code>assertionMethod</code>. A <a>DID controller</a> MUST be explicit about the
+<a>verification relationship</a> between the DID subject and the <a>verification
+method</a>. <a>Verification methods</a> that are not associated with a
+particular <a>verification relationship<a/> MUST NOT be used for that
+<a>verification relationship</a>. See Section <a href="#authentication"></a>
+for a more detailed example of a <a>verification relationship</a>.
       </p>
 
       <p>
@@ -1588,7 +1590,7 @@ Authentication is a mechanism by which an entity can prove it is the
 can check if the authenticating party is presenting a valid proof of
 authentication, that is, that they are who they say they are. Note that
 a successful authentication on its own may or may not confer authority;
-that is up to the verifying application. 
+that is up to the verifying application.
       </p>
 
       <p class="note" title="Uses of authentication">
@@ -1841,9 +1843,9 @@ standard specification.
   }]
 }
       </pre>
-	  
+
       <p>
-For more information about security considerations regarding authentication 
+For more information about security considerations regarding authentication
 <a>service endpoints</a> see Sections <a href="#did-method-schemes"></a>
 and <a href="#authentication"></a>.
       </p>
@@ -2418,16 +2420,16 @@ defined in the specification.
       <p>
 At least the following forms of attack MUST be considered: eavesdropping,
 replay, message insertion, deletion, modification, and man-in-the-middle.
-Potential denial of service attacks MUST be identified as well. 
+Potential denial of service attacks MUST be identified as well.
       </p>
       <p>
-If the protocol incorporates cryptographic protection mechanisms, the 
+If the protocol incorporates cryptographic protection mechanisms, the
 <a>DID method</a> specification MUST clearly indicate which portions of the
 data are protected and what the protections are, and SHOULD give an indication
 to what sorts of attacks the cryptographic protection is susceptible.
 For example, integrity only, confidentiality, endpoint authentication, and so
-on.  
-      <p>    
+on.
+      <p>
 Data which is to be held secret (keying material, random seeds, and so on) SHOULD
 be clearly labeled.
       </p>
@@ -2449,7 +2451,7 @@ operations required by Section <a href="#did-operations"></a>.
 Where <a>DID methods</a> make use of peer-to-peer computing resources, such as
 with all known <a>DLTs</a>, the expected burdens of those resources SHOULD be
 discussed in relation to denial of service.
-      </p> 
+      </p>
       <p>
 Method-specific endpoint authentication MUST be discussed. Where
 <a>DID methods</a> make use of <a>DLTs</a> with varying network topology,
@@ -2492,7 +2494,7 @@ The <a>DID method</a> specification's Privacy Considerations section
 MUST discuss any subsection of section 5 of [[RFC6973]] that could
 apply in a method-specific manner. The subsections to consider are:
 surveillance, stored data compromise, unsolicited traffic, misattribution,
-correlation, identification, secondary use, disclosure, exclusion.    
+correlation, identification, secondary use, disclosure, exclusion.
       </p>
     </section>
   </section>
@@ -2708,7 +2710,7 @@ Is monitoring for unauthorized updates (see Section
 <a href="#notification-of-did-document-changes"></a>).
         </li>
         <li>
-Has had adequate opportunity to revert malicious updates according to the 
+Has had adequate opportunity to revert malicious updates according to the
 access control mechanism for the <a>DID method</a> (see Section
 <a href="#authentication"></a>).
         </li>

--- a/terms.html
+++ b/terms.html
@@ -70,8 +70,10 @@ takes control of the private keys.
   <dt><dfn data-lt="did controllers|did controller(s)">DID controller</dfn></dt>
 
   <dd>
-The entity, or a group of entities, in control of a <a>DID</a> or
-<a>DID document</a>. Note that the <a>DID controller</a> might include the
+The entity that has the ability to make changes to a <a>DID document</a>. 
+A <a>DID</a> can have more than one controller. The <a>DID controller(s)</a>
+are denoted by the `controller` property on the top level of the <a>DID
+document</a>. Note that the <a>DID controller(s)</a> might include the
 <a>DID subject</a>.
   </dd>
 

--- a/terms.html
+++ b/terms.html
@@ -186,6 +186,14 @@ by a <a>DID</a> and who directly controls the private keys to control the
 since a <a>DID subject</a> is not always an individual person.
   </dd>
 
+  <dt><dfn data-lt="proofPurpose">proof purpose</dfn></dt>
+
+  <dd>
+The specific intent for a proof, the reason why an entity created it.
+Acts as a safeguard to prevent the proof from being misused for a purpose
+other than the one it was intended for. 
+  </dd>
+
   <dt><dfn>JSON Pointer</dfn></dt>
 
   <dd>
@@ -216,6 +224,13 @@ might also be provided by a generalized data interchange protocol, such as
 An identifier, as defined by [[RFC3986]].
   </dd>
 
+  <dt><dfn data-lt="">verification method</dfn></dt>
+
+  <dd>
+A set of parameters required to independently verify a proof, such
+as an identifier for a public/private key pair that would be used in the
+proof.
+  </dd>
   <dt><dfn data-lt="UUID|UUIDs">Universally Unique Identifier</dfn> (UUID)</dt>
 
   <dd>


### PR DESCRIPTION
Mostly by pulling @dlongley's words from various places around the web :)

This is a first pass at sorting out a lot of uses of 'controller' and should fix the problems with the authentication section. I also updated the definition of 'controller', and added definitions for 'proof purpose' and 'verification method'. It contains new or changed normative language. Needs careful review please! Anticipating changes and corrections.

The Authorization & Delegation section still contains old language still that I'm not sure about.

The Binding of Identity section in Security Considerations is I think also wrong, but I haven't tried to do anything with that yet.

When complete, should fix #2, #3, #22, #39 and help with #4.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/123.html" title="Last updated on Feb 5, 2020, 9:26 PM UTC (24244d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/123/bee98cb...24244d1.html" title="Last updated on Feb 5, 2020, 9:26 PM UTC (24244d1)">Diff</a>