### PR TITLE
Define simple type-less resolution function

### DIFF
--- a/index.html
+++ b/index.html
@@ -2687,13 +2687,30 @@ Resolution
 This section defines the inputs and outputs of the <a>DID resolution</a> and
 <a>DID URL dereferencing</a> processes. The exact implementation of these
 functions is out of scope for this specification, but some considerations for
-implementors are available in [[?DID-RESOLUTION]].
+implementors are discussed in [[?DID-RESOLUTION]].
+    </p>
+
+    <p>
+All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
+for at least one <a>DID method</a> and MUST be able to return a <a>DID document</a> in 
+at least one conformant representation.
     </p>
 
     <section>
         <h2>
 DID Resolution
         </h2>
+        <p>
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
+by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
+The details of how this process is accomplished are outside the scope of this
+specification, but all conformant implementations MUST implement a function in the following form:
+        </p>
+
+        <p><code>
+resolve ( did, did-resolution-input-metadata ) <br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
+        </code></p>
     </section>
 
     <section>


### PR DESCRIPTION
This adapts the DID Resolution functional definition defined by #253 into a single type-less function with no additional requirements.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jricher/did-core/pull/295.html" title="Last updated on May 27, 2020, 9:27 PM UTC (8515500)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/295/200cff0...jricher:8515500.html" title="Last updated on May 27, 2020, 9:27 PM UTC (8515500)">Diff</a>