### PR TITLE
Remove suggestion of polling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2757,29 +2757,21 @@ One mitigation against unauthorized changes to a <a>DID document</a> is
 monitoring and actively notifying the <a>DID subject</a> when there are changes.
 This is analogous to helping prevent account takeover on conventional
 username/password accounts by sending password reset notifications to the email
-addresses on file. In the case of a <a>DID</a>, where there is no intermediary
-registrar or account provider to generate the notification, the following
-approaches are suggested:
+addresses on file.
       </p>
-
-      <ul>
-        <li>
-Subscriptions. If the <a>DID registry</a> on which the <a>DID</a> is registered
-directly supports change notifications, this service can be offered to
-<a>DID controllers</a>. Notifications could be sent directly to the relevant
-<a>service endpoints</a> listed in an existing <a>DID</a>.
-        </li>
-
-        <li>
-Self-monitoring. A <a>DID subject</a> can employ their own local or online agent
-to periodically monitor for changes to a <a>DID document</a>.
-        </li>
-
-        <li>
-Third-party monitoring. A <a>DID subject</a> could rely on a third-party
-monitoring service, however this introduces another vector of attack.
-        </li>
-      </ul>
+      <p>
+In the case of a <a>DID</a>, there is no intermediary registrar or account
+provider to generate such notification. However, if the <a>DID registry</a>
+on which the <a>DID</a> is registered directly supports change notifications,
+a subscription service can be offered to <a>DID controllers</a>. Notifications
+could be sent directly to the relevant <a>service endpoints</a> listed in an
+existing <a>DID</a>.
+      </p>
+      <p>
+If a <a>DID controller</a> chooses to rely on a third-party monitoring service
+(other than the <a>DID registry</a> itself), this introduces another vector of
+attack.
+      </p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2761,7 +2761,7 @@ addresses on file.
       </p>
       <p>
 In the case of a <a>DID</a>, there is no intermediary registrar or account
-provider to generate such notification. However, if the <a>DID registry</a>
+provider to generate such notifications. However, if the <a>DID registry</a>
 on which the <a>DID</a> is registered directly supports change notifications,
 a subscription service can be offered to <a>DID controllers</a>. Notifications
 could be sent directly to the relevant <a>service endpoints</a> listed in an


### PR DESCRIPTION
I removed the non-normative suggestion to self-monitor (poll) for changes to DID docs, as proposed in #179. I reworded the section a bit to make stripping a bullet out of a short list less odd. (The bullets are gone, it's just paragraphs now.) 

I'm not sure if there's consensus to remove this wording though - so far nobody objected in the issue, so anyone who really wants to keep it should comment.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/244.html" title="Last updated on Mar 30, 2020, 12:25 PM UTC (780b7dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/244/fd4c5cf...780b7dd.html" title="Last updated on Mar 30, 2020, 12:25 PM UTC (780b7dd)">Diff</a>