### PR TITLE
Define resolution function with data types, property values, and simple metadata structures

### DIFF
--- a/index.html
+++ b/index.html
@@ -2884,6 +2884,16 @@ DID URL Dereferencing
         <h2>
 Metadata Structure
         </h2>
+
+        <p>
+A <a href="metadata-structure">metadata structure</a> is a common and interoperable data structure used to
+communicate information alongside a <a>DID</a> and <a>DID document</a>, and is specifically
+used for the <a>DID resolution</a> function definition in this specification.
+Use of a <a href="metadata-structure">metadata structure</a> is intended to compliment the information available
+within a <a>DID</a> or <a>DID document</a>, and therefore is best suited to carrying
+metadata as an input or output to the function process.
+        </p>
+        
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -2767,6 +2767,14 @@ the <a>DID document</a> changes, as it represents data about the <a>DID document
 If the resolution is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
             </dd>
         </dl>
+
+        <p>
+<a>DID resolver</a> implementations MUST NOT alter the signature of this function in any way. <a>DID resolver</a>
+implementations MAY map the <code>resolve</code> function to a method-specific internal function to perform the
+actual <a>DID resolution</a> process. <a>DID resolver</a> implementations <a>DID resolver</a> implementations MAY implement 
+and expose additional functions with different signatures in addition to the <code>resolve</code> function specified here.
+        </p>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2711,6 +2711,62 @@ specification, but all conformant implementations MUST implement a function in t
 resolve ( did, did-resolution-input-metadata ) <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
         </code></p>
+
+        <p>
+The input variables of this function MUST be as follows:
+        </p>
+
+        <dl>
+            <dt>
+did
+            </dt>
+            <dd>
+A conformant <a>DID</a> as a single string. This is the <a>DID</a> to resolve.
+This input is REQUIRED.
+            </dd>
+            <dt>
+did-resolution-input-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of input options to the <code>resolve</code>
+function in addition to the <code>did</code> itself.
+This input is REQUIRED, but the structure MAY be empty.
+            </dd>
+        </dl>
+
+        <p>
+The output variables of this function MUST be as follows:
+        </p>
+    
+        <dl>
+            <dt>
+did-resolution-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of values relating to the results of the <a>DID resolution</a> process.
+This structure is REQUIRED and MUST NOT be empty.
+This metadata typically changes between invocations of the <code>resolve</code> function as it represents data about the resolution process itself.
+            </dd>
+            <dt>
+did-document-stream
+            </dt>
+            <dd>
+If the resolution is successful, this MUST be a byte stream of the resolved <a>DID document</a> in a single conformant <a>representation</a>.
+The byte stream MAY then be parsed by the caller of the <code>resolve</code> function into a <a>DID document</a> abstract data model, which
+can in turn be validated and processed.
+If the resolution is unsuccessful, this value MUST be an empty stream.
+            </dd>
+            <dt>
+did-document-metadata
+            </dt>
+            <dd>
+If the resolution is successful, this MUST be a <a href="metadata-structure">metadata structure</a>.
+This structure contains metadata about the <a>DID document</a> contained in the <code>did-document-stream</code>.
+This metadata typically does not change between invocations of the <code>resolve</code> function unless
+the <a>DID document</a> changes, as it represents data about the <a>DID document</a>.
+If the resolution is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
+            </dd>
+        </dl>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2730,6 +2730,7 @@ did-resolution-input-metadata
             <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of input options to the <code>resolve</code>
 function in addition to the <code>did</code> itself.
+Properties defined by this specification are in <a href="#did-resolution-input-metadata-properties"></a>.
 This input is REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
@@ -2746,6 +2747,9 @@ did-resolution-metadata
 A <a href="metadata-structure">metadata structure</a> consisting of values relating to the results of the <a>DID resolution</a> process.
 This structure is REQUIRED and MUST NOT be empty.
 This metadata typically changes between invocations of the <code>resolve</code> function as it represents data about the resolution process itself.
+Properties defined by this specification are in <a href="#did-resolution-metadata-properties"></a>.
+If the resolution is successful, this structure MUST contain a <code>content-type</code> property containing the mime-type <a>representation</a> of the <code>did-document-stream</code> in this result.
+If the resolution is not successful, this structure MUST contain an <code>error</code> property describing the error.
             </dd>
             <dt>
 did-document-stream
@@ -2765,6 +2769,7 @@ This structure contains metadata about the <a>DID document</a> contained in the 
 This metadata typically does not change between invocations of the <code>resolve</code> function unless
 the <a>DID document</a> changes, as it represents data about the <a>DID document</a>.
 If the resolution is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
+Properties defined by this specification are in <a href="#did-document-metadata-properties"></a>.
             </dd>
         </dl>
 
@@ -2774,6 +2779,98 @@ implementations MAY map the <code>resolve</code> function to a method-specific i
 actual <a>DID resolution</a> process. <a>DID resolver</a> implementations <a>DID resolver</a> implementations MAY implement 
 and expose additional functions with different signatures in addition to the <code>resolve</code> function specified here.
         </p>
+
+        <section>
+            <h3>
+DID Resolution Input Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+            
+            <dl>
+                <dt>
+accept
+                </dt>
+                <dd>
+The MIME type of the caller's preferred representation of the <a>DID document</a>. The <a>DID resolver</a> implementation 
+MAY use this value to determine the representation contained in the returned <code>did-document-stream</code> if such
+a representation is supported and available. This property is OPTIONAL.
+                </dd>
+            </dl>
+        </section>
+
+        <section>
+            <h3>
+DID Resolution Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+            <dl>
+                <dt>
+content-type
+                </dt>
+                <dd>
+The mime-type of the returned conformant representation of the contained in the returned <code>did-document-stream</code>.
+This property is REQUIRED if resolution is successful and a <code>did-document-stream</code> is returned. 
+The caller of the <code>resolve</code> function MUST use this value when determining how to
+parse and process the <code>did-document-stream</code> returned by this function into a
+<a>DID document</a> abstract data model.
+                </dd>
+                <dt>
+error
+                </dt>
+                <dd>
+The error code from the resolution process. 
+This property is REQUIRED when there is an error in the resolution process.
+The value of this property is a single keyword string.
+The possible property values of this field are defined by the DID Core Registry [[DID-CORE-REGISTRY]]. 
+This specification defines the following error values:
+                    <dl>
+                        <dt>
+invalid-did
+                        </dt>
+                        <dd>
+The <a>DID</a> supplied to the <a>DID resolution</a> function does not
+conform to valid syntax. (See <a href="#did-syntax"></a>.)
+                        </dd>
+                        <dt>
+unauthorized
+                        </dt>
+                        <dd>
+The caller is not authorized to resolve this <a>DID</a> with
+this <a>DID resolver</a>.
+                        </dd>
+                        <dt>
+not-found
+                        </dt>
+                        <dd>
+The <a>DID resolver</a> was unable to return the <a>DID document</a>
+resulting from this resolution request.
+                        </dd>
+                    </dl>
+                </dd>
+            </dl>
+
+        </section>
+
+        <section>
+            <h3>
+DID Document Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+        </section>
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2687,13 +2687,30 @@ Resolution
 This section defines the inputs and outputs of the <a>DID resolution</a> and
 <a>DID URL dereferencing</a> processes. The exact implementation of these
 functions is out of scope for this specification, but some considerations for
-implementors are available in [[?DID-RESOLUTION]].
+implementors are discussed in [[?DID-RESOLUTION]].
+    </p>
+
+    <p>
+All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a> function
+for at least one <a>DID method</a> and MUST be able to return a <a>DID document</a> in 
+at least one conformant representation.
     </p>
 
     <section>
         <h2>
 DID Resolution
         </h2>
+        <p>
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID document</a>
+by using the "Read" operation of the applicable <a>DID method</a>. (See <a href="#read-verify"></a>.)
+The details of how this process is accomplished are outside the scope of this
+specification, but all conformant implementations MUST implement a function in the following form:
+        </p>
+
+        <p><code>
+resolve ( did, did-resolution-input-metadata ) <br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
+        </code></p>
     </section>
 
     <section>


### PR DESCRIPTION
This adapts the DID Resolution functional definition defined by #253 into a single typed function with requirements for the function signature and implementation conformance. Property values for input and output metadata structures are defined here, with pointers to the DID registry for management of properties. Requirements for when and how to return each value are also added. 

Simple metadata structures are defined here, without detail for conformance or transmission.

This builds on #295, #296, and #297.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 27, 2020, 9:28 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fjricher%2Fdid-core%2F1b2f1523e079a2c09f7dad531aa87b132c6092cb%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
[36mSpecification: https://rawcdn.githack.com/jricher/did-core/1b2f1523e079a2c09f7dad531aa87b132c6092cb/index.html?isPreview=true&publishDate=2020-05-27[39m
[36mReSpec version: 25.6.0[39m
[36mFile a bug: https://github.com/w3c/respec/[39m
[36mError: Error: Evaluation failed: Timeout: document.respecIsReady didn't resolve in 19587ms.[39m
[36m    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/ExecutionContext.js:122:13)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/ExecutionContext.js:48:12)[39m
[36m    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:12)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:91:29)[39m
[36m  -- ASYNC --[39m
[36m    at ExecutionContext.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:111:15)[39m
[36m    at DOMWorld.evaluate (/u/spec-generator/node_modules/puppeteer/lib/DOMWorld.js:112:20)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m  -- ASYNC --[39m
[36m    at Frame.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:111:15)[39m
[36m    at Page.evaluate (/u/spec-generator/node_modules/puppeteer/lib/Page.js:860:43)[39m
[36m    at Page.<anonymous> (/u/spec-generator/node_modules/puppeteer/lib/helper.js:112:23)[39m
[36m    at generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:128:23)[39m
[36m    at runMicrotasks (<anonymous>)[39m
[36m    at processTicksAndRejections (internal/process/task_queues.js:97:5)[39m
[36m    at async fetchAndWrite (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:95:18)[39m
[36m    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:14:20)[39m
[36m    at async generate (/u/spec-generator/server.js:91:29)[39m
[36m[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-core%23298.)._
</details>
