### PR TITLE
Remove self-reference to the public keys section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1261,8 +1261,7 @@ Regarding cryptographic key material, public keys can be included in a
 <code>authentication</code> properties, depending on what they are to be used
 for. Each public key has an identifier (<code>id</code>) of its own, a
 <code>type</code>, and a <code>controller</code>, as well as other properties
-that depend on the type of key it is. For more information, see Section
-<a href="#public-keys"></a>.
+that depend on the type of key it is.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1271,8 +1271,7 @@ likelihood of interoperability. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
 approach attempts to strike a delicate balance between ease of implementation
 and supporting formats that have historically had broad deployment. The specific
-types of key formats that are supported in this specification are listed in <a
-href="#public-keys"></a>.
+types of key formats that are supported in this specification are listed below.
       </p>
 
       <p>


### PR DESCRIPTION
I don't see the point of a section that references itself in the second paragraph of itself.

As an alternative it could say something in the line of `For more information, keep reading.`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/PeterTheOne/did-core/pull/250.html" title="Last updated on Apr 3, 2020, 2:56 PM UTC (60e4ffe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/250/eb4c6fa...PeterTheOne:60e4ffe.html" title="Last updated on Apr 3, 2020, 2:56 PM UTC (60e4ffe)">Diff</a>