### PR TITLE
remove untestable normative statement regarding did method specs

### DIFF
--- a/common.js
+++ b/common.js
@@ -150,6 +150,15 @@ var ccg = {
       ],
       status: "Draft Community Group Report",
       publisher: "Credentials Community Group"
+    },
+    "DID-RUBRIC": {
+      title: "Decentralized Characteristics Rubric v1.0",
+      href: "https://w3c.github.io/did-rubric/",
+      authors: [
+        "Joe Andrieu"
+      ],
+      status: "Draft Community Group Report",
+      publisher: "Credentials Community Group"
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -803,11 +803,10 @@ usually contains cryptographic material enabling authentication of the
   developers.
         </p>
 
-        <p>
-  To avoid these issues, it is RECOMMENDED that <a>DID method</a> specifications
-  only produce <a>DIDs</a> and <a>DID methods</a> bound to strong, stable
-  <a>DID registries</a> capable of making the highest level of commitment to
-  persistence of the <a>DID</a> and <a>DID method</a> over time.
+        <p class="note">
+          To avoid these issues, developers should reference the <a
+            href="https://w3c.github.io/did-rubric/"></a> to decide which did method
+          best suites the needs of the use case.
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -804,8 +804,9 @@ usually contains cryptographic material enabling authentication of the
         </p>
 
         <p class="note">
-          To avoid these issues, developers should reference the [[DID-RUBRIC]] to
-          decide which did method best suits the needs of the use case.
+To avoid these issues, developers should refer to the Decentralized Characteristics 
+Rubric [[DID-RUBRIC]] to decide which <a>DID method</a> best addresses the needs of 
+the use case.
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -804,9 +804,8 @@ usually contains cryptographic material enabling authentication of the
         </p>
 
         <p class="note">
-          To avoid these issues, developers should reference the <a
-            href="https://w3c.github.io/did-rubric/"></a> to decide which did method
-          best suites the needs of the use case.
+          To avoid these issues, developers should reference the [[DID-RUBRIC]] to
+          decide which did method best suits the needs of the use case.
         </p>
 
         <p class="note">


### PR DESCRIPTION
This addresses issues #166 by removing the normative statement and
adding a link to the rubrics for developers to reference.

Signed-off-by: Kyle Den Hartog <kyle.denhartog@mattr.global>

Closes #166


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kdenhartog/did-core/pull/231.html" title="Last updated on Mar 19, 2020, 1:52 AM UTC (0116868)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/231/93bc34c...kdenhartog:0116868.html" title="Last updated on Mar 19, 2020, 1:52 AM UTC (0116868)">Diff</a>