### PR TITLE
Remove statement about JSON Pointer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,11 +1129,6 @@ in [?DID-RESOLUTION].
   includes a <a>DID fragment</a>. Tree-based processing can be used instead.
         </p>
 
-        <p>
-  Implementations SHOULD NOT prevent the use of <a>JSON Pointer</a>
-  ([[!RFC6901]]).
-        </p>
-
         <pre class="example nohighlight">
   did:example:123456#public-key-1
         </pre>

--- a/index.html
+++ b/index.html
@@ -1134,6 +1134,14 @@ in [?DID-RESOLUTION].
         </pre>
 
         <p>
+In order to maximize interoperability, implementers are urged to ensure that
+<a>DID fragments</a> are interpreted in the same way across representations (as
+described in <a href="#core-representations"></a>). For example, while
+JSON Pointer [[?RFC6901]] can be used in a <a>DID fragment</a>, it will not
+be interpreted in the same way across representations.
+        </p>
+
+        <p>
   Additional semantics for fragment identifiers, which are compatible with and
   layered upon the semantics in this section, are described for JSON-LD
   representations in Section <a href="#application-did-ld-json"></a>.
@@ -1209,7 +1217,7 @@ representations, and a set of requirements for extensibility.
     <section>
       <h2>Definition</h2>
       <p>
-A <a>DID document</a> consists of a collection of property-value pairs. The definitions 
+A <a>DID document</a> consists of a collection of property-value pairs. The definitions
 of each of these properties are specified in section <a href="#core-properties"></a>. Specific
 representations are defined in section <a href="#core-representations"></a>.
       </p>
@@ -1247,7 +1255,7 @@ The data model supports two types of extensibility.
       <ol>
         <li>
 For maximum interoperability, it is RECOMMENDED that extensions use the official
-W3C DID Core Registries mechanism [[DID-CORE-REGISTRIES]]. 
+W3C DID Core Registries mechanism [[DID-CORE-REGISTRIES]].
 The use of this mechanism for new properties or other
 extensions is the only specified method that ensures that two different
 representations will be able to work together.

--- a/terms.html
+++ b/terms.html
@@ -225,13 +225,6 @@ Acts as a safeguard to prevent the proof from being misused for a purpose
 other than the one it was intended for.
   </dd>
 
-  <dt><dfn>JSON Pointer</dfn></dt>
-
-  <dd>
-Defines a string syntax for identifying a specific value within a JavaScript
-Object Notation (JSON) document, as defined in [[RFC6901]].
-  </dd>
-
   <dt><dfn>public key description</dfn></dt>
 
   <dd>


### PR DESCRIPTION
There is a strange statement about JSON Pointers from way back in the day. Based on where the matrix parameters and DID path discussion is going, JSON Pointer is going to be incompatible. This PR removes JSON Pointer because:

1) No known production-bound implementation depends on it, and 
2) the '/' character is going to be reserved shortly and shouldn't be used.

Related to #164.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/257.html" title="Last updated on May 1, 2020, 4:35 PM UTC (af251b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/257/aaac504...af251b6.html" title="Last updated on May 1, 2020, 4:35 PM UTC (af251b6)">Diff</a>