### PR TITLE
Trivial nit wrt a reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1003,7 +1003,7 @@ time. Note that this parameter might not be supported by all <a>DID methods</a>.
 
         <p>
 Additional considerations for processing these parameters are discussed in
-[?DID-RESOLUTION].
+[[?DID-RESOLUTION]].
         </p>
 
         <p>


### PR DESCRIPTION
The reference to DID-RESOLUTION in line 1006 was only in single square brackets, not double. So this PR just doubles up those [] characters.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/287.html" title="Last updated on May 18, 2020, 8:08 AM UTC (ea6dc25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/287/9a7cad0...ea6dc25.html" title="Last updated on May 18, 2020, 8:08 AM UTC (ea6dc25)">Diff</a>