### PR TITLE
Enable pure JSON processing of DID Documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -1132,10 +1132,10 @@ mutually agreed terminology.
       </p>
 
       <p>
-<a>DID Documents</a> contain a number of value-value pairs, where the names  are
-globally identified using <a>URIs</a>. However, those <a>URIs</a> can be  long
-and not very human-friendly. In such cases, short-form human-friendly  aliases
-can be more helpful. This specification uses the <code>@context</code>
+<a>DID Documents</a> contain a number of property-value pairs, where the names
+are globally identified using <a>URIs</a>. However, those <a>URIs</a> can be
+long and not very human-friendly. In such cases, short-form human-friendly
+aliases can be more helpful. This specification uses the <code>@context</code>
 <a>property</a> to map such short-form aliases to the URIs used by specific
 <a>DID Documents</a>.
      </p>
@@ -1183,12 +1183,33 @@ Example:
 
       <pre class="example nohighlight">
 {
-  "@context": [
+  <span class="highlight">"@context": [
     "https://www.w3.org/ns/did/v1",
     "https://www.w3.org/ns/did/example/v1"
-  ]
+  ]</span>,
+  "authentication": [{
+    "id": "did:example:123456789abcdefghi#keys-1",
+    "type": "Ed25519VerificationKey2018",
+    "controller": "did:example:123456789abcdefghi",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+  }]
 }
       </pre>
+
+      <p>
+The example above uses the base context <a>URI</a>
+(<code>https://www.w3.org/ns/did/v1</code>) to establish that the
+conversation is about a <a>DID Document</a>. The second <a>URI</a>
+(<code>https://www.w3.org/ns/did/example/v1</code>) establishes that
+the conversation is also about the Example DID Method.
+      </p>
+
+      <p class="note">
+This document uses the example context <a>URI</a>
+(<code>https://www.w3.org/ns/did/v1</code>) for the purpose of demonstrating
+examples. Implementations are expected to not use this <a>URI</a> for any other
+purpose, such as in pilot or production systems.
+      </p>
 
       <p>
 <a>DID method</a> specifications MAY define their own JSON-LD contexts.

--- a/index.html
+++ b/index.html
@@ -1132,6 +1132,15 @@ mutually agreed terminology.
         </p>
 
         <p>
+<a>DID Documents</a> contain a number of value-value pairs, where the names  are
+globally identified using <a>URIs</a>. However, those <a>URIs</a> can be  long
+and not very human-friendly. In such cases, short-form human-friendly  aliases
+can be more helpful. This specification uses the <code>@context</code>
+<a>property</a> to map such short-form aliases to the URIs used by specific
+<a>DID Documents</a>.
+       </p>
+
+        <p>
 <a>DID documents</a> MUST include the <code>@context</code> property.
         </p>
 
@@ -2392,7 +2401,7 @@ At least the following forms of attack MUST be considered: eavesdropping,
 replay, message insertion, deletion, modification, and man-in-the-middle.
             </li>
             <li>
-Potential denial of service attacks MUST be identified as well. 
+Potential denial of service attacks MUST be identified as well.
             </li>
             <li>
 If the protocol incorporates cryptographic protection mechanisms, clearly
@@ -2402,7 +2411,7 @@ on.
             </li>
             <li>
 Give an indication to what sorts of attacks the cryptographic protection is
-susceptible. 
+susceptible.
             </li>
             <li>
 Data which is to be held secret (keying material, random seeds, and so on) is to
@@ -2624,7 +2633,7 @@ Is monitoring for unauthorized updates (see Section
 <a href="#notification-of-did-document-changes"></a>).
         </li>
         <li>
-Has had adequate opportunity to revert malicious updates according to the 
+Has had adequate opportunity to revert malicious updates according to the
 access control mechanism for the <a>DID method</a> (see Section
 <a href="#authentication"></a>).
         </li>

--- a/index.html
+++ b/index.html
@@ -1124,37 +1124,37 @@ including whether these properties are required or optional.
     <section>
       <h2>Contexts</h2>
 
-        <p>
+      <p>
 When two software systems need to exchange data, they need to use terminology
 and a protocol that both systems understand. The <code>@context</code>
 property ensures that two systems operating on the same DID document are using
 mutually agreed terminology.
-        </p>
+      </p>
 
-        <p>
+      <p>
 <a>DID Documents</a> contain a number of value-value pairs, where the names  are
 globally identified using <a>URIs</a>. However, those <a>URIs</a> can be  long
 and not very human-friendly. In such cases, short-form human-friendly  aliases
 can be more helpful. This specification uses the <code>@context</code>
 <a>property</a> to map such short-form aliases to the URIs used by specific
 <a>DID Documents</a>.
-       </p>
+     </p>
 
-       <p class="note">
+     <p class="note">
 In JSON-LD, the <code>@context</code> <a>property</a> can also be used to
 communicate other details, such as datatype information, language information,
 transformation rules, and so on, which are used by some DID Methods. For more
 information, see <a href="https://www.w3.org/TR/json-ld11/#the-context">Section
 3.1: The Context</a> of the [[JSON-LD]] specification.
-        </p>
+      </p>
 
-        <p>
+      <p>
 <a>DID documents</a> MUST include the <code>@context</code> property.
-        </p>
+      </p>
 
-        <dl>
-          <dt><dfn>@context</dfn></dt>
-          <dd>
+      <dl>
+        <dt><dfn>@context</dfn></dt>
+        <dd>
 The value of the <code>@context</code> <a>property</a> MUST be an ordered set
 where the first item is a <a>URI</a> with the value
 <code>https://www.w3.org/ns/did/v1</code>. For reference, a copy of the base
@@ -1163,8 +1163,19 @@ in the array MUST express context information and be composed of any combination
 of <a>URIs</a> or objects. It is RECOMMENDED that each <a>URI</a> in the
 <code>@context</code> be one which, if dereferenced, results in a document
 containing machine-readable information about the <code>@context</code>.
-          </dd>
-        </dl>
+        </dd>
+      </dl>
+
+      <p class="note">
+Though this specification requires that a <code>@context</code> <a>property</a>
+be present, it is not required that the value of the <code>@context</code>
+<a>property</a> be processed using JSON-LD. This is to support constrained
+processing environments using plain JSON libraries. All libraries or processors
+MUST ensure that the order of the values in the <code>@context</code>
+<a>property</a> is what is expected for the specific application. Libraries or
+processors that support JSON-LD can process the <code>@context</code>
+<a>property</a> using full JSON-LD processing as expected.
+      </p>
 
       <p>
 Example:
@@ -1172,9 +1183,13 @@ Example:
 
       <pre class="example nohighlight">
 {
-  "@context": "https://www.w3.org/ns/did/v1"
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://www.w3.org/ns/did/example/v1"
+  ]
 }
-</pre>
+      </pre>
+
       <p>
 <a>DID method</a> specifications MAY define their own JSON-LD contexts.
 However it is NOT RECOMMENDED to define a new context unless

--- a/index.html
+++ b/index.html
@@ -1152,21 +1152,17 @@ information, see <a href="https://www.w3.org/TR/json-ld11/#the-context">Section
 <a>DID documents</a> MUST include the <code>@context</code> property.
         </p>
 
-        <p class="note" title="The JSON-LD Context">
-More information about the
-<a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD Context</a>
-in general can be found in the [[!JSON-LD]] specification.
-        </p>
-
         <dl>
           <dt><dfn>@context</dfn></dt>
           <dd>
-The value of the <code>@context</code> property MUST be one or more
-<a>URIs</a>, where the value of the first <a>URI</a> is
-<code>https://www.w3.org/ns/did/v1</code>. If more than one
-<a>URI</a> is provided, the <a>URIs</a> MUST be interpreted as an ordered set.
-It is RECOMMENDED that dereferencing the <a>URIs</a> results in a document
-containing machine-readable information about the context.
+The value of the <code>@context</code> <a>property</a> MUST be an ordered set
+where the first item is a <a>URI</a> with the value
+<code>https://www.w3.org/ns/did/v1</code>. For reference, a copy of the base
+context is provided in Appendix <a href="#base-context"></a>. Subsequent items
+in the array MUST express context information and be composed of any combination
+of <a>URIs</a> or objects. It is RECOMMENDED that each <a>URI</a> in the
+<code>@context</code> be one which, if dereferenced, results in a document
+containing machine-readable information about the <code>@context</code>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -3296,6 +3296,79 @@ A future-facing real-world context is provided below:
 }
 </pre>
   </section>
+  <section class="appendix informative">
+      <h2>Base Context</h2>
+
+      <p>
+The base context, located at <code>https://www.w3.org/ns/did/v1</code> with a
+SHA-256 digest of
+<strong><code>a3b2a2a54e69384f41cdb0f9a86ba8bf4a700b996d816ac48abe5a2f285d5db5</code></strong>,
+can be used to implement a local cached copy. For convenience, the base context
+is also provided in this section.
+      </p>
+
+<pre class="informative">
+{
+  "@context": {
+    "@version": 1.1,
+    "id": "@id",
+    "type": "@type",
+
+    "dc": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "sec": "https://w3id.org/security#",
+    "didv": "https://w3id.org/did#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+    "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+    "RsaSignature2018": "sec:RsaSignature2018",
+    "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+    "SchnorrSecp256k1Signature2019": "sec:SchnorrSecp256k1Signature2019",
+    "SchnorrSecp256k1VerificationKey2019": "sec:SchnorrSecp256k1VerificationKey2019",
+    "ServiceEndpointProxyService": "didv:ServiceEndpointProxyService",
+
+    "allowedAction": "sec:allowedAction",
+    "assertionMethod": {"@id": "sec:assertionMethod", "@type": "@id", "@container": "@set"},
+    "authentication": {"@id": "sec:authenticationMethod", "@type": "@id", "@container": "@set"},
+    "capability": {"@id": "sec:capability", "@type": "@id"},
+    "capabilityAction": "sec:capabilityAction",
+    "capabilityChain": {"@id": "sec:capabilityChain", "@type": "@id", "@container": "@list"},
+    "capabilityDelegation": {"@id": "sec:capabilityDelegationMethod", "@type": "@id", "@container": "@set"},
+    "capabilityInvocation": {"@id": "sec:capabilityInvocationMethod", "@type": "@id", "@container": "@set"},
+    "capabilityStatusList": {"@id": "sec:capabilityStatusList", "@type": "@id"},
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "caveat": {"@id": "sec:caveat", "@type": "@id", "@container": "@set"},
+    "challenge": "sec:challenge",
+    "controller": {"@id": "sec:controller", "@type": "@id"},
+    "created": {"@id": "dc:created", "@type": "xsd:dateTime"},
+    "creator": {"@id": "dc:creator", "@type": "@id"},
+    "delegator": {"@id": "sec:delegator", "@type": "@id"},
+    "domain": "sec:domain",
+    "expirationDate": {"@id": "sec:expiration", "@type": "xsd:dateTime"},
+    "invocationTarget": {"@id": "sec:invocationTarget", "@type": "@id"},
+    "invoker": {"@id": "sec:invoker", "@type": "@id"},
+    "jws": "sec:jws",
+    "keyAgreement": {"@id": "sec:keyAgreementMethod", "@type": "@id", "@container": "@set"},
+    "nonce": "sec:nonce",
+    "owner": {"@id": "sec:owner", "@type": "@id"},
+    "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
+    "proofPurpose": {"@id": "sec:proofPurpose", "@type": "@vocab"},
+    "proofValue": "sec:proofValue",
+    "publicKey": {"@id": "sec:publicKey", "@type": "@id", "@container": "@set"},
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
+    "service": {"@id": "didv:service", "@type": "@id", "@container": "@set"},
+    "serviceEndpoint": {"@id": "didv:serviceEndpoint", "@type": "@id"},
+    "verificationMethod": {"@id": "sec:verificationMethod", "@type": "@id"}
+  }
+}
+</pre>
+
+  </section>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1212,6 +1212,14 @@ purpose, such as in pilot or production systems.
       </p>
 
       <p>
+The data available at <code>https://www.w3.org/ns/did/v1</code> is a
+static document that is never updated and SHOULD be downloaded and cached. The
+associated human-readable vocabulary document for the DID Core Data Model is available at
+<a href="https://www.w3.org/ns/did">https://www.w3.org/ns/did</a>.
+This concept is further expanded on in Section <a href="#extensibility"></a>.
+      </p>
+
+      <p>
 <a>DID method</a> specifications MAY define their own JSON-LD contexts.
 However it is NOT RECOMMENDED to define a new context unless
 necessary to properly implement the method. Method-specific contexts

--- a/index.html
+++ b/index.html
@@ -1128,25 +1128,18 @@ including whether these properties are required or optional.
 When two software systems need to exchange data, they need to use terminology
 and a protocol that both systems understand. The <code>@context</code>
 property ensures that two systems operating on the same DID document are using
-mutually agreed terminology.
+mutually agreed upon terminology.
       </p>
 
       <p>
-<a>DID Documents</a> contain a number of property-value pairs, where the names
-are globally identified using <a>URIs</a>. However, those <a>URIs</a> can be
-long and not very human-friendly. In such cases, short-form human-friendly
-aliases can be more helpful. This specification uses the <code>@context</code>
-<a>property</a> to map such short-form aliases to the URIs used by specific
-<a>DID Documents</a>.
+<a>DID Documents</a> contain a number of property-value pairs, where the
+properties are globally identified using <a>URIs</a>. However, those <a>URIs</a>
+can be long and and difficult to work with for humans; short-form aliases
+provide a more human-centric approach while not negatively impacting semantic
+accuracy. This specification uses the <code>@context</code> <a>property</a>
+to map such short-form aliases to the URIs used by specific <a>DID
+Documents</a>.
      </p>
-
-     <p class="note">
-In JSON-LD, the <code>@context</code> <a>property</a> can also be used to
-communicate other details, such as datatype information, language information,
-transformation rules, and so on, which are used by some DID Methods. For more
-information, see <a href="https://www.w3.org/TR/json-ld11/#the-context">Section
-3.1: The Context</a> of the [[JSON-LD]] specification.
-      </p>
 
       <p>
 <a>DID documents</a> MUST include the <code>@context</code> property.
@@ -1156,7 +1149,7 @@ information, see <a href="https://www.w3.org/TR/json-ld11/#the-context">Section
         <dt><dfn>@context</dfn></dt>
         <dd>
 The value of the <code>@context</code> <a>property</a> MUST be an ordered set
-where the first item is a <a>URI</a> with the value
+where the first item is a <a>URI</a> with the base context value
 <code>https://www.w3.org/ns/did/v1</code>. For reference, a copy of the base
 context is provided in Appendix <a href="#base-context"></a>. Subsequent items
 in the array MUST express context information and be composed of any combination
@@ -1166,22 +1159,31 @@ containing machine-readable information about the <code>@context</code>.
         </dd>
       </dl>
 
-      <p class="note">
+      <p>
 Though this specification requires that a <code>@context</code> <a>property</a>
 be present, it is not required that the value of the <code>@context</code>
-<a>property</a> be processed using JSON-LD. This is to support constrained
-processing environments using plain JSON libraries. All libraries or processors
-MUST ensure that the order of the values in the <code>@context</code>
+<a>property</a> be processed using a JSON-LD processor. This is to support
+constrained processing environments using plain JSON libraries. All libraries or
+processors MUST ensure that the order of the values in the <code>@context</code>
 <a>property</a> is what is expected for the specific application. Libraries or
 processors that support JSON-LD can process the <code>@context</code>
 <a>property</a> using full JSON-LD processing as expected.
       </p>
 
       <p>
-Example:
+ In JSON-LD, the <code>@context</code> <a>property</a> can also be used to
+ communicate other details, such as datatype information, language information,
+ transformation rules, and so on, which are used by some DID Methods. For more
+ information, see <a href="https://www.w3.org/TR/json-ld11/#the-context">Section
+ 3.1: The Context</a> of the [[JSON-LD]] specification.
       </p>
 
-      <pre class="example nohighlight">
+      <p>
+The following example outlines a common usage of the <code>@context</code>
+<a>property</a>:
+      </p>
+
+      <pre class="example nohighlight" title="Common usage of @context property">
 {
   <span class="highlight">"@context": [
     "https://www.w3.org/ns/did/v1",
@@ -1220,10 +1222,10 @@ This concept is further expanded on in Section <a href="#extensibility"></a>.
       </p>
 
       <p>
-<a>DID method</a> specifications MAY define their own JSON-LD contexts.
-However it is NOT RECOMMENDED to define a new context unless
-necessary to properly implement the method. Method-specific contexts
-MUST NOT override the terms defined in the generic <a>DID</a> context.
+<a>DID method</a> specifications MAY define their own JSON-LD contexts. However
+it is NOT RECOMMENDED to define a new context unless necessary to properly
+implement the method. Method-specific contexts MUST NOT override the terms
+defined in the base context specified in Appendix <a href="#base-context"></a>.
       </p>
     </section>
 
@@ -3296,6 +3298,7 @@ A future-facing real-world context is provided below:
 }
 </pre>
   </section>
+
   <section class="appendix informative">
       <h2>Base Context</h2>
 

--- a/index.html
+++ b/index.html
@@ -1140,6 +1140,14 @@ can be more helpful. This specification uses the <code>@context</code>
 <a>DID Documents</a>.
        </p>
 
+       <p class="note">
+In JSON-LD, the <code>@context</code> <a>property</a> can also be used to
+communicate other details, such as datatype information, language information,
+transformation rules, and so on, which are used by some DID Methods. For more
+information, see <a href="https://www.w3.org/TR/json-ld11/#the-context">Section
+3.1: The Context</a> of the [[JSON-LD]] specification.
+        </p>
+
         <p>
 <a>DID documents</a> MUST include the <code>@context</code> property.
         </p>

--- a/index.html
+++ b/index.html
@@ -1153,7 +1153,7 @@ where the first item is a <a>URI</a> with the base context value
 <code>https://www.w3.org/ns/did/v1</code>. For reference, a copy of the base
 context is provided in Appendix <a href="#base-context"></a>. Subsequent items
 in the array MUST express context information and be composed of any combination
-of <a>URIs</a> or objects. It is RECOMMENDED that each <a>URI</a> in the
+of <a>URIs</a> and/or objects. It is RECOMMENDED that each <a>URI</a> in the
 <code>@context</code> be one which, if dereferenced, results in a document
 containing machine-readable information about the <code>@context</code>.
         </dd>
@@ -1208,7 +1208,7 @@ the conversation is also about the Example DID Method.
 
       <p class="note">
 This document uses the example context <a>URI</a>
-(<code>https://www.w3.org/ns/did/v1</code>) for the purpose of demonstrating
+(<code>https://www.w3.org/ns/did/example/v1</code>) for the purpose of demonstrating
 examples. Implementations are expected to not use this <a>URI</a> for any other
 purpose, such as in pilot or production systems.
       </p>

--- a/terms.html
+++ b/terms.html
@@ -193,6 +193,15 @@ Defines a string syntax for identifying a specific value within a JavaScript
 Object Notation (JSON) document, as defined in [[RFC6901]].
   </dd>
 
+  <dt><dfn data-lt="property|properties">property-value pair</dfn></dt>
+
+  <dd>
+A construct that associates a lookup string, known as the
+<em><strong>property</strong></em>, with a <em><strong>value</strong></em> such
+as a string, number, date, or object. This construct is also known as a
+name-value pair or a key-value pair.
+  </dd>
+
   <dt><dfn>public key description</dfn></dt>
 
   <dd>


### PR DESCRIPTION
The purpose of this PR is to enable pure JSON processing of DID Documents while not creating large problems for JSON-LD processors. It is an attempt at a compromise for the various positions asserted in issue #128. Specifically, this PR:

* Makes it clear that you do not need to do any JSON-LD processing.
* Clarifies the processing rules for pure JSON processors.
* Ensures that the processing rules for pure JSON processors can be implemented via a two line `if` statement to keep things simple.
* Ensures that the JSON processing rules don't lead to different semantics from JSON-LD processing rules.
* Clarifies that the JSON-LD context is static and can be hard coded / cached forever (after the spec is an official global standard).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/142.html" title="Last updated on Dec 12, 2019, 4:11 PM UTC (8b3361e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/142/26f4891...8b3361e.html" title="Last updated on Dec 12, 2019, 4:11 PM UTC (8b3361e)">Diff</a>