### PR TITLE
Update broken URL for BIP113

### DIFF
--- a/index.html
+++ b/index.html
@@ -3182,7 +3182,7 @@ timestamp mechanism. Despite some transactional cost, they are the
 most censorship-resistant transaction ordering systems in the world,
 so they are nearly ideal for <a>DID document</a> timestamping. In some cases
 a <a>DLT</a>'s immediate timing is approximate, however their sense of
-<a href="https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki%23Abstract">
+<a href="https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki#Abstract">
 "median time past" (see Bitcoin BIP 113)</a> can be precisely
 defined. A generic <a>DID document</a> timestamping mechanism could would
 work across all <a>DLTs</a> and might operate via a mechanism including


### PR DESCRIPTION
Fixes a broken link for issue: https://github.com/w3c/did-core/issues/181


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yancyribbens/did-core/pull/227.html" title="Last updated on Mar 17, 2020, 4:01 PM UTC (a57ed45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/227/93bc34c...yancyribbens:a57ed45.html" title="Last updated on Mar 17, 2020, 4:01 PM UTC (a57ed45)">Diff</a>