### PR TITLE
Add verificationMethod as a DID document property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1330,8 +1330,9 @@ verification method objects MAY include additional properties.
       <p>
 The value of the <code>id</code> property MUST be a <a>URI</a>. The array of
 verification methods MUST NOT contain multiple entries with the same
-<code>id</code>. In this case, a <a>DID document</a> processor MUST produce an
-error.
+<code>id</code>. If the array of <a>verification methods</a> contains multiple 
+entries with the same <code>id</code>, a <a>DID document</a> processor MUST 
+produce an error.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1392,7 +1392,7 @@ detailed example of a <a>verification relationship</a>.
       <h2>Public Keys</h2>
 
       <p>
-A public key is a <a href="#verification-methods">verification method</a>.
+A public key is a <a>verification method</a>.
 Public keys are used for digital signatures, encryption and other cryptographic
 operations, which in turn are the basis for purposes such as authentication
 (see Section <a href="#authentication"></a>) or establishing secure

--- a/index.html
+++ b/index.html
@@ -1336,8 +1336,9 @@ error.
 
       <p>
 The value of the <code>type</code> property MUST be exactly one verification
-method type. The verification method type SHOULD be registered in the
-[[DID-SPEC-REGISTRIES]] for maximum interoperability.
+method type. In order to maximize global interoperability, the 
+<a>verification method</a> type SHOULD be registered in the
+[[DID-SPEC-REGISTRIES]].
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1294,39 +1294,97 @@ match the <a>DID</a> that was resolved.
     </section>
 
     <section>
+      <h2>Verification Methods</h2>
+      <p>
+A <a>DID document</a> can express <a>verification methods</a>, such as
+cryptographic keys, which can be used to authenticate or authorize interactions
+with the <a>DID subject</a> or associated parties. The information expressed
+often includes globally unambiguous identifiers and public key material, which
+can be used to verify digital signatures. Other information can be expressed,
+such as attributes that enable one to determine whether it is a hardware-backed
+cryptographic key.
+      </p>
+
+      <p>
+A <a>DID document</a> MAY include a <code>verificationMethod</code> property.
+      </p>
+
+      <dl>
+        <dt><dfn>verificationMethod</dfn></dt>
+        <dd>
+If a <a>DID document</a> includes a <code>verificationMethod</code> property,
+the value of the property MUST be an array of verification method objects.
+Each verification method object MUST have the <code>id</code>, <code>type</code>,
+<code>controller</code>, and specific verification method properties. The
+verification method objects MAY include additional properties.
+        </dd>
+      </dl>
+
+      <p>
+The value of the <code>id</code> property MUST be a <a>URI</a>. The array of
+verification methods MUST NOT contain multiple entries with the same
+<code>id</code>. In this case, a <a>DID document</a> processor MUST produce an
+error.
+      </p>
+
+      <p>
+The value of the <code>type</code> property MUST be exactly one verification
+method type. The verification method type MUST be registered in the
+[[DID-SPEC-REGISTRIES]].
+      </p>
+
+      <p>
+The value of the <code>controller</code> property, MUST be a valid <a>DID</a>.
+      </p>
+
+      <p>
+The verification method properties MUST be registered in the [[DID-SPEC-REGISTRIES]].
+      </p>
+
+      <pre class="example" title="Example verification methods">
+{
+  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/v1"],
+  "id": "did:example:123456789abcdefghi",
+  <span class="comment">...</span>
+  "verificationMethod": [{
+    "id": <span class="comment">...</span>,
+    "type": <span class="comment">...</span>,
+    "controller": <span class="comment">...</span>,
+    <span class="comment">...</span>
+  ]}
+}
+      </pre>
+
+      <section>
+        <h3>Verification relationships</h3>
+
+        <p>
+A <dfn>verification relationship</dfn> expresses the relationship between the
+<a>DID subject</a> and a <a>verification method</a>.
+        </p>
+        <p>
+A <a>DID document</a> MAY include a property expressing a specific
+<a>verification relationship</a>. Such a property MUST be registered in
+[[DID-SPEC-REGISTRIES]].
+        </p>
+        <p>
+A <a>DID controller</a> MUST be explicit about the <a>verification
+relationship</a> between the DID subject and the <a>verification method</a>.
+<a href="#verification-methods"></a> that are not associated with a particular
+<a>verification relationship</a> MUST NOT be used for that <a>verification
+relationship</a>. See Section <a href="#authentication"></a> for a more
+detailed example of a <a>verification relationship</a>.
+        </p>
+
+      </section>
+
+    </section>
+
+    <section>
       <h2>Public Keys</h2>
 
       <p>
-A <a>DID document</a> can express cryptographic keys and other verification
-methods, which can be used to authenticate or authorize interactions with the
-<a>DID subject</a> or associated parties. The information expressed often
-includes globally unambiguous identifiers and public key material, which can be
-used to verify digital signatures. Other information can be expressed, such as
-attributes that enable one to determine whether it is a
-hardware-backed cryptographic key.
-      </p>
-
-      <p>
-Regarding cryptographic key material, public keys can be included in a
-<a>DID document</a> using, for example, the <code>publicKey</code> or
-<code>authentication</code> properties, depending on what they are to be used
-for. Each public key has an identifier (<code>id</code>) of its own, a
-<code>type</code>, and a <code>controller</code>, as well as other properties
-that depend on the type of key it is.
-      </p>
-
-      <p>
-This specification strives to limit the number of formats for expressing public
-key material in a DID Document to the fewest possible, to increase the
-likelihood of interoperability. The fewer formats that implementers have to
-implement, the more likely it will be that they will support all of them. This
-approach attempts to strike a delicate balance between ease of implementation
-and supporting formats that have historically had broad deployment. The specific
-types of key formats that are supported in this specification are listed below.
-      </p>
-
-      <p>
-A public key is a <a>verification method</a>.
+A public key is a <a href="#verification-methods">verification method</a>.
 Public keys are used for digital signatures, encryption and other cryptographic
 operations, which in turn are the basis for purposes such as authentication
 (see Section <a href="#authentication"></a>) or establishing secure
@@ -1336,20 +1394,21 @@ authorization mechanisms of <a>DID</a> method operations (see Section
 <a href="#method-operations"></a>), which can be defined by <a>DID method</a>
 specifications.
       </p>
-
-      <p class="note" title="Verification methods">
-A public key is just one type of <a>verification method</a>.  A <a>DID
-document</a> expresses the relationship between the <a>DID subject</a> and a
-<a>verification method</a> using a <dfn>verification relationship</dfn>.
-Examples of <a>verification relationship</a>s include:
-<code>authentication</code>, <code> capabilityInvocation</code>,
-<code>capabilityDelegation</code>, <code>keyAgreement</code>, and
-<code>assertionMethod</code>. A <a>DID controller</a> MUST be explicit about the
-<a>verification relationship</a> between the DID subject and the <a>verification
-method</a>. <a>Verification methods</a> that are not associated with a
-particular <a>verification relationship</a> MUST NOT be used for that
-<a>verification relationship</a>. See Section <a href="#authentication"></a>
-for a more detailed example of a <a>verification relationship</a>.
+      <p>
+Public keys can be included in a <a>DID document</a> using the
+<code>publicKey</code> or <code>authentication</code> properties, depending on
+what they are to be used for. Each public key has an identifier (<code>id</code>)
+of its own, a <code>type</code>, and a <code>controller</code>, as well as
+other properties that depend on the type of key it is.
+      </p>
+      <p>
+This specification strives to limit the number of formats for expressing public
+key material in a DID Document to the fewest possible, to increase the
+likelihood of interoperability. The fewer formats that implementers have to
+implement, the more likely it will be that they will support all of them. This
+approach attempts to strike a delicate balance between ease of implementation
+and supporting formats that have historically had broad deployment. The specific
+types of key formats that are supported in this specification are listed below.
       </p>
 
       <p>
@@ -1653,6 +1712,8 @@ themselves.
 
       <p>
 A <a>DID document</a> MAY include an <code>authentication</code> property.
+The <code>authentication</code> property is an example of a <a>verification
+relationship</a>.
       </p>
 
       <dl>

--- a/index.html
+++ b/index.html
@@ -1300,9 +1300,16 @@ A <a>DID document</a> can express <a>verification methods</a>, such as
 cryptographic keys, which can be used to authenticate or authorize interactions
 with the <a>DID subject</a> or associated parties. The information expressed
 often includes globally unambiguous identifiers and public key material, which
-can be used to verify digital signatures. Other information can be expressed,
-such as attributes that enable one to determine whether it is a hardware-backed
-cryptographic key.
+can be used to verify digital signatures. For example, a public key can be
+used as a verification method with respect to a digital signature; in such
+usage, it verifies that the signer possessed the associated private key.
+      </p>
+      <p>
+Verification methods might take many parameters. An example of this is a set
+of five cryptographic keys from which any three are required to contribute to
+a threshold signature. Methods need not be cryptographic. An example of this
+might be the contact information for a biometric service provider that compares
+a purported <a>DID controller</a> against a candidate biometric vector.
       </p>
 
       <p>
@@ -1360,7 +1367,7 @@ The verification method properties SHOULD be registered in the
         <h3>Verification relationships</h3>
 
         <p>
-A <dfn>verification relationship</dfn> expresses the relationship between the
+A <a>verification relationship</a> expresses the relationship between the
 <a>DID subject</a> and a <a>verification method</a>.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -1345,8 +1345,8 @@ The value of the <code>controller</code> property, MUST be a valid <a>DID</a>.
       </p>
 
       <p>
-The verification method properties SHOULD be registered in the
-[[DID-SPEC-REGISTRIES]] for maximum interoperability.
+In order to maximize global interoperability, the verification method properties 
+SHOULD be registered in the [[DID-SPEC-REGISTRIES]].
       </p>
 
       <pre class="example" title="Example verification methods">

--- a/index.html
+++ b/index.html
@@ -1372,8 +1372,8 @@ A <a>verification relationship</a> expresses the relationship between the
         </p>
         <p>
 A <a>DID document</a> MAY include a property expressing a specific
-<a>verification relationship</a>. Such a property SHOULD be registered in
-[[DID-SPEC-REGISTRIES]] for maximum interoperability.
+<a>verification relationship</a>. In order to maximize global interoperability, 
+the property SHOULD be registered in [[DID-SPEC-REGISTRIES]].
         </p>
         <p>
 A <a>DID controller</a> MUST be explicit about the <a>verification

--- a/index.html
+++ b/index.html
@@ -1378,7 +1378,7 @@ A <a>DID document</a> MAY include a property expressing a specific
         <p>
 A <a>DID controller</a> MUST be explicit about the <a>verification
 relationship</a> between the DID subject and the <a>verification method</a>.
-<a href="#verification-methods"></a> that are not associated with a particular
+<a>Verification methods</a> that are not associated with a particular
 <a>verification relationship</a> MUST NOT be used for that <a>verification
 relationship</a>. See Section <a href="#authentication"></a> for a more
 detailed example of a <a>verification relationship</a>.

--- a/index.html
+++ b/index.html
@@ -1329,8 +1329,8 @@ error.
 
       <p>
 The value of the <code>type</code> property MUST be exactly one verification
-method type. The verification method type MUST be registered in the
-[[DID-SPEC-REGISTRIES]].
+method type. The verification method type SHOULD be registered in the
+[[DID-SPEC-REGISTRIES]] for maximum interoperability.
       </p>
 
       <p>
@@ -1338,7 +1338,8 @@ The value of the <code>controller</code> property, MUST be a valid <a>DID</a>.
       </p>
 
       <p>
-The verification method properties MUST be registered in the [[DID-SPEC-REGISTRIES]].
+The verification method properties SHOULD be registered in the
+[[DID-SPEC-REGISTRIES]] for maximum interoperability.
       </p>
 
       <pre class="example" title="Example verification methods">
@@ -1364,8 +1365,8 @@ A <dfn>verification relationship</dfn> expresses the relationship between the
         </p>
         <p>
 A <a>DID document</a> MAY include a property expressing a specific
-<a>verification relationship</a>. Such a property MUST be registered in
-[[DID-SPEC-REGISTRIES]].
+<a>verification relationship</a>. Such a property SHOULD be registered in
+[[DID-SPEC-REGISTRIES]] for maximum interoperability.
         </p>
         <p>
 A <a>DID controller</a> MUST be explicit about the <a>verification

--- a/terms.html
+++ b/terms.html
@@ -183,7 +183,7 @@ the dereferenced resource indicated by the <a>DID URL</a>. The inputs and output
 process are defined in <a href="#did-url-dereferencing"></a>.
   </dd>
 
-  <dt><dfn data-lt"DID URL dereferencers">DID URL dereferencer</dfn></dt>
+  <dt><dfn data-lt="DID URL dereferencers">DID URL dereferencer</dfn></dt>
 
   <dd>
 A software and/or hardware system that is capable of executing the <a>DID URL dereferencing</a>
@@ -286,14 +286,18 @@ key for encryption. This guarantees the integrity of the key agreement process. 
 is thus another type of verification method, even though descriptions of the process
 might not use the words "verification" and "proof."
     </p>
+  </dd>
+
+  <dt><dfn data-lt="">verification relationship</dfn></dt>
+
+  <dd>
     <p>
-Verification methods might take many parameters. An example of this is a set of five
-cryptographic keys from which any three are required to contribute to a threshold signature. Methods
-need not be cryptographic. An example of this might be the contact information for a
-biometric service provider that compares a purported DID controller against a candidate
-biometric vector.
+A verification relationship expresses the relationship between the <a>DID
+subject</a> and a <a>verification method</a>. An example of a verification
+relationship is <a href="#authentication"></a>. 
     </p>
   </dd>
+
   <dt><dfn data-lt="UUID|UUIDs">Universally Unique Identifier</dfn> (UUID)</dt>
 
   <dd>


### PR DESCRIPTION
Adds verificationMethod as a DID document property, fixing #283. 

Also removes undefined terms that are verification relationships - which fixes #272 - replacing them with links to the DID Spec Registries, until such a time as (if ever) they are defined as top level properties in DID Core.

**WIP!** Needs input:

* The contents of the verificationMethod example please, it's blank right now.
* I essentially copied the definitions for the property from publicKey. I also created a "verification relationships" subsection to express some of what was in a NOTE in the publicKey section. I'd appreciate close review and corrections to this because I'm not sure if it's all accurate.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/304.html" title="Last updated on Jun 5, 2020, 5:09 AM UTC (cc9cd77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/304/490cccb...cc9cd77.html" title="Last updated on Jun 5, 2020, 5:09 AM UTC (cc9cd77)">Diff</a>