### PR TITLE
Update did-v0.11.jsonld to match the current spec

### DIFF
--- a/contexts/did-v0.11.jsonld
+++ b/contexts/did-v0.11.jsonld
@@ -50,6 +50,8 @@
     "publicKey": {"@id": "sec:publicKey", "@type": "@id", "@container": "@set"},
     "publicKeyBase58": "sec:publicKeyBase58",
     "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyJwk": "sec:publicKeyJwk",
+    "publicKeyHex": "sec:publicKeyHex",
     "revoked": {"@id": "sec:revoked", "@type": "xsd:dateTime"},
     "service": {"@id": "didv:service", "@type": "@id", "@container": "@set"},
     "serviceEndpoint": {"@id": "didv:serviceEndpoint", "@type": "@id"},


### PR DESCRIPTION
Add missing properties to context. 

Absence of these properties severely impacts interoperability when relying on https://www.w3.org/ns/did/v1

And per the current spec: https://w3c.github.io/did-core/#public-keys

`Public keys of all types MUST be expressed in either JSON Web Key (JWK) format using the publicKeyJwk property or one of the formats listed in the table below.`