### PR TITLE
Define resolution function with data types

### DIFF
--- a/index.html
+++ b/index.html
@@ -2684,9 +2684,9 @@ Resolution
     </h1>
 
     <p>
-This section defines the inputs and outputs of the <a>DID resolution</a> and
-<a>DID URL dereferencing</a> processes. The exact implementation of these
-functions is out of scope for this specification, but some considerations for
+This section defines the inputs and outputs of <a>DID resolution</a> and
+<a>DID URL dereferencing</a>. These functions are defined in an abstract way.
+Their exact implementation is out of scope for this specification, but some considerations for
 implementors are discussed in [[?DID-RESOLUTION]].
     </p>
 
@@ -2704,7 +2704,7 @@ DID Resolution
 The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
 by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
 The details of how this process is accomplished are outside the scope of this
-specification, but all conformant implementations MUST implement a function in the following form:
+specification, but all conformant implementations MUST implement a function which has the following abstract form:
         </p>
 
         <p><code>

--- a/index.html
+++ b/index.html
@@ -2767,6 +2767,14 @@ the <a>DID document</a> changes, as it represents data about the <a>DID document
 If the resolution is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
             </dd>
         </dl>
+
+        <p>
+<a>DID resolver</a> implementations MUST NOT alter the signature of this function in any way. <a>DID resolver</a>
+implementations MAY map the <code>resolve</code> function to a method-specific internal function to perform the
+actual <a>DID resolution</a> process. <a>DID resolver</a> implementations <a>DID resolver</a> implementations MAY implement 
+and expose additional functions with different signatures in addition to the <code>resolve</code> function specified here.
+        </p>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2711,6 +2711,62 @@ specification, but all conformant implementations MUST implement a function in t
 resolve ( did, did-resolution-input-metadata ) <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
         </code></p>
+
+        <p>
+The input variables of this function MUST be as follows:
+        </p>
+
+        <dl>
+            <dt>
+did
+            </dt>
+            <dd>
+A conformant <a>DID</a> as a single string. This is the <a>DID</a> to resolve.
+This input is REQUIRED.
+            </dd>
+            <dt>
+did-resolution-input-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of input options to the <code>resolve</code>
+function in addition to the <code>did</code> itself.
+This input is REQUIRED, but the structure MAY be empty.
+            </dd>
+        </dl>
+
+        <p>
+The output variables of this function MUST be as follows:
+        </p>
+    
+        <dl>
+            <dt>
+did-resolution-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of values relating to the results of the <a>DID resolution</a> process.
+This structure is REQUIRED and MUST NOT be empty.
+This metadata typically changes between invocations of the <code>resolve</code> function as it represents data about the resolution process itself.
+            </dd>
+            <dt>
+did-document-stream
+            </dt>
+            <dd>
+If the resolution is successful, this MUST be a byte stream of the resolved <a>DID document</a> in a single conformant <a>representation</a>.
+The byte stream MAY then be parsed by the caller of the <code>resolve</code> function into a <a>DID document</a> abstract data model, which
+can in turn be validated and processed.
+If the resolution is unsuccessful, this value MUST be an empty stream.
+            </dd>
+            <dt>
+did-document-metadata
+            </dt>
+            <dd>
+If the resolution is successful, this MUST be a <a href="metadata-structure">metadata structure</a>.
+This structure contains metadata about the <a>DID document</a> contained in the <code>did-document-stream</code>.
+This metadata typically does not change between invocations of the <code>resolve</code> function unless
+the <a>DID document</a> changes, as it represents data about the <a>DID document</a>.
+If the resolution is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
+            </dd>
+        </dl>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2687,13 +2687,30 @@ Resolution
 This section defines the inputs and outputs of the <a>DID resolution</a> and
 <a>DID URL dereferencing</a> processes. The exact implementation of these
 functions is out of scope for this specification, but some considerations for
-implementors are available in [[?DID-RESOLUTION]].
+implementors are discussed in [[?DID-RESOLUTION]].
+    </p>
+
+    <p>
+All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
+for at least one <a>DID method</a> and MUST be able to return a <a>DID document</a> in 
+at least one conformant representation.
     </p>
 
     <section>
         <h2>
 DID Resolution
         </h2>
+        <p>
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
+by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
+The details of how this process is accomplished are outside the scope of this
+specification, but all conformant implementations MUST implement a function in the following form:
+        </p>
+
+        <p><code>
+resolve ( did, did-resolution-input-metadata ) <br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
+        </code></p>
     </section>
 
     <section>


### PR DESCRIPTION
This adapts the DID Resolution functional definition defined by #253 into a single typed function with requirements for the function signature and implementation conformance. 

This builds on #295.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jricher/did-core/pull/296.html" title="Last updated on Jun 9, 2020, 4:23 PM UTC (38c9969)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/296/200cff0...jricher:38c9969.html" title="Last updated on Jun 9, 2020, 4:23 PM UTC (38c9969)">Diff</a>