### PR TITLE
Add publicKeyJwk with compound key identifier example and note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1303,10 +1303,13 @@ the <a>DID document</a>; see Section <a href="#authorization-and-delegation"></a
       </p>
 
       <p class="note" title="Key Identifiers">
-The value of the <code>id</code> property may be structured as a <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. 
+        
+      
+The value of the <code>id</code> property MAY be structured as a <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. 
 This is especially useful for integrating with existing key management systems and key formats such as <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.
-When possible a public key fingerprint SHOULD be used in the construction of compound keys. 
-However, as is the case with <code>kid</code> in JWK, one cannot rely on the identifier to map directly to the key value.
+It is RECOMMENDED that <a href="https://tools.ietf.org/html/rfc7517">JWK</a> <code>kid</code> values are set to the <a href="https://tools.ietf.org/html/rfc7638">public key fingerprint</a>. 
+It is RECOMMENDED that verification methods that use JWKs to represent their 
+public keys utilize the value of <code>kid</code> as their fragment identifier.
 See the first key in <a href="#example-11-various-public-keys">EXAMPLE 11</a> for an example of a public key with a compound key identifier.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -1305,7 +1305,7 @@ the <a>DID document</a>; see Section <a href="#authorization-and-delegation"></a
       <p class="note" title="Key Identifiers">
 The value of the <code>id</code> property may be structured as a <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. 
 This is especially useful for integrating with existing key management systems and key formats such as <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.
-When possible a thumbprint or fingerprint SHOULD be used in the construction of compound keys. 
+When possible a public key fingerprint SHOULD be used in the construction of compound keys. 
 However, as is the case with <code>kid</code> in JWK, one cannot rely on the identifier to map directly to the key value.
 See the first key in <a href="#example-11-various-public-keys">EXAMPLE 11</a> for an example of a public key with a compound key identifier.
       </p>

--- a/index.html
+++ b/index.html
@@ -1302,9 +1302,7 @@ expressed using the <code>controller</code> property on the top level of
 the <a>DID document</a>; see Section <a href="#authorization-and-delegation"></a>.
       </p>
 
-      <p class="note" title="Key Identifiers">
-        
-      
+      <p>
 The value of the <code>id</code> property MAY be structured as a <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. 
 This is especially useful for integrating with existing key management systems and key formats such as <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.
 It is RECOMMENDED that <a href="https://tools.ietf.org/html/rfc7517">JWK</a> <code>kid</code> values are set to the <a href="https://tools.ietf.org/html/rfc7638">public key fingerprint</a>. 

--- a/index.html
+++ b/index.html
@@ -1304,7 +1304,7 @@ the <a>DID document</a>; see Section <a href="#authorization-and-delegation"></a
 
       <p class="note" title="Key Identifiers">
 The value of the <code>id</code> property may be structured as a <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. 
-This is especially useful for integrating with existing key mangement systems and key formats such as <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.
+This is especially useful for integrating with existing key management systems and key formats such as <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.
 When possible a thumbprint or fingerprint SHOULD be used in the construction of compound keys. 
 However, as is the case with <code>kid</code> in JWK, one cannot rely on the identifier to map directly to the key value.
 See the first key in <a href="#example-11-various-public-keys">EXAMPLE 11</a> for an example of a public key with a compound key identifier.

--- a/index.html
+++ b/index.html
@@ -1302,6 +1302,14 @@ expressed using the <code>controller</code> property on the top level of
 the <a>DID document</a>; see Section <a href="#authorization-and-delegation"></a>.
       </p>
 
+      <p class="note" title="Key Identifiers">
+The value of the <code>id</code> property may be structured as a <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. 
+This is especially useful for integrating with existing key mangement systems and key formats such as <a href="https://tools.ietf.org/html/rfc7517">JWK</a>.
+When possible a thumbprint or fingerprint SHOULD be used in the construction of compound keys. 
+However, as is the case with <code>kid</code> in JWK, one cannot rely on the identifier to map directly to the key value.
+See the first key in <a href="#example-11-various-public-keys">EXAMPLE 11</a> for an example of a public key with a compound key identifier.
+      </p>
+
       <p>
 All public key properties MUST be from the Linked Data Cryptographic Suite
 Registry. For a registry of key types and formats, see Appendix
@@ -1412,6 +1420,16 @@ Example:
   "id": "did:example:123456789abcdefghi",
   <span class="comment">...</span>
   "publicKey": [{
+    "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+    "type": "JwsVerificationKey2020",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "crv": "Ed25519",
+      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+      "kty": "OKP",
+      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
+    }
+  }, {
     "id": "did:example:123456789abcdefghi#keys-1",
     "type": "RsaVerificationKey2018",
     "controller": "did:example:123456789abcdefghi",


### PR DESCRIPTION
Addresses https://github.com/w3c/did-core/issues/131

- Add note about public key identifiers and compound keys
- Add publicKeyJwk example


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 15, 2020, 6:54 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2FOR13%2Fdid-core%2F20ae30caf2158026be71d6b45dfc4f362dd53a49%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-core%23221.)._
</details>
