### PR TITLE
Add IANA Considerations section. Fix #1.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3236,7 +3236,7 @@ See <a data-cite="RFC8259#section-12">RFC&nbsp;8259, section 12</a> [[RFC8259]].
         <dt>Applications that use this media type:</dt>
         <dd>
 Any application that requires an identifier that is decentralized, persistent,
-crytopgraphically verifiable, and resolvable. Applications typically consist of
+cryptographically verifiable, and resolvable. Applications typically consist of
 cryptographic identity systems, decentralized networks of devices, and
 websites that issue or verify W3C Verifiable Credentials.
         </dd>
@@ -3298,7 +3298,7 @@ See <a data-cite="JSON-LD11#security">JSON-LD 1.1, Security Considerations</a>
         <dt>Applications that use this media type:</dt>
         <dd>
 Any application that requires an identifier that is decentralized, persistent,
-crytopgraphically verifiable, and resolvable. Applications typically consist of
+cryptographically verifiable, and resolvable. Applications typically consist of
 cryptographic identity systems, decentralized networks of devices, and
 websites that issue or verify W3C Verifiable Credentials.
         </dd>

--- a/index.html
+++ b/index.html
@@ -3199,5 +3199,140 @@ document</a>.
     </section>
   </section>
 
+  <section class="appendix">
+    <h1>
+IANA Considerations
+    </h1>
+
+    <p>
+This section will be submitted to the Internet Engineering SteeringGroup (IESG)
+for review, approval, and registration with IANA.
+    </p>
+
+    <section>
+      <h2>application/did+json</h2>
+      <dl>
+        <dt>Type name:</dt>
+        <dd>application</dd>
+        <dt>Subtype name:</dt>
+        <dd>did+json</dd>
+        <dt>Required parameters:</dt>
+        <dd>None</dd>
+        <dt>Optional parameters:</dt>
+        <dd>None</dd>
+        <dt>Encoding considerations:</dt>
+        <dd>
+See <a data-cite="RFC8259#section-11">RFC&nbsp;8259, section 11</a>.
+        </dd>
+        <dt id="iana-security">Security considerations:</dt>
+        <dd>
+See <a data-cite="RFC8259#section-12">RFC&nbsp;8259, section 12</a> [[RFC8259]].
+        </dd>
+        <dt>Interoperability considerations:</dt>
+        <dd>Not Applicable</dd>
+        <dt>Published specification:</dt>
+        <dd>http://www.w3.org/TR/did-core/</dd>
+        <dt>Applications that use this media type:</dt>
+        <dd>
+Any application that requires an identifier that is decentralized, persistent,
+crytopgraphically verifiable, and resolvable. Applications typically consist of
+cryptographic identity systems, decentralized networks of devices, and
+websites that issue or verify W3C Verifiable Credentials.
+        </dd>
+        <dt>Additional information:</dt>
+        <dd>
+          <dl>
+            <dt>Magic number(s):</dt>
+            <dd>Not Applicable</dd>
+            <dt>File extension(s):</dt>
+            <dd>.did</dd>
+            <dt>Macintosh file type code(s):</dt>
+            <dd>TEXT</dd>
+          </dl>
+        </dd>
+        <dt>Person &amp; email address to contact for further information:</dt>
+        <dd>Ivan Herman &lt;ivan@w3.org&gt;</dd>
+        <dt>Intended usage:</dt>
+        <dd>Common</dd>
+        <dt>Restrictions on usage:</dt>
+        <dd>None</dd>
+        <dt>Author(s):</dt>
+        <dd>Drummond Reed, Manu Sporny, Markus Sabadello, Dave Longley, Christopher Allen</dd>
+        <dt>Change controller:</dt>
+        <dd>W3C</dd>
+      </dl>
+
+      <p>
+Fragment identifiers used with
+<a href="#application-did-json">application/did+json</a> are treated
+according to the rules defined in
+<a data-cite="DID-CORE#fragment">DID Core v1.0, Fragment</a> [[DID-CORE]].
+      </p>
+    </section>
+
+    <section>
+      <h2>application/did+ld+json</h2>
+      <dl>
+        <dt>Type name:</dt>
+        <dd>application</dd>
+        <dt>Subtype name:</dt>
+        <dd>did+ld+json</dd>
+        <dt>Required parameters:</dt>
+        <dd>None</dd>
+        <dt>Optional parameters:</dt>
+        <dd>None</dd>
+        <dt>Encoding considerations:</dt>
+        <dd>
+See <a data-cite="RFC8259#section-11">RFC&nbsp;8259, section 11</a>.
+        </dd>
+        <dt id="iana-security">Security considerations:</dt>
+        <dd>
+See <a data-cite="JSON-LD11#security">JSON-LD 1.1, Security Considerations</a>
+[[JSON-LD11]].
+        </dd>
+        <dt>Interoperability considerations:</dt>
+        <dd>Not Applicable</dd>
+        <dt>Published specification:</dt>
+        <dd>http://www.w3.org/TR/did-core/</dd>
+        <dt>Applications that use this media type:</dt>
+        <dd>
+Any application that requires an identifier that is decentralized, persistent,
+crytopgraphically verifiable, and resolvable. Applications typically consist of
+cryptographic identity systems, decentralized networks of devices, and
+websites that issue or verify W3C Verifiable Credentials.
+        </dd>
+        <dt>Additional information:</dt>
+        <dd>
+          <dl>
+            <dt>Magic number(s):</dt>
+            <dd>Not Applicable</dd>
+            <dt>File extension(s):</dt>
+            <dd>.did</dd>
+            <dt>Macintosh file type code(s):</dt>
+            <dd>TEXT</dd>
+          </dl>
+        </dd>
+        <dt>Person &amp; email address to contact for further information:</dt>
+        <dd>Ivan Herman &lt;ivan@w3.org&gt;</dd>
+        <dt>Intended usage:</dt>
+        <dd>Common</dd>
+        <dt>Restrictions on usage:</dt>
+        <dd>None</dd>
+        <dt>Author(s):</dt>
+        <dd>Drummond Reed, Manu Sporny, Markus Sabadello, Dave Longley, Christopher Allen</dd>
+        <dt>Change controller:</dt>
+        <dd>W3C</dd>
+      </dl>
+
+      <p>
+Fragment identifiers used with
+<a href="#application-did-ld-json">application/did+ld+json</a> are treated
+according to the rules defined in
+<a data-cite="DID-CORE#fragment">DID Core v1.0, Fragment</a> [[DID-CORE]].
+      </p>
+    </section>
+
+  </section>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -951,16 +951,15 @@ did:example:123456?query=true
       <h2>Fragment</h2>
 
       <p>
-A generic <a>DID fragment</a> is identical to a URI fragment and MUST conform to
-the <code>fragment</code> ABNF rule in [[RFC3986]]. Implementers are strongly
-discouraged from using a <a>DID fragment</a> for anything other than a
-method-independent reference into the <a>DID document</a> to identify a
-component of a <a>DID document</a> (for example, a unique
-<a>public key description</a> or <a>service endpoint</a>). To resolve this
-reference, the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be
-used as input to the <a>DID URL</a> dereferencing algorithm for the
-target component in the <a>DID document</a> object. For more information, see
-[[DID-RESOLUTION]].
+A <a>DID fragment</a> is used as method-independent reference into the <a>DID
+document</a> to identify a component of the document (for example, a unique
+<a>public key description</a> or <a>service endpoint</a>). <a>DID fragment</a>
+syntax and semantics are identical to a generic URI fragment and  MUST conform
+to <a data-cite="RFC3986#section-3.5">RFC&nbsp;3986, section 3.5</a>. To resolve
+a <a>DID fragment</a> reference, the complete <a>DID URL</a> including the
+<a>DID fragment</a> MUST be used as input to the <a>DID URL</a> dereferencing
+algorithm for the target component in the <a>DID document</a> object. For more
+information, see [[DID-RESOLUTION]].
       </p>
 
       <p>
@@ -980,8 +979,15 @@ Implementations SHOULD NOT prevent the use of <a>JSON Pointer</a>
       </p>
 
       <pre class="example nohighlight">
-did:example:123456#oidc
+did:example:123456#public-key-1
       </pre>
+
+      <p>
+Additional semantics for fragment identifiers, which are compatible with and
+layered upon the semantics in this section, are described for JSON-LD
+representations in Section <a href="#application-did-ld-json"></a>.
+      </p>
+
     </section>
 
     <section>
@@ -3328,8 +3334,9 @@ websites that issue or verify W3C Verifiable Credentials.
       <p>
 Fragment identifiers used with
 <a href="#application-did-ld-json">application/did+ld+json</a> are treated
-according to the rules defined in
-<a data-cite="DID-CORE#fragment">DID Core v1.0, Fragment</a> [[DID-CORE]].
+according to the rules associated with the
+<a data-cite="JSON-LD11#iana-considerations">JSON-LD 1.1: application/ld+json
+media type</a> [[JSON-LD11]].
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -3205,8 +3205,9 @@ IANA Considerations
     </h1>
 
     <p>
-This section will be submitted to the Internet Engineering SteeringGroup (IESG)
-for review, approval, and registration with IANA.
+This section will be submitted to the Internet Engineering Steering Group
+(IESG) for review, approval, and registration with IANA when this specification
+becomes a W3C Proposed Recommendation.
     </p>
 
     <section>


### PR DESCRIPTION
This section adds an IANA considerations section, which we need to do in time... but it's being added so we can establish MIME Types for DID Documents, which then describe how fragment identifiers should be interpreted by pointing to the Fragment section in the spec. Doing so will address issue #1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/196.html" title="Last updated on Feb 21, 2020, 2:14 AM UTC (5741e22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/196/3fb8902...5741e22.html" title="Last updated on Feb 21, 2020, 2:14 AM UTC (5741e22)">Diff</a>