### PR TITLE
A DID Document MUST NOT contain revoked keys.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1504,6 +1504,47 @@ responsibility of <a>DID resolvers</a> and other clients. For more information,
 see Section <a href="#resolution"></a>.
       </p>
 
+<p>
+Revoked keys MUST NOT be present in the <code>publicKey</code> property of a <a>DID document</a>.<br/>
+Revoked keys MAY be present in the <code>revokedKey</code> property of a <a>DID document</a>.
+</p>
+
+<pre class="example nohighlight" title="Revoked public keys">
+{
+  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/v1"],
+  "id": "did:example:123456789abcdefghi",
+  <span class="comment">...</span>
+  "publicKey": [],
+  "revokedKey": [{
+    "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+    "type": "JwsVerificationKey2020",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "crv": "Ed25519",
+      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+      "kty": "OKP",
+      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
+    },
+    "revocation": {
+      <span class="comment">...</span>
+    }
+  }, {
+    "id": "did:example:123#4SZ-StXrp5Yd4_4rxHVTCYTHyt4zyPfN1fIuYsm6k3A",
+    "type": "JwsVerificationKey2020",
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "crv": "secp256k1",
+      "x": "Z4Y3NNOxv0J6tCgqOBFnHnaZhJF6LdulT7z8A-2D5_8",
+      "y": "i5a2NtJoUKXkLm6q8nOEu9WOkso1Ag6FTUT6k_LMnGk",
+      "kty": "EC",
+      "kid": "4SZ-StXrp5Yd4_4rxHVTCYTHyt4zyPfN1fIuYsm6k3A"
+    },
+    "revocation": "http://example.com/revocations"
+  }],
+  <span class="comment">...</span>
+}
+</pre>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1203,8 +1203,7 @@ methods, which can be used to authenticate or authorize interactions with the
 <a>DID subject</a> or associated parties. The information expressed often
 includes globally unambiguous identifiers and public key material, which can be
 used to verify digital signatures. Other information can be expressed, such as
-status information for the key (for example, whether it is suspended or
-revoked), or other attributes that enable one to determine whether it is a
+status information for the key, or other attributes that enable one to determine whether it is a
 hardware-backed cryptographic key.
       </p>
 
@@ -1310,11 +1309,8 @@ Registry. For a registry of key types and formats, see Appendix
 
       <p>
 If a public key does not exist in the <a>DID document</a>, it MUST be assumed
-the key was revoked or is invalid. The <a>DID document</a> MAY contain revoked
-keys. A <a>DID document</a> containing a revoked key MUST also contain or refer
-to the revocation information for the key (for example, a revocation list). Each
-<a>DID method</a> specification is expected to detail how revocation is
-performed and tracked.
+the key was revoked or is invalid. The <a>DID document</a> MUST NOT contain revoked
+keys.
       </p>
 
       <p>
@@ -1503,47 +1499,6 @@ Caching and expiration of the keys in a <a>DID document</a> is entirely the
 responsibility of <a>DID resolvers</a> and other clients. For more information,
 see Section <a href="#resolution"></a>.
       </p>
-
-<p>
-Revoked keys MUST NOT be present in the <code>publicKey</code> property of a <a>DID document</a>.<br/>
-Revoked keys MAY be present in the <code>revokedKey</code> property of a <a>DID document</a>.
-</p>
-
-<pre class="example nohighlight" title="Revoked public keys">
-{
-  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/v1"],
-  "id": "did:example:123456789abcdefghi",
-  <span class="comment">...</span>
-  "publicKey": [],
-  "revokedKey": [{
-    "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
-    "type": "JwsVerificationKey2020",
-    "controller": "did:example:123",
-    "publicKeyJwk": {
-      "crv": "Ed25519",
-      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
-      "kty": "OKP",
-      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
-    },
-    "revocation": {
-      <span class="comment">...</span>
-    }
-  }, {
-    "id": "did:example:123#4SZ-StXrp5Yd4_4rxHVTCYTHyt4zyPfN1fIuYsm6k3A",
-    "type": "JwsVerificationKey2020",
-    "controller": "did:example:123",
-    "publicKeyJwk": {
-      "crv": "secp256k1",
-      "x": "Z4Y3NNOxv0J6tCgqOBFnHnaZhJF6LdulT7z8A-2D5_8",
-      "y": "i5a2NtJoUKXkLm6q8nOEu9WOkso1Ag6FTUT6k_LMnGk",
-      "kty": "EC",
-      "kid": "4SZ-StXrp5Yd4_4rxHVTCYTHyt4zyPfN1fIuYsm6k3A"
-    },
-    "revocation": "http://example.com/revocations"
-  }],
-  <span class="comment">...</span>
-}
-</pre>
 
     </section>
 


### PR DESCRIPTION
Revised based on feedback... DID Documents MUST NOT contain revoked keys.

Attempts to address:
- https://github.com/w3c/did-core/issues/14
- https://github.com/w3c/did-core/issues/168


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OR13/did-core/pull/224.html" title="Last updated on Mar 21, 2020, 7:08 PM UTC (e004e2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/224/93bc34c...OR13:e004e2b.html" title="Last updated on Mar 21, 2020, 7:08 PM UTC (e004e2b)">Diff</a>