### PR TITLE
Add "id" DID parameter instead of "service".

### DIFF
--- a/index.html
+++ b/index.html
@@ -826,10 +826,10 @@ specified in [[HASHLINK]].
           </tr>
           <tr>
             <td>
-<code>service</code>
+<code>id</code>
             </td>
             <td>
-Identifies a service from the <a>DID document</a> by service ID.
+Identifies a public key or service or other part of the <a>DID document</a> by its `id` property.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
This adds one concrete DID URL matrix parameter.

Description: Identifies a public key or service or other part of the <a>DID document</a> by its `id` property.

Examples: `did:example:1234;id=key-1`, `did:example:1234;id=openid`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/139.html" title="Last updated on Apr 7, 2020, 8:39 PM UTC (0b74a40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/139/b8c3918...0b74a40.html" title="Last updated on Apr 7, 2020, 8:39 PM UTC (0b74a40)">Diff</a>