### PR TITLE
Move DID method security & privacy into normative section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2229,7 +2229,7 @@ identified as well.
       <p>
 If the protocol incorporates cryptographic protection mechanisms,
 it should be clearly indicated which portions
-of the data are protected and what the protections are (i.e.,
+of the data are protected and what the protections are (e.g.,
 integrity only, confidentiality, and/or endpoint authentication,
 etc.). Some indication should also be given of the sorts of attacks to which
 the cryptographic protection is susceptible. Data which should be

--- a/index.html
+++ b/index.html
@@ -675,7 +675,7 @@ Each service has its own <code>id</code> and <code>type</code>, as well as a
 service.
       </p>
       <p>
-For more information see <a href="#service-endpoints"></a>.
+For more information see Section <a href="#service-endpoints"></a>.
       </p>
     </section>
 
@@ -2111,8 +2111,8 @@ of detail necessary to build and test interoperable client implementations with 
 <a>DID registry</a>. These operations can effectively be used to perform all the operations
 required of a CKMS (cryptographic key management system), e.g.: key registration,
 key replacement, key rotation, key recovery, and key expiration.
-
       </p>
+
       <p>
 Any <a>DID method</a> specification that does not support a specific operation,
 such as Update or Deactivate, MUST clearly state these limitations.
@@ -2200,6 +2200,111 @@ inclusion are documented in the [[DID-METHOD-REGISTRY]].
       </p>
     </section>
 
+    <section>
+      <h2>
+Security requirements
+      </h2>
+
+      <p class="issue">
+Discussions at Rebooting the Web of Trust 5 resulted in consensus to
+move Authorization to <a>DID method</a> specifications. It is currently
+expected that there will be an attempt to create a generalized
+authorization mechanism that is build on object capabilities.
+      </p>
+
+      <p>
+<a>DID method</a> specifications MUST include their own Security
+Considerations sections.
+      </p>
+
+      <p>
+This section MUST consider all the requirements mentioned in
+section 5 of [[RFC3552]] (page 27) for the <a>DID</a> operations defined in
+the specification. At least the following forms of attack MUST be considered:
+eavesdropping, replay, message insertion, deletion, modification, and
+man-in-the-middle. Potential denial of service attacks MUST be
+identified as well. 
+      </p>
+
+      <p>
+If the protocol incorporates cryptographic protection mechanisms,
+it should be clearly indicated which portions
+of the data are protected and what the protections are (i.e.,
+integrity only, confidentiality, and/or endpoint authentication,
+etc.). Some indication should also be given of the sorts of attacks to which
+the cryptographic protection is susceptible. Data which should be
+held secret (keying material, random seeds, etc.) should be clearly
+labeled. If the technology involves authentication, particularly
+user-host authentication, the security of the authentication method
+MUST be clearly specified.
+      </p>
+
+      <p>
+This section MUST also discuss, per Section 5 of [[RFC3552]],
+residual risks (such as the risks from compromise in a related
+protocol, incorrect implementation, or cipher) after threat
+mitigation has been deployed.
+      </p>
+
+      <p>
+This section MUST provide integrity protection and update
+authentication for all operations required by
+Section <a href="#did-operations"></a>.
+      </p>
+
+      <p>
+Where <a>DID methods</a> make use of peer-to-peer computing resources
+(such as with all known <a>DLTs</a>), the expected burdens of those
+resources SHOULD be discussed in relation to denial of service.
+      </p>
+
+      <p>
+Method-specific endpoint authentication MUST be discussed. Where
+<a>DID methods</a> make use of <a>DLTs</a> with varying network topology, sometimes
+offered as "light node" or "<a href="https://en.bitcoin.it/wiki/Thin_Client_Security">thin client</a>"
+implementations to reduce required computing resources, the security
+assumptions of the topology available to implementations of the <a>DID
+method</a> MUST be discussed.
+      </p>
+
+      <p>
+<a>DID methods</a> MUST discuss the policy mechanism by which <a>DIDs</a> are
+proven to be uniquely assigned. A <a>DID</a> fits the functional definition
+of a URN as defined in [[RFC8141]] &mdash; a persistent identifier that is
+assigned once to a resource and never reassigned. In a security
+context this is particularly important since a <a>DID</a> may be used to
+identify a specific party subject to a specific set of authorization
+rights.
+      </p>
+
+      <p>
+<a>DID methods</a> that introduce new authentication <a>service endpoint</a>
+types (see <a href="#service-endpoints"></a>) SHOULD consider the
+security requirements of the supported authentication protocol.
+      </p>
+
+    </section>
+
+    <section class='normative'>
+      <h2>
+Privacy Requirements
+      </h2>
+
+      <p>
+<a>DID method</a> specifications MUST include their own Privacy
+Considerations sections, if only to point to
+<a href="#privacy-considerations"></a>.
+      </p>
+
+      <p>
+The <a>DID method</a> specification's Privacy Considerations section
+MUST discuss any subsection of section 5 of [[RFC6973]] that could
+apply in a method-specific manner. The subsections to consider are:
+surveillance, stored data compromise, unsolicited traffic, misattribution,
+correlation, identification, secondary use, disclosure, exclusion.    
+      </p>
+    </section>
+
   </section>
 
   <section class='normative'>
@@ -2240,102 +2345,13 @@ designed to operate under the general Internet threat model used by
 many IETF standards. We assume uncompromised endpoints, but allow
 messages to be read or corrupted on the network. Protecting against an
 attack when a system is compromised requires external key-signing
-hardware. See also Section <a href="#key-revocation-and-recovery"></a>
-regarding key revocation and recovery. For their part, the <a>DLTs</a> hosting
-<a>DIDs</a> and <a>DID documents</a> have special security properties for preventing
-active attacks. Their design uses public/private key cryptography to
-allow operation on passively monitored networks without risking
-compromise of private keys. This is what makes <a>DID</a> architecture and
-decentralized identity possible.
+hardware. See also Section <a href="#key-revocation-and-recovery"></a>.
+For their part, the <a>DLTs</a> hosting <a>DIDs</a> and <a>DID documents</a>
+have special security properties for preventing active attacks. Their design
+uses public/private key cryptography to allow operation on passively monitored
+networks without risking compromise of private keys. This is what makes
+<a>DID</a> architecture and decentralized identity possible.
     </p>
-
-    <section>
-      <h2>
-Requirements of DID Method Specifications
-      </h2>
-
-      <ol start="1">
-        <li>
-<a>DID method</a> specifications MUST include their own Security
-Considerations sections.
-        </li>
-
-        <li>
-This section MUST consider all the requirements mentioned in
-section 5 of [[RFC3552]] (page 27) for the <a>DID</a> operations defined in
-the specification. In particular:
-        </li>
-      </ol>
-
-      <p class="issue">
-Discussions at Rebooting the Web of Trust 5 resulted in consensus to
-move Authorization to <a>DID method</a> specifications. It is currently
-expected that there will be an attempt to create a generalized
-authorization mechanism that is build on object capabilities.
-      </p>
-
-      <p>
-At least the following forms of attack MUST be considered:
-eavesdropping, replay, message insertion, deletion, modification, and
-man-in-the-middle. Potential denial of service attacks MUST be
-identified as well. If the protocol incorporates cryptographic
-protection mechanisms, it should be clearly indicated which portions
-of the data are protected and what the protections are (i.e.,
-integrity only, confidentiality, and/or endpoint authentication,
-etc.). Some indication should also be given to what sorts of attacks
-the cryptographic protection is susceptible. Data which should be
-held secret (keying material, random seeds, etc.) should be clearly
-labeled. If the technology involves authentication, particularly
-user-host authentication, the security of the authentication method
-MUST be clearly specified.
-      </p>
-
-      <ol start="3">
-        <li>
-This section MUST also discuss, per Section 5 of [[RFC3552]],
-residual risks (such as the risks from compromise in a related
-protocol, incorrect implementation, or cipher) after threat
-mitigation has been deployed.
-        </li>
-
-        <li>
-This section MUST provide integrity protection and update
-authentication for all operations required by
-Section <a href="#did-operations"></a>.
-        </li>
-
-        <li>
-Where <a>DID methods</a> make use of peer-to-peer computing resources
-(such as with all known <a>DLTs</a>), the expected burdens of those
-resources SHOULD be discussed in relation to denial of service.
-        </li>
-
-        <li>
-Method-specific endpoint authentication MUST be discussed. Where
-<a>DID methods</a> make use of <a>DLTs</a> with varying network topology, sometimes
-offered as "light node" or "<a href="https://en.bitcoin.it/wiki/Thin_Client_Security">thin client</a>"
-implementations to reduce required computing resources, the security
-assumptions of the topology available to implementations of the <a>DID
-method</a> MUST be discussed.
-        </li>
-
-        <li>
-<a>DID methods</a> MUST discuss the policy mechanism by which <a>DIDs</a> are
-proven to be uniquely assigned. A <a>DID</a> fits the functional definition
-of a URN as defined in [[RFC8141]] &mdash; a persistent identifier that is
-assigned once to a resource and never reassigned. In a security
-context this is particularly important since a <a>DID</a> may be used to
-identify a specific party subject to a specific set of authorization
-rights.
-        </li>
-
-        <li>
-<a>DID methods</a> that introduce new authentication <a>service endpoint</a>
-types (Section <a href="#service-endpoints"></a>) SHOULD consider the
-security requirements of the supported authentication protocol.
-        </li>
-      </ol>
-    </section>
 
     <section>
       <h2>
@@ -2469,7 +2485,7 @@ Authentication Service Endpoints
 
       <p>
 If a <a>DID document</a> publishes a <a>service endpoint</a> intended for
-authentication or authorization of the <a>DID subject</a> (section
+authentication or authorization of the <a>DID subject</a> (see Section
 <a href="#service-endpoints"></a>), it is the responsibility of the <a>service
 endpoint</a> provider, subject, and/or relying party to comply with the
 requirements of the authentication protocol(s) supported at that
@@ -2678,29 +2694,6 @@ embodies principle #7, "Respect for user privacy &mdash; keep it user-centric."
 This section lists additional privacy considerations that implementers,
 delegates, and <a>DID subjects</a> should bear in mind.
     </p>
-
-    <section>
-      <h2>
-Requirements of DID Method Specifications
-      </h2>
-
-      <ol start="1">
-        <li>
-<a>DID method</a> specifications MUST include their own Privacy
-Considerations sections, if only to point to the general privacy
-considerations in this section.
-        </li>
-
-        <li>
-The <a>DID method</a> specification's Privacy Considerations section
-MUST discuss any subsection of
-section 5 of [[RFC6973]] that could apply in a method-specific
-manner. The subsections to consider are: surveillance, stored data
-compromise, unsolicited traffic, misattribution, correlation,
-identification, secondary use, disclosure, exclusion.
-        </li>
-      </ol>
-    </section>
 
     <section>
       <h2>


### PR DESCRIPTION
Identical changes to https://github.com/w3c/did-core/pull/112 but with a clean history.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/130.html" title="Last updated on Jan 21, 2020, 2:49 PM UTC (9fabb41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/130/e479550...9fabb41.html" title="Last updated on Jan 21, 2020, 2:49 PM UTC (9fabb41)">Diff</a>