### PR TITLE
HTML errors 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1847,7 +1847,7 @@ integrity of the <a>DID document</a> according to either the:
 <a>DID controller</a>, as defined in Section
 <a href="#authorization-and-delegation"></a>, if present.
         </li>
-      </ol>
+      </ul>
 
       <p>
 This proof is NOT proof of the binding between a <a>DID</a> and a

--- a/index.html
+++ b/index.html
@@ -2459,8 +2459,8 @@ correlation, identification, secondary use, disclosure, exclusion.
       </p>
     </section>
   </section>
-  </section>
 
+	
   <section class='normative'>
     <h1>
 Resolution
@@ -2664,7 +2664,7 @@ Has had adequate opportunity to revert malicious updates according to the
 access control mechanism for the <a>DID method</a> (see Section
 <a href="#authentication"></a>).
         </li>
-      <ul>
+      </ul>
 
       <p>
 Non-repudiation is further supported if timestamps are included (see Sections
@@ -2790,7 +2790,7 @@ identifier for a target entity.
 Privacy consequences of using human-friendly identifiers that are inherently
 correlatable, especially if they are globally unique.
         </li>
-      <ul>
+      </ul>
 
       <p class="note">
 A draft specification for discovering a <a>DID</a> from domain names and email
@@ -3279,7 +3279,7 @@ becomes a W3C Proposed Recommendation.
         <dd>
 See <a data-cite="RFC8259#section-11">RFC&nbsp;8259, section 11</a>.
         </dd>
-        <dt id="iana-security">Security considerations:</dt>
+        <dt id="iana-security-json">Security considerations:</dt>
         <dd>
 See <a data-cite="RFC8259#section-12">RFC&nbsp;8259, section 12</a> [[RFC8259]].
         </dd>
@@ -3340,7 +3340,7 @@ according to the rules defined in
         <dd>
 See <a data-cite="RFC8259#section-11">RFC&nbsp;8259, section 11</a>.
         </dd>
-        <dt id="iana-security">Security considerations:</dt>
+        <dt id="iana-security-jsonld">Security considerations:</dt>
         <dd>
 See <a data-cite="JSON-LD11#security">JSON-LD 1.1, Security Considerations</a>
 [[JSON-LD11]].


### PR DESCRIPTION
The source had a number HTML errors that meant that ECHIDNA did not work. As a result, the 'official' version of the document at https://www.w3.org/did-core is still dated as December 9...

The HTML errors (and some warnings) can be seen it at:

https://validator.w3.org/nu/?doc=https%3A%2F%2Fw3c.github.io%2Fdid-core%2F

This PR takes care of the HTML validation errors (and one obvious warning with a duplicate `id` value). If everything works I expect this merge to get ECHIDNA rolling again...

(Good to check if the PR has not changed the semantics. They seem to be harmless (e.g., using a `<ul>` instead of `</ul>`...) but better check...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/iherman/did-core/pull/209.html" title="Last updated on Feb 23, 2020, 12:37 PM UTC (0b1961d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/209/d6d218f...iherman:0b1961d.html" title="Last updated on Feb 23, 2020, 12:37 PM UTC (0b1961d)">Diff</a>