### PR TITLE
Add normative DID Resolution section. (option #2)

### DIFF
--- a/common.js
+++ b/common.js
@@ -41,6 +41,16 @@ var ccg = {
       status: "FPWD",
       publisher: "Verifiable Claims Working Group"
     },
+    "DID-CORE-REGISTRIES": {
+      title: "Decentralized Identifier Core Registries",
+      href: "https://w3c.github.io/did-core-registries/",
+      authors: [
+        "Orie Steele",
+        "Manu Sporny"
+      ],
+      status: "ED",
+      publisher: "Decentralized Identifier Working Group"
+    },
     "DID-USE-CASES": {
       title: "Decentralized Identifier Use Cases",
       href: "https://w3c.github.io/did-use-cases/",

--- a/index.html
+++ b/index.html
@@ -652,6 +652,10 @@ A <a>DID resolver</a> is a software and/or hardware component that takes a
 DID document</a> (and associated metadata) as output in a process
 called <a>DID resolution</a>.
       </p>
+    </section>
+
+    <section>
+      <h2>DID Dereferencers</h2>
       <p>
 The inputs and outputs of the <a>DID resolution</a> process are defined in
 <a href="#did-resolution"></a>. Additional considerations for implementing a

--- a/index.html
+++ b/index.html
@@ -739,6 +739,21 @@ hardware and conforms to this specification if it consumes
 when consuming non-conforming <a>DIDs</a> or <a>DID Documents</a>.
     </p>
 
+    <p>
+A <dfn>conforming DID resolver</dfn> that is conformant with this specification
+MUST be capable of performing the <a>DID resolution</a> process, as described in
+<a href="#did-resolution"></a> for at least one <a>DID method</a> and MUST
+return a <a>conforming DID document</a> in at least one conformant
+representation.
+    </p>
+
+    <p>
+A <dfn>conforming DID URL dereferencer</dfn> that is conformant with this
+specification MUST implement the <a>DID URL dereferencing</a> process, as
+described in <a href="#did-url-dereferencing"></a> for at least one conformant
+representation.
+          </p>
+
   </section>
 
   <section>
@@ -2694,13 +2709,6 @@ functions is out of scope for this specification, but some considerations for
 implementors are available in [[?DID-RESOLUTION]].
     </p>
 
-    <p>
-All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
-for at least one <a>DID method</a> and be able to return a <a>DID document</a> in
-at least one conformant representation. All conformant <a>DID URL dereferencers</a>
-MUST implement dereferencing for at least one conformant representation type.
-    </p>
-
     <section>
         <h2>
 DID Resolution
@@ -2738,7 +2746,6 @@ defines the following keys and values:
                     representation is supported and available.</dd>
             </dl>
         </p>
-
 
         <p>
 The <a>DID resolver</a> executes the "Read" operation of the <a>DID method</a> as described in
@@ -2816,6 +2823,7 @@ DID URL Dereferencing
         <h2>
 Metadata Structure
         </h2>
+    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -2767,7 +2767,7 @@ key-value string pairs as described in <a href="#resolution-metadata"></a>. This
 contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
 typically does not change between invocations of the <a>DID resolution</a> function. The keys and
 possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRIES]].
-The <a>DID Document metadata</a> MAY be empty.
+The DID Document metadata MAY be empty.
         </p>
 
         <p class="issue" data-number="203">

--- a/index.html
+++ b/index.html
@@ -740,19 +740,17 @@ when consuming non-conforming <a>DIDs</a> or <a>DID Documents</a>.
     </p>
 
     <p>
-A <dfn>conforming DID resolver</dfn> that is conformant with this specification
-MUST be capable of performing the <a>DID resolution</a> process, as described in
-<a href="#did-resolution"></a> for at least one <a>DID method</a> and MUST
-return a <a>conforming DID document</a> in at least one conformant
-representation.
+A <dfn>conforming DID resolver</dfn> MUST be capable of performing the <a>DID
+resolution</a> process, as described in <a href="#did-resolution"></a>, for at
+least one <a>DID method</a> and MUST return a <a>conforming DID document</a> in
+at least one conformant representation.
     </p>
 
     <p>
-A <dfn>conforming DID URL dereferencer</dfn> that is conformant with this
-specification MUST implement the <a>DID URL dereferencing</a> process, as
-described in <a href="#did-url-dereferencing"></a> for at least one conformant
-representation.
-          </p>
+A <dfn>conforming DID URL dereferencer</dfn> MUST implement the <a>DID URL
+dereferencing</a> process, as described in <a href="#did-url-dereferencing"></a>
+for at least one conformant representation.
+    </p>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -2739,8 +2739,8 @@ define additional inputs to this function.
         </p>
 
         <p>
-The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification
-defines the following keys and values:
+The possible properties for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification
+defines the following keys and values for these properties:
 
             <dl>
                 <dt>accept</dt>
@@ -2766,7 +2766,7 @@ REQUIRED unless an error is returned by the <a>DID resolution</a> function.
 
         <p>
 When a <a>DID document</a> is returned, the <code>DID document metadata</code> is returned as a map of
-key-value string pairs as described in <a href="#resolution-metadata"></a>. This metadata
+name-value properties as described in <a href="#resolution-metadata"></a>. This metadata
 contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
 typically does not change between invocations of the <a>DID resolution</a> function. The keys and
 possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRIES]].
@@ -2778,10 +2778,10 @@ The contents of the DID document metadata still needs to be defined within this 
         </p>
 
         <p>
-The <code>DID resolution metadata</code> is returned as a map of key-value string pairs as described in
+The <code>DID resolution metadata</code> is returned as a map of name-value properties as described in
 <a href="#resolution-metadata"></a>. This metadata contains information about the results of
 the resolution process. This metadata typically changes between invocations of the <a>DID resolution</a>
-function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This
+function. The property names and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This
 specification defines the following keys and values:
 
             <dl>

--- a/index.html
+++ b/index.html
@@ -2713,62 +2713,122 @@ DID Resolution
         </h2>
 
         <p>
-The <a>DID resolution</a> process takes a <a>DID</a> and
-resolution options as input, and produces a <a>DID document</a> and
-resolution metadata as output. The process utilizes the "Read" operation of
-the applicable <a>DID method</a>, as described in <a href="#read-verify"></a>.
-The <a>DID method</a>-specific details of how this process is accomplished is
-outside the scope of this specification, but all implementations MUST implement
-a function in the form:
+The <a>DID resolution</a> process takes a <a>DID</a> and resolution options as
+input, and produces a <a>DID document</a> and resolution metadata as output. The
+process utilizes the "Read" operation of the applicable <a>DID method</a>, as
+described in <a href="#read-verify"></a>. The <a>DID method</a>-specific details
+of how this process is accomplished is outside the scope of this specification.
         </p>
 
+        <section>
+          <h3>
+Generic DID Resolution Algorithm
+          </h3>
+
+          <p>
+The generic DID resolution algorithm takes a <a>conforming DID</a>
+(<em>did</em>) and resolution options (<em>resolutionOptions</em>) as input and
+produces a <a>conforming DID Document</a> (<em>didDocument</em>), DID Document
+Metadata (<em>didDocumentMetadata</em>), and resolution metadata
+(<em>resolutionMetadata</em>) as output.
+          <p>
+
+          <p>
+Any errors encountered during the execution of this algorithm MUST be expressed
+using the <strong>error</strong> property in <em>resolutionMetadata</em>.
+          </p>
+
+          <p>
+When resolving a <a>DID</a> to a <a>DID document</a>, the following algorithm,
+or one producing an equivalent result, MUST be used:
+          </p>
+
+          <ol>
+            <li>
+Ensure that the <em>did</em> conforms to <a href="#generic-did-syntax"></a>.
+If the <em>did</em> does not conform, an <code>invalid did</code> error MUST be
+returned.
+            </li>
+            <li>
+Ensure that the each value in <em>resolutionOptions</em> conforms to  <a
+href="#resolution-options"></a>. If an option does not conform, an <code>invalid
+resolution option</code> error MUST be returned.
+            </li>
+            <li>
+Execute the <a>DID method</a>-specific "Read" operation, from the concrete
+<a>binding</a>, as described in <a href="#read-verify"></a> using the
+<em>did</em> and <em>resolutionOptions</em> as input. If the operation
+operation is unsuccessful, a <code>resolution failure</code> error MUST be
+returned.
+            </li>
+            <li>
+If successful, store the resulting <a>DID document</a>
+(<em>didDocument</em>), the DID Document Metadata
+(<em>didDocumentMetadata</em>), and the resolution metadata
+(<em>resolutionMetadata</em>).
+            </li>
+            <li>
+Ensure that <em>didDocument</em> is a <a>conforming DID document</a>. If the
+<em>didDocument</em> does not conform, an <code>invalid did document</code>
+error MUST be returned.
+            </li>
+            <li>
+Ensure that the each value in <em>didDocumentMetadata</em> conforms to
+<a href="#did-document-metadata"></a>. If an option does not conform, an
+<code>invalid did document metadata</code> error MUST be returned.
+            </li>
+            <li>
+Ensure that the each value in <em>didResolutionMetadata</em> conforms to  <a
+href="#resolution-metadata"></a>. If an option does not conform, an
+<code>invalid did resolution metadata</code> error MUST be returned.
+            </li>
+            <li>
+Return the <a>conforming DID document</a> (<em>didDocument</em>), the DID
+Document Metadata (<em>didDocumentMetadata</em>), and the resolution metadata
+(<em>resolutionMetadata</em>).
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h3>
+Resolution Options
+          </h3>
+          <p>
+This specification defines the following properties that can be passed as
+resolution options into <a href="#generic-did-resolution-algorithm"></a>:
+          </p>
+
+          <dl>
+            <dt>accept</dt>
+            <dd>
+The MIME type of the preferred representation of the <a>DID document</a>. The
+<a>DID resolver</a> MUST use this value to generate the representation of the
+returned <a>DID document</a> if such a representation is supported and
+available. If the MIME type representation is not available, a <a>DID
+resolver</a> SHOULD produce an alternate representation.
+            </dd>
+          </dl>
+
         <p>
-<code>resolve ( did, input-metadata ) -> ( did-document, did-document-metadata, did-resolution-metadata )</code>
+Additional properties that can be passed to the DID Resolution algorithm
+are defined in the DID Core Registries [[?DID-CORE-REGISTRIES]].
         </p>
+      </section>
+
+      <section>
+        <h3>
+DID Document Metadata
+        </h3>
 
         <p>
-The inputs of this function are a <a>DID</a> and a set of input metadata. The
-<a>DID</a> is REQUIRED. Note that if the caller of this function wishes to resolve a <a>DID URL</a>,
-the caller MUST first transform the <a>DID URL</a> into a bare <a>DID</a>,
-including removal of any fragment. The input metadata are a map of key-value
-string pairs as described in <a href="#resolution-metadata"></a>.
-The input metadata are REQUIRED but the map MAY be empty. Concrete <a>bindings</a> MUST NOT
-define additional inputs to this function.
-        </p>
-
-        <p>
-The possible properties for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification
-defines the following keys and values for these properties:
-
-            <dl>
-                <dt>accept</dt>
-                <dd>The MIME type of the preferred representation of the <a>DID document</a>. The <a>DID resolver</a> MAY
-                    use this value to determine the representation of the returned <a>DID document</a> if such a
-                    representation is supported and available.</dd>
-            </dl>
-        </p>
-
-        <p>
-The <a>DID resolver</a> executes the "Read" operation of the <a>DID method</a> as described in
-<a href="#read-verify"></a>. If successful, the outputs of this function MUST contain a <a>DID document</a>,
-a set of metadata for the DID document (which MAY be empty), and a set of metadata for the resolution process. If
-the function results in an error, the outputs MUST contain a set of metadata for the resolution process.
-        </p>
-
-        <p>
-The <a>DID document</a> is returned as a byte stream of a conformant representation
-as determined and supported by the <a>DID resolver</a>. The caller of the <a>DID resolution</a> function
-can then parse and process the <a>DID document</a> from this byte stream. The <a>DID document</a> is
-REQUIRED unless an error is returned by the <a>DID resolution</a> function.
-        </p>
-
-        <p>
-When a <a>DID document</a> is returned, the <code>DID document metadata</code> is returned as a map of
-name-value properties as described in <a href="#resolution-metadata"></a>. This metadata
-contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
-typically does not change between invocations of the <a>DID resolution</a> function. The keys and
-possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRIES]].
-The DID Document metadata MAY be empty.
+When a <a>DID document</a> is returned as a part of <a
+href="#generic-did-resolution-algorithm"></a>, the corresponding metadata
+associated with the <a>DID document</a> is also returned. This metadata
+contains information about the input <a>DID</a> and the returned <a>DID
+document</a>. The metadata typically does not change between invocations of the
+<a href="#generic-did-resolution-algorithm"></a>. This section defines common
+DID Document Metadata properties:
         </p>
 
         <p class="issue" data-number="203">
@@ -2776,41 +2836,64 @@ The contents of the DID document metadata still needs to be defined within this 
         </p>
 
         <p>
-The <code>DID resolution metadata</code> is returned as a map of name-value properties as described in
-<a href="#resolution-metadata"></a>. This metadata contains information about the results of
-the resolution process. This metadata typically changes between invocations of the <a>DID resolution</a>
-function. The property names and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This
-specification defines the following keys and values:
+Additional DID Document Metadata properties can be found in
+[[DID-CORE-REGISTRIES]].
+        </p>
+      </section>
 
-            <dl>
-                <dt>content-type</dt>
-                <dd>The mime-type of the returned conformant representation of the <a>DID document</a> if successful.
-                    The <a>DID resolver</a> MUST supply this value when a <a>DID document</a>
-                    is returned. The caller of the resolution function MUST use this value when determining how to
-                    parse and process the byte stream returned by this function into
-                    <a>DID document</a>.</dd>
+      <section>
+        <h3>
+Resolution Metadata
+        </h3>
 
-                <dt>error</dt>
-                <dd>The error code from the resolution process. The <a>DID resolver</a> MUST supply
-                    this value when there is an error. The possible values
-                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification defines the following
-                    error values:
-
-                    <dl>
-                        <dt>invalid-did</dt>
-                        <dd>The <a>DID</a> supplied to the <a>DID resolution</a> function does not
-                            conform to valid syntax. (See <a href="#did-syntax"></a>.)</dd>
-
-                        <dt>unauthorized</dt>
-                        <dd>The caller is not authorized to resolve this <a>DID</a> with
-                            this <a>DID resolver</a>.</dd>
-                    </dl>
-
-                </dd>
-
-            </dl>
+        <p>
+DID resolution metadata is returned as a part of the <a
+href="#generic-did-resolution-algorithm"></a>. This metadata contains
+information about the results of the resolution process and typically changes
+between invocations of the <a href="#generic-did-resolution-algorithm"></a>.
         </p>
 
+        <p>
+This specification defines the following properties that can be passed as
+resolution options into the <a href="#generic-did-resolution-algorithm"></a>:
+        </p>
+
+        <dl>
+          <dt>content-type</dt>
+          <dd>
+The MIME type of the returned <a>conforming DID document</a>. The <a>DID
+resolver</a> MUST provide this value when a <a>DID document</a> is returned. The
+value MUST be used when determining how to parse and process the representation
+returned by the <a href="#generic-did-resolution-algorithm"></a>.
+            </dd>
+
+          <dt>error</dt>
+          <dd>
+The error code from the resolution process. The <a>DID resolver</a> MUST supply
+this value when there is an error. Additional values for this field are defined
+in the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification defines the
+following error values:
+
+            <dl>
+              <dt>invalid-did</dt>
+              <dd>
+The <a>DID</a> supplied to the <a>DID resolution</a> function does not conform
+to valid syntax. (See <a href="#did-syntax"></a>.)
+              </dd>
+
+              <dt>unauthorized</dt>
+              <dd>
+The caller is not authorized to resolve this <a>DID</a> with this <a>DID
+resolver</a>.</dd>
+            </dl>
+          </dd>
+        </dl>
+
+        <p>
+Additional Resolution Metadata properties can be found in
+[[DID-CORE-REGISTRIES]].
+        </p>
+      </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2694,23 +2694,128 @@ functions is out of scope for this specification, but some considerations for
 implementors are available in [[?DID-RESOLUTION]].
     </p>
 
+    <p>
+All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
+for at least one <a>DID method</a> and be able to return a <a>DID document</a> in
+at least one conformant representation. All conformant <a>DID URL dereferencers</a>
+MUST implement dereferencing for at least one conformant representation type.
+    </p>
+
     <section>
         <h2>
 DID Resolution
         </h2>
+
+        <p>
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
+by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
+The details of how this process is accomplished is outside the scope of this
+specification, but all implementations MUST implement a function in the form:
+        </p>
+
+        <p>
+<code>resolve ( did, input-metadata ) -> ( did-document, did-document-metadata, did-resolution-metadata )</code>
+        </p>
+
+        <p>
+The inputs of this function are a <a>DID</a> and a set of input metadata. The
+<a>DID</a> is REQUIRED. Note that if the caller of this function wishes to resolve a <a>DID URL</a>,
+the caller MUST first transform the <a>DID URL</a> into a bare <a>DID</a>,
+including removal of any fragment. The input metadata are a map of key-value
+string pairs as described in <a href="#resolution-metadata"></a>.
+The input metadata are REQUIRED but the map MAY be empty. Concrete <a>bindings</a> MUST NOT
+define additional inputs to this function.
+        </p>
+
+        <p>
+The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification
+defines the following keys and values:
+
+            <dl>
+                <dt>accept</dt>
+                <dd>The MIME type of the preferred representation of the <a>DID document</a>. The <a>DID resolver</a> MAY
+                    use this value to determine the representation of the returned <a>DID document</a> if such a
+                    representation is supported and available.</dd>
+            </dl>
+        </p>
+
+
+        <p>
+The <a>DID resolver</a> executes the "Read" operation of the <a>DID method</a> as described in
+<a href="#read-verify"></a>. If successful, the outputs of this function MUST contain a <a>DID document</a>,
+a set of metadata for the DID document (which MAY be empty), and a set of metadata for the resolution process. If
+the function results in an error, the outputs MUST contain a set of metadata for the resolution process.
+        </p>
+
+        <p>
+The <a>DID document</a> is returned as a byte stream of a conformant representation
+as determined and supported by the <a>DID resolver</a>. The caller of the <a>DID resolution</a> function
+can then parse and process the <a>DID document</a> from this byte stream. The <a>DID document</a> is
+REQUIRED unless an error is returned by the <a>DID resolution</a> function.
+        </p>
+
+        <p>
+When a <a>DID document</a> is returned, the <code>DID document metadata</code> is returned as a map of
+key-value string pairs as described in <a href="#resolution-metadata"></a>. This metadata
+contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
+typically does not change between invocations of the <a>DID resolution</a> function. The keys and
+possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRY]].
+The <a>DID Document metadata</a> MAY be empty.
+        </p>
+
+        <p class="issue" data-number="203">
+The contents of the DID document metadata still needs to be defined within this document.
+        </p>
+
+        <p>
+The <code>DID resolution metadata</code> is returned as a map of key-value string pairs as described in
+<a href="#resolution-metadata"></a>. This metadata contains information about the results of
+the resolution process. This metadata typically changes between invocations of the <a>DID resolution</a>
+function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
+specification defines the following keys and values:
+
+            <dl>
+                <dt>content-type</dt>
+                <dd>The mime-type of the returned conformant representation of the <a>DID document</a> if successful.
+                    The <a>DID resolver</a> MUST supply this value when a <a>DID document</a>
+                    is returned. The caller of the resolution function MUST use this value when determining how to
+                    parse and process the byte stream returned by this function into
+                    <a>DID document</a>.</dd>
+
+                <dt>error</dt>
+                <dd>The error code from the resolution process. The <a>DID resolver</a> MUST supply
+                    this value when there is an error. The possible values
+                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
+                    error values:
+
+                    <dl>
+                        <dt>invalid-did</dt>
+                        <dd>The <a>DID</a> supplied to the <a>DID resolution</a> function does not
+                            conform to valid syntax. (See <a href="#did-syntax"></a>.)</dd>
+
+                        <dt>unauthorized</dt>
+                        <dd>The caller is not authorized to resolve this <a>DID</a> with
+                            this <a>DID resolver</a>.</dd>
+                    </dl>
+
+                </dd>
+
+            </dl>
+        </p>
+
     </section>
 
     <section>
         <h2>
 DID URL Dereferencing
         </h2>
+
     </section>
 
     <section>
         <h2>
 Metadata Structure
         </h2>
-    </section>
 
   </section>
 

--- a/index.html
+++ b/index.html
@@ -1003,7 +1003,7 @@ time. Note that this parameter might not be supported by all <a>DID methods</a>.
 
         <p>
 Additional considerations for processing these parameters are discussed in
-[?DID-RESOLUTION].
+[[?DID-RESOLUTION]].
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -2715,10 +2715,13 @@ DID Resolution
         </h2>
 
         <p>
-The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
-by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
-The details of how this process is accomplished is outside the scope of this
-specification, but all implementations MUST implement a function in the form:
+The <a>DID resolution</a> process takes a <a>DID</a> and
+resolution options as input, and produces a <a>DID document</a> and
+resolution metadata as output. The process utilizes the "Read" operation of
+the applicable <a>DID method</a>, as described in <a href="#read-verify"></a>.
+The <a>DID method</a>-specific details of how this process is accomplished is
+outside the scope of this specification, but all implementations MUST implement
+a function in the form:
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -2736,7 +2736,7 @@ define additional inputs to this function.
         </p>
 
         <p>
-The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification
+The possible keys for the input metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification
 defines the following keys and values:
 
             <dl>
@@ -2766,7 +2766,7 @@ When a <a>DID document</a> is returned, the <code>DID document metadata</code> i
 key-value string pairs as described in <a href="#resolution-metadata"></a>. This metadata
 contains information about the input <a>DID</a> and the returned <a>DID document</a>. This metadata
 typically does not change between invocations of the <a>DID resolution</a> function. The keys and
-possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRY]].
+possible values for this metadata are defined in the DID Core Registry [[?DID-CORE-REGISTRIES]].
 The <a>DID Document metadata</a> MAY be empty.
         </p>
 
@@ -2778,7 +2778,7 @@ The contents of the DID document metadata still needs to be defined within this 
 The <code>DID resolution metadata</code> is returned as a map of key-value string pairs as described in
 <a href="#resolution-metadata"></a>. This metadata contains information about the results of
 the resolution process. This metadata typically changes between invocations of the <a>DID resolution</a>
-function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This
+function. The keys and possible values for this metadata are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This
 specification defines the following keys and values:
 
             <dl>
@@ -2792,7 +2792,7 @@ specification defines the following keys and values:
                 <dt>error</dt>
                 <dd>The error code from the resolution process. The <a>DID resolver</a> MUST supply
                     this value when there is an error. The possible values
-                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRY]]. This specification defines the following
+                    this field are defined by the DID Core Registry [[?DID-CORE-REGISTRIES]]. This specification defines the following
                     error values:
 
                     <dl>


### PR DESCRIPTION
This PR refactors PR #263 by doing the following things:

* Takes a less-prosey / more algorithmic approach to establish how the inputs are provided and checked to the DID Resolution process and how the outputs are received and validated from the DID Resolution process.
* Further aligns how properties defined in DID Core are reflected in DID Spec Registries.
* Splits the resolution options, DID document metadata, and resolution metadata sections into their own subsections and points to the DID Spec Registries in each to ensure the normative requirements flow down from the top-level algorithm.
* Uses stronger and more accurate, testable normative wording while clarifying and/or eliminating some redundant statements.

This is a WIP, do not merge.

Human readable preview is here:

https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/286.html#did-resolution


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/286.html" title="Last updated on May 18, 2020, 1:10 PM UTC (108da3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/286/200cff0...108da3d.html" title="Last updated on May 18, 2020, 1:10 PM UTC (108da3d)">Diff</a>