### PR TITLE
Add DID parameter examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -930,6 +930,19 @@ Additional considerations for processing these parameters are discussed in
         </p>
 
         <p>
+Two example <a>DID URLs</a> using the <code>service</code> and
+<code>version-time</code> generic DID parameters are shown below.
+        </p>
+
+        <pre class="example nohighlight" title="A DID URL with a 'service' DID parameter">
+did:foo:21tDAKCERh95uGgKbJNHYp?service=agent
+        </pre>
+
+        <pre class="example nohighlight" title="A DID URL with a 'version-time' DID parameter">
+did:foo:21tDAKCERh95uGgKbJNHYp?version-time=2002-10-10T17:00:00Z
+        </pre>
+
+        <p>
 Adding a DID parameter to a <a>DID URL</a> means that the parameter becomes part
 of an identifier for a <a>resource</a> (the <a>DID document</a> or other).
 Alternatively, the <a>DID resolution</a> and the <a>DID URL dereferencing</a>


### PR DESCRIPTION
During the various discussions around matrix vs. query parameter syntax, it was mentioned that while there are a lot of examples of [Method-Specific DID URL Parameters](https://w3c.github.io/did-core/#method-specific-did-url-parameters), there are currently no examples of [Generic DID URL Parameters](https://w3c.github.io/did-core/#generic-did-url-parameters). This PR adds two such examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 1, 2020, 2:08 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fdid-core%2Fc30934765f9b176293ca1100a48a3ab9ddfd7062%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 522:[39m [36mhttps://rawcdn.githack.com/w3c/did-core/c30934765f9b176293ca1100a48a3ab9ddfd7062/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-core%23306.)._
</details>
