### PR TITLE
Clarify id value for json-ld

### DIFF
--- a/index.html
+++ b/index.html
@@ -1226,7 +1226,7 @@ it is the entity identified by the <a>DID</a> and described by the
       <dl>
         <dt><dfn>id</dfn></dt>
         <dd>
-The value of <code>id</code> MUST be a single valid <a>DID</a>. 
+The value of <code>id</code> MUST be a single valid <a>DID</a>.
         </dd>
       </dl>
 

--- a/index.html
+++ b/index.html
@@ -1226,7 +1226,7 @@ it is the entity identified by the <a>DID</a> and described by the
       <dl>
         <dt><dfn>id</dfn></dt>
         <dd>
-The value of <code>id</code> MUST be a single valid <a>DID</a>.
+The value of <code>id</code> MUST be a single valid <a>DID</a>. 
         </dd>
       </dl>
 
@@ -2172,6 +2172,11 @@ the document metadata), the following rules MUST be followed.
 The <code>@id</code> and <code>@type</code> keywords are aliased to
 <code>id</code> and <code>type</code> respectively, enabling developers to use
 this specification as idiomatic JSON.
+            </li>
+            <li>
+Even though JSON-LD allows any IRI as node identifiers, <a>DID documents</a>
+are explicitly restricted to only describe DIDs. This means that the value of
+<code>id</code> MUST be a valid <a>DID</a> and not any other kind of IRI.
             </li>
             <li>
 Data types, such as integers, dates, units of measure, and URLs, are


### PR DESCRIPTION
Very small update to JSON-LD requirements to say the value of `id` must always be a DID, even though JSON-LD permits any kind of IRI; see #217


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/242.html" title="Last updated on Apr 8, 2020, 11:20 AM UTC (437cbb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/242/fd4c5cf...437cbb1.html" title="Last updated on Apr 8, 2020, 11:20 AM UTC (437cbb1)">Diff</a>