### PR TITLE
Add normative DID URL Dereferencing section.

### DIFF
--- a/common.js
+++ b/common.js
@@ -41,6 +41,16 @@ var ccg = {
       status: "FPWD",
       publisher: "Verifiable Claims Working Group"
     },
+    "DID-CORE-REGISTRIES": {
+      title: "Decentralized Identifier Core Registries",
+      href: "https://w3c.github.io/did-core-registries/",
+      authors: [
+        "Orie Steele",
+        "Manu Sporny"
+      ],
+      status: "ED",
+      publisher: "Decentralized Identifier Working Group"
+    },
     "DID-USE-CASES": {
       title: "Decentralized Identifier Use Cases",
       href: "https://w3c.github.io/did-use-cases/",

--- a/index.html
+++ b/index.html
@@ -665,9 +665,10 @@ document</a> using the complete <a>DID URL</a>.
       </p>
 
       <p>
-The inputs and outputs of the <a>DID URL dereferencing</a> process are defined in
-<a href="#did-url-dereferencing"></a>. Additional considerations for implementing a
-<a>DID URL dereferencer</a> are discussed in [[?DID-RESOLUTION]].
+The general process of <a>DID URL dereferencing</a> is described in <a
+href="#did-url-dereferencing"></a>. The details of implementing a <a>DID URL
+dereferencer</a> is described in the DID Resolution specification
+[[?DID-RESOLUTION]].
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2691,7 +2691,7 @@ define additional inputs to this function.
         </p>
 
         <p>
-The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification
+The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification
 defines the following keys and values:
 
             <dl>
@@ -2721,7 +2721,7 @@ When a <a>DID document</a> is returned, the <code>DID document metadata</code> i
 key-value string pairs as described in <a href="#resolution-metadata"></a>. This metadata
 contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
 typically does not change between invocations of the <a>DID resolution</a> function. The keys and
-possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRY]].
+possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRIES]].
 The <a>DID Document metadata</a> MAY be empty.
         </p>
 
@@ -2733,7 +2733,7 @@ The contents of the DID document metadata still needs to be defined within this 
 The <code>DID resolution metadata</code> is returned as a map of key-value string pairs as described in
 <a href="#resolution-metadata"></a>. This metadata contains information about the results of
 the resolution process. This metadata typically changes between invocations of the <a>DID resolution</a>
-function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
+function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This
 specification defines the following keys and values:
 
             <dl>
@@ -2747,7 +2747,7 @@ specification defines the following keys and values:
                 <dt>error</dt>
                 <dd>The error code from the resolution process. The <a>DID resolver</a> MUST supply
                     this value when there is an error. The possible values
-                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
+                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification defines the following
                     error values:
 
                     <dl>

--- a/index.html
+++ b/index.html
@@ -2807,14 +2807,14 @@ not represent.
         <p>
 The inputs to this function are a <a>DID URL</a> and a set of input metadata. The
 <a>DID URL</a> is REQUIRED and MAY be any valid <a>DID URL</a>, including a fragment.
-The input metadata are a map of key-value string pairs as
+The input metadata are a map of name-value properties as
 described in <a href="#resolution-metadata"></a>. The input metadata are REQUIRED but
 the map MAY be empty. Concrete <a>bindings</a> MUST NOT define additional
 inputs to this function.
         </p>
 
         <p>
-The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]].
+The possible properties for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]].
         </p>
 
         <p>
@@ -2832,12 +2832,12 @@ required by the <a>DID URL</a>, the <a>DID document</a> is returned as the
         </p>
 
         <p>
-The <code>DID dereference metadata</code> is returned as a map of key-value string pairs as described in
+The <code>DID dereference metadata</code> is returned as a map of name-value properties as described in
 <a href="#resolution-metadata"></a>. The metadata structure is REQUIRED and MUST NOT be empty.
 This metadata contains information about the results of
 the dereferencing process. This metadata typically changes between invocations of the <a>DID URL dereferencing</a>
-function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
-specification defines the following keys and values:
+function. The names and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
+specification defines the following property names and values:
 
             <dl>
                 <dt>content-type</dt>
@@ -2846,7 +2846,7 @@ specification defines the following keys and values:
                 <dt>error</dt>
                 <dd>The error code from the dereferencing process. The <a>DID resolver</a> MUST supply
                     this value when there is an error. The possible values
-                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
+                    this property are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
                     error values:
 
                     <dl>

--- a/index.html
+++ b/index.html
@@ -638,6 +638,10 @@ A <a>DID resolver</a> is a software and/or hardware component that takes a
 DID document</a> (and associated metadata) as output in a process
 called <a>DID resolution</a>.
       </p>
+    </section>
+
+    <section>
+      <h2>DID Dereferencers</h2>
       <p>
 The inputs and outputs of the <a>DID resolution</a> process are defined in
 <a href="#did-resolution"></a>. Additional considerations for implementing a

--- a/index.html
+++ b/index.html
@@ -2670,10 +2670,13 @@ DID Resolution
         </h2>
 
         <p>
-The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
-by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
-The details of how this process is accomplished is outside the scope of this
-specification, but all implementations MUST implement a function in the form:
+The <a>DID resolution</a> process takes a <a>DID</a> and
+resolution options as input, and produces a <a>DID document</a> and
+resolution metadata as output. The process utilizes the "Read" operation of
+the applicable <a>DID method</a>, as described in <a href="#read-verify"></a>.
+The <a>DID method</a>-specific details of how this process is accomplished is
+outside the scope of this specification, but all implementations MUST implement
+a function in the form:
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -2649,23 +2649,128 @@ exact implementation of these functions is out of scope for this specification,
 but some considerations for implementors are available in [[?DID-RESOLUTION]].
     </p>
 
+    <p>
+All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
+for at least one <a>DID method</a> and be able to return a <a>DID document</a> in
+at least one conformant representation. All conformant <a>DID URL dereferencers</a>
+MUST implement dereferencing for at least one conformant representation type.
+    </p>
+
     <section>
         <h2>
 DID Resolution
         </h2>
+
+        <p>
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
+by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
+The details of how this process is accomplished is outside the scope of this
+specification, but all implementations MUST implement a function in the form:
+        </p>
+
+        <p>
+<code>resolve ( did, input-metadata ) -> ( did-document, did-document-metadata, did-resolution-metadata )</code>
+        </p>
+
+        <p>
+The inputs of this function are a <a>DID</a> and a set of input metadata. The
+<a>DID</a> is REQUIRED. Note that if the caller of this function wishes to resolve a <a>DID URL</a>,
+the caller MUST first transform the <a>DID URL</a> into a bare <a>DID</a>,
+including removal of any fragment. The input metadata are a map of key-value
+string pairs as described in <a href="#resolution-metadata"></a>.
+The input metadata are REQUIRED but the map MAY be empty. Concrete <a>bindings</a> MUST NOT
+define additional inputs to this function.
+        </p>
+
+        <p>
+The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification
+defines the following keys and values:
+
+            <dl>
+                <dt>accept</dt>
+                <dd>The MIME type of the preferred representation of the <a>DID document</a>. The <a>DID resolver</a> MAY
+                    use this value to determine the representation of the returned <a>DID document</a> if such a
+                    representation is supported and available.</dd>
+            </dl>
+        </p>
+
+
+        <p>
+The <a>DID resolver</a> executes the "Read" operation of the <a>DID method</a> as described in
+<a href="#read-verify"></a>. If successful, the outputs of this function MUST contain a <a>DID document</a>,
+a set of metadata for the DID document (which MAY be empty), and a set of metadata for the resolution process. If
+the function results in an error, the outputs MUST contain a set of metadata for the resolution process.
+        </p>
+
+        <p>
+The <a>DID document</a> is returned as a byte stream of a conformant representation
+as determined and supported by the <a>DID resolver</a>. The caller of the <a>DID resolution</a> function
+can then parse and process the <a>DID document</a> from this byte stream. The <a>DID document</a> is
+REQUIRED unless an error is returned by the <a>DID resolution</a> function.
+        </p>
+
+        <p>
+When a <a>DID document</a> is returned, the <code>DID document metadata</code> is returned as a map of
+key-value string pairs as described in <a href="#resolution-metadata"></a>. This metadata
+contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
+typically does not change between invocations of the <a>DID resolution</a> function. The keys and
+possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRY]].
+The <a>DID Document metadata</a> MAY be empty.
+        </p>
+
+        <p class="issue" data-number="203">
+The contents of the DID document metadata still needs to be defined within this document.
+        </p>
+
+        <p>
+The <code>DID resolution metadata</code> is returned as a map of key-value string pairs as described in
+<a href="#resolution-metadata"></a>. This metadata contains information about the results of
+the resolution process. This metadata typically changes between invocations of the <a>DID resolution</a>
+function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
+specification defines the following keys and values:
+
+            <dl>
+                <dt>content-type</dt>
+                <dd>The mime-type of the returned conformant representation of the <a>DID document</a> if successful.
+                    The <a>DID resolver</a> MUST supply this value when a <a>DID document</a>
+                    is returned. The caller of the resolution function MUST use this value when determining how to
+                    parse and process the byte stream returned by this function into
+                    <a>DID document</a>.</dd>
+
+                <dt>error</dt>
+                <dd>The error code from the resolution process. The <a>DID resolver</a> MUST supply
+                    this value when there is an error. The possible values
+                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
+                    error values:
+
+                    <dl>
+                        <dt>invalid-did</dt>
+                        <dd>The <a>DID</a> supplied to the <a>DID resolution</a> function does not
+                            conform to valid syntax. (See <a href="#did-syntax"></a>.)</dd>
+
+                        <dt>unauthorized</dt>
+                        <dd>The caller is not authorized to resolve this <a>DID</a> with
+                            this <a>DID resolver</a>.</dd>
+                    </dl>
+
+                </dd>
+
+            </dl>
+        </p>
+
     </section>
 
     <section>
         <h2>
 DID URL Dereferencing
         </h2>
+
     </section>
 
     <section>
         <h2>
 Metadata Structure
         </h2>
-    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -2722,7 +2722,7 @@ key-value string pairs as described in <a href="#resolution-metadata"></a>. This
 contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
 typically does not change between invocations of the <a>DID resolution</a> function. The keys and
 possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRIES]].
-The <a>DID Document metadata</a> MAY be empty.
+The DID Document metadata MAY be empty.
         </p>
 
         <p class="issue" data-number="203">

--- a/index.html
+++ b/index.html
@@ -2808,7 +2808,7 @@ not represent.
 The inputs to this function are a <a>DID URL</a> and a set of input metadata. The
 <a>DID URL</a> is REQUIRED and MAY be any valid <a>DID URL</a>, including a fragment.
 The input metadata are a map of name-value properties as
-described in <a href="#resolution-metadata"></a>. The input metadata are REQUIRED but
+described in <a href="#resolution-metadata"></a>. The input metadata is REQUIRED but
 the map MAY be empty. Concrete <a>bindings</a> MUST NOT define additional
 inputs to this function.
         </p>
@@ -2818,7 +2818,7 @@ The possible properties for the input metadata are defined by the DID Core Regis
         </p>
 
         <p>
-The <a>DID URL dereferencer</a> first MUST resolve the <a>DID</a> within the
+The <a>DID URL dereferencer</a> MUST first resolve the <a>DID</a> within the
 <a>DID URL</a> into a <a>DID document</a> using a <a>DID resolution</a> process.
 The <a>DID URL dereferencer</a> MUST parse the resulting <a>DID document</a>
 from its conformant representation to allow for additional processing.

--- a/index.html
+++ b/index.html
@@ -2664,6 +2664,13 @@ exact implementation of these functions is out of scope for this specification,
 but some considerations for implementors are available in [[?DID-RESOLUTION]].
     </p>
 
+    <p>
+All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
+for at least one <a>DID method</a> and be able to return a <a>DID document</a> in
+at least one conformant representation. All conformant <a>DID URL dereferencers</a>
+MUST implement dereferencing for at least one conformant representation type.
+    </p>
+
     <section>
         <h2>
 DID Resolution
@@ -2781,7 +2788,6 @@ DID URL Dereferencing
         <h2>
 Metadata Structure
         </h2>
-    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -726,6 +726,21 @@ hardware and conforms to this specification if it consumes
 when consuming non-conforming <a>DIDs</a> or <a>DID Documents</a>.
     </p>
 
+    <p>
+A <dfn>conforming DID resolver</dfn> that is conformant with this specification
+MUST be capable of performing the <a>DID resolution</a> process, as described in
+<a href="#did-resolution"></a> for at least one <a>DID method</a> and MUST
+return a <a>conforming DID document</a> in at least one conformant
+representation.
+    </p>
+
+    <p>
+A <dfn>conforming DID URL dereferencer</dfn> that is conformant with this
+specification MUST implement the <a>DID URL dereferencing</a> process, as
+described in <a href="#did-url-dereferencing"></a> for at least one conformant
+representation.
+          </p>
+
   </section>
 
   <section>
@@ -2649,13 +2664,6 @@ exact implementation of these functions is out of scope for this specification,
 but some considerations for implementors are available in [[?DID-RESOLUTION]].
     </p>
 
-    <p>
-All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
-for at least one <a>DID method</a> and be able to return a <a>DID document</a> in
-at least one conformant representation. All conformant <a>DID URL dereferencers</a>
-MUST implement dereferencing for at least one conformant representation type.
-    </p>
-
     <section>
         <h2>
 DID Resolution
@@ -2693,7 +2701,6 @@ defines the following keys and values:
                     representation is supported and available.</dd>
             </dl>
         </p>
-
 
         <p>
 The <a>DID resolver</a> executes the "Read" operation of the <a>DID method</a> as described in
@@ -2771,6 +2778,7 @@ DID URL Dereferencing
         <h2>
 Metadata Structure
         </h2>
+    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -2782,12 +2782,104 @@ specification defines the following keys and values:
 DID URL Dereferencing
         </h2>
 
+        <p>
+The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into content
+represented by that <a>DID URL</a> based on the <a>DID document</a> represented by
+the <a>DID</a> within the <a>DID URL</a>. This content MAY be a <a>DID document</a>, a
+portion of a <a>DID document</a>, a service endpoint, or some other data. The details of the implementation of this function
+are outside the scope of this specification, but all implementations MUST provide
+a function of the following form:
+        </p>
+
+        <p>
+<code>dereference ( did-url, input-options ) -> ( content, did-document-metadata, did-dereference-metadata )</code>
+        </p>
+
+
+        <div class="note">
+It would be possible to define dereferencing in terms of a DID URL
+and a fully parsed and modeled DID document, where the resolution process could happen externally
+to the dereferencer. The problem with this is that the caller could potentially
+dereference a URL against a document that the DID within the DID URL does
+not represent.
+        </div>
+
+        <p>
+The inputs to this function are a <a>DID URL</a> and a set of input metadata. The
+<a>DID URL</a> is REQUIRED and MAY be any valid <a>DID URL</a>, including a fragment.
+The input metadata are a map of key-value string pairs as
+described in <a href="#resolution-metadata"></a>. The input metadata are REQUIRED but
+the map MAY be empty. Concrete <a>bindings</a> MUST NOT define additional
+inputs to this function.
+        </p>
+
+        <p>
+The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]].
+        </p>
+
+        <p>
+The <a>DID URL dereferencer</a> first MUST resolve the <a>DID</a> within the
+<a>DID URL</a> into a <a>DID document</a> using a <a>DID resolution</a> process.
+The <a>DID URL dereferencer</a> MUST parse the resulting <a>DID document</a>
+from its conformant representation to allow for additional processing.
+        </p>
+
+        <p>
+The <a>DID URL dereferencer</a> MUST perform any additional processing indicated
+by the <a>DID URL</a>, such as resolving a fragment into an element. If no additional processing is
+required by the <a>DID URL</a>, the <a>DID document</a> is returned as the
+<code>content</code>.
+        </p>
+
+        <p>
+The <code>DID dereference metadata</code> is returned as a map of key-value string pairs as described in
+<a href="#resolution-metadata"></a>. The metadata structure is REQUIRED and MUST NOT be empty.
+This metadata contains information about the results of
+the dereferencing process. This metadata typically changes between invocations of the <a>DID URL dereferencing</a>
+function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
+specification defines the following keys and values:
+
+            <dl>
+                <dt>content-type</dt>
+                <dd>The mime-type of the returned content if successful.</dd>
+
+                <dt>error</dt>
+                <dd>The error code from the dereferencing process. The <a>DID resolver</a> MUST supply
+                    this value when there is an error. The possible values
+                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
+                    error values:
+
+                    <dl>
+                        <dt>invalid-url</dt>
+                        <dd>The <a>DID URL</a> supplied to the <a>DID URL dereferencing</a> function does not
+                            conform to valid syntax. (See <a href="#did-url-syntax"></a>.)</dd>
+                    </dl>
+
+                </dd>
+
+            </dl>
+        </p>
+
+        <p>
+The <code>content</code> of this function's output is a byte stream of data. This byte stream MAY
+represent a <a>DID document</a> in a conformant representation, a portion of a <a>DID document</a>
+in a conformant representation, the results of calling a service
+endpoint, or something else determined by the <a>DID method</a> and its services.
+        </p>
+
+        <p>
+If the returned <code>content</code> is a <a>DID document</a>, the <a>DID URL dereferencer</a> MAY
+return an additional set of DID document metadata, as described in <a href="#did-resolution"></a>.
+        </p>
+
     </section>
 
     <section>
         <h2>
 Metadata Structure
         </h2>
+
+    </section>
 
   </section>
 


### PR DESCRIPTION
This adds the normative text related to DID URL Dereferencing.

This is a WIP, do not merge.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/264.html" title="Last updated on May 14, 2020, 2:41 PM UTC (a99179c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/264/5c839b1...a99179c.html" title="Last updated on May 14, 2020, 2:41 PM UTC (a99179c)">Diff</a>