### PR TITLE
Fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@ provider, or certificate authority. <a>DIDs</a> are URLs that relate a
 <a>DID subject</a> to a <a>DID document</a> allowing trustable interactions with
 that subject. <a>DID documents</a> are simple documents describing how to use
 that specific <a>DID</a>. Each <a>DID document</a> can express cryptographic
-material, verification methods, or <a>service endpoints</a>, which. provide a
+material, verification methods, or <a>service endpoints</a>, which provide a
 set of mechanisms enabling a <a>DID controller</a> to prove control of the
 <a>DID</a>. <a>Service endpoints</a> enable trusted interactions with the
 <a>DID subject</a>.


### PR DESCRIPTION
which. -> which


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/melvincarvalho/did-core/pull/129.html" title="Last updated on Nov 27, 2019, 9:27 AM UTC (42df4a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/129/b8c3918...melvincarvalho:42df4a3.html" title="Last updated on Nov 27, 2019, 9:27 AM UTC (42df4a3)">Diff</a>