### PR TITLE
Add "transform-keys" matrix parameter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,6 +817,17 @@ Identifies a certain version timestamp of a <a>DID document</a> to be resolved
 Note: This parameter may not be supported by all <a>DID methods</a>.
             </td>
           </tr>
+
+          <tr>
+            <td>
+<code>transform-keys</code>
+            </td>
+            <td>
+Identifies a variation of a <a>DID document</a> in which public keys are transformed
+to a certain format. Supported values are "jwk" (JSON Web Key) and "jwks"
+(JSON Web Key Set). Note: This parameter is method-independent.
+            </td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
This adds one concrete DID URL matrix parameter.

Description: Identifies a variation of a DID document in which public keys are transformed
to a certain format. Supported values are "jwk" (JSON Web Key) and "jwks"
(JSON Web Key Set).

Example: `did:example:1234;transform-keys=jwk`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/138.html" title="Last updated on Dec 6, 2019, 3:16 PM UTC (65bf8e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/138/a8d0c28...65bf8e1.html" title="Last updated on Dec 6, 2019, 3:16 PM UTC (65bf8e1)">Diff</a>