### PR TITLE
Fix typo: duplicate "are"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2375,7 +2375,7 @@ verify the invocation of a capability to update the DID Document.; or
         </li>
         <li>
 not use the <a>DID Document</a> at all to decide this, but have rules that are
-are "built into" the method.
+"built into" the method.
         </li>
       </ul>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/PeterTheOne/did-core/pull/251.html" title="Last updated on Apr 3, 2020, 4:18 PM UTC (095f41e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/251/1812b11...PeterTheOne:095f41e.html" title="Last updated on Apr 3, 2020, 4:18 PM UTC (095f41e)">Diff</a>