### PR TITLE
change example of a revoked key to use a more common example

### DIFF
--- a/index.html
+++ b/index.html
@@ -2734,15 +2734,14 @@ Key Revocation and Recovery
       </h2>
 
       <p>
-Section <a href="#method-operations"></a> specifies the <a>DID</a> operations to be
-supported by a <a>DID method</a> specification, including deactivation of a
-<a>DID document</a> by replacing it with an updated <a>DID document</a>. In
-general, checking for key revocation on <a>DLT</a>-based methods is expected to
-be handled in a manner similar to checking the balance of a cryptocurrency
-account on a <a>distributed ledger</a>. That is, if the balance is empty, the
-entire <a>DID</a> is deactivated. <a>DID method</a> specifications are expected
-to enable support for a quorum of trusted parties to enable key recovery. Some
-of the facilities to do so are suggested in Section
+Section <a href="#method-operations"></a> specifies the <a>DID</a> operations to
+be supported by a <a>DID method</a> specification, including deactivation of a
+<a>DID document</a> by replacing it with an updated <a>DID document</a>. As an
+example, removal of a cryptographic key from a <a>DID document</a> is an
+indication that the key has been revoked and is no longer valid. That is, if the
+balance is empty, the entire <a>DID</a> is deactivated. <a>DID method</a>
+specifications are expected to enable support for a quorum of trusted parties to
+enable key recovery. Some of the facilities to do so are suggested in Section
 <a href="#authorization-and-delegation"></a>. Not all <a>DID method</a>
 specifications will recognize control from <a>DIDs</a> registered using other
 <a>DID methods</a> and they might restrict third-party control to <a>DIDs</a>

--- a/index.html
+++ b/index.html
@@ -2736,12 +2736,11 @@ Key Revocation and Recovery
       <p>
 Section <a href="#method-operations"></a> specifies the <a>DID</a> operations to
 be supported by a <a>DID method</a> specification, including deactivation of a
-<a>DID document</a> by replacing it with an updated <a>DID document</a>. As an
-example, removal of a cryptographic key from a <a>DID document</a> is an
-indication that the key has been revoked and is no longer valid. That is, if the
-balance is empty, the entire <a>DID</a> is deactivated. <a>DID method</a>
-specifications are expected to enable support for a quorum of trusted parties to
-enable key recovery. Some of the facilities to do so are suggested in Section
+<a>DID document</a> by replacing it with an updated <a>DID document</a>. It's
+also up to the <a>DID Method</a> to define how revocation of cryptographic keys
+should occur. Additionally, <a>DID method</a> specifications are also expected
+to enable support for a quorum of trusted parties to enable key recovery. Some
+of the facilities to do so are suggested in Section
 <a href="#authorization-and-delegation"></a>. Not all <a>DID method</a>
 specifications will recognize control from <a>DIDs</a> registered using other
 <a>DID methods</a> and they might restrict third-party control to <a>DIDs</a>
@@ -2750,7 +2749,7 @@ specification can also include a time lock feature to protect against key
 compromise by maintaining a second track of control for recovery. Further
 specification of this type of control is a matter for future work (see Section
 <a href="#time-locks-and-did-document-recovery"></a>).
-      </p>
+</p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2736,9 +2736,9 @@ Key Revocation and Recovery
       <p>
 Section <a href="#method-operations"></a> specifies the <a>DID</a> operations to
 be supported by a <a>DID method</a> specification, including deactivation of a
-<a>DID document</a> by replacing it with an updated <a>DID document</a>. It's
-also up to the <a>DID Method</a> to define how revocation of cryptographic keys
-should occur. Additionally, <a>DID method</a> specifications are also expected
+<a>DID document</a> by replacing it with an updated <a>DID document</a>. It is
+also up to the <a>DID method</a> to define how revocation of cryptographic keys
+might occur. Additionally, <a>DID method</a> specifications are also expected
 to enable support for a quorum of trusted parties to enable key recovery. Some
 of the facilities to do so are suggested in Section
 <a href="#authorization-and-delegation"></a>. Not all <a>DID method</a>


### PR DESCRIPTION
In issue #180 there was a concern raised that the example provided
is confusing. In this pull request the example was changed to use a
more common method of indicating revocation which aligns with section
7.3 of the specification.

Signed-off-by: Kyle Den Hartog <kyle.denhartog@mattr.global>

Closes #180


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kdenhartog/did-core/pull/230.html" title="Last updated on Mar 19, 2020, 1:45 AM UTC (bb2ec1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/230/93bc34c...kdenhartog:bb2ec1b.html" title="Last updated on Mar 19, 2020, 1:45 AM UTC (bb2ec1b)">Diff</a>