### PR TITLE
Cut down security note; fixes #115

### DIFF
--- a/index.html
+++ b/index.html
@@ -2433,26 +2433,14 @@ Security Considerations
     </h1>
 
     <p class="note" title="Note to implementers">
-During the Implementer’s Draft stage, this
-section focuses on security topics that should be important in early
-implementations. The editors are also seeking feedback on threats and
-threat mitigations that should be reflected in this section or
-elsewhere in the spec. As the root identifier records for <a>decentralized
-identifiers</a> (DIDs) and <a>DID documents</a> are a vital component of
-<a>decentralized identity management</a>. They are also the foundational
-building blocks of <a>decentralized public key infrastructure</a> (DPKI)
-as an augmentation to conventional X.509 certificates. As such, <a>DIDs</a> are
-designed to operate under the general Internet threat model used by
-many IETF standards. We assume uncompromised endpoints, but allow
-messages to be read or corrupted on the network. Protecting against an
-attack when a system is compromised requires external key-signing
-hardware. See also Section <a href="#key-revocation-and-recovery"></a>
-regarding key revocation and recovery. For their part, the <a>DLTs</a> hosting
-<a>DIDs</a> and <a>DID documents</a> have special security properties for preventing
-active attacks. Their design uses public/private key cryptography to
-allow operation on passively monitored networks without risking
-compromise of private keys. This is what makes <a>DID</a> architecture and
-decentralized identity possible.
+During the Working Draft stage, this section focuses on security topics that
+should be important in early implementations. The editors are seeking feedback
+on threats and threat mitigations that should be reflected in this section or
+elsewhere in the spec. <a>DIDs</a> are designed to operate under the general
+Internet threat model used by many IETF standards. We assume uncompromised
+endpoints, but anticipate that messages could be read or corrupted on the network.
+Protecting against an attack when a system is compromised requires external
+key-signing hardware (see Section <a href="#key-revocation-and-recovery"></a>).
     </p>
 
     <section>


### PR DESCRIPTION
Removes old text from the NOTE at the start of Security Considerations, that no longer makes sense in context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/155.html" title="Last updated on Jan 25, 2020, 10:12 AM UTC (48ac11c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/155/bee98cb...48ac11c.html" title="Last updated on Jan 25, 2020, 10:12 AM UTC (48ac11c)">Diff</a>