### PR TITLE
Replace RsaVerificationKey2018 examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -3235,14 +3235,9 @@ A future-facing real-world context is provided below:
 
   "publicKey": [{
     "id": "did:example:123456789abcdefghi#keys-1",
-    "type": "JwsVerificationKey2020",
+    "type": "Ed25519VerificationKey2018",
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyJwk": {
-      "crv": "Ed25519",
-      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
-      "kty": "OKP",
-      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
-    }
+    "publicKeyBase58": "DggG1kT5JEFwTC6RJTsT6VQPgCz1qszCkX5Lv4nun98x"
 
   }, {
     "id": "did:example:123456789abcdefghi#keys-3",

--- a/index.html
+++ b/index.html
@@ -334,9 +334,9 @@ well as services that can be used to interact with the <a>DID subject</a>.
   "authentication": [{
     <span class="comment">// used to authenticate as did:...fghi</span>
     "id": "did:example:123456789abcdefghi#keys-1",
-    "type": "RsaVerificationKey2018",
+    "type": "Ed25519VerificationKey2018",
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
   }],
   "service": [{
     <span class="comment">// used to retrieve Verifiable Credentials associated with the DID</span>
@@ -1141,9 +1141,9 @@ tend to be more verbose than necessary.
   "id": "did:example:123456789abcdefghi",
   "publicKey": [{
     "id": "did:example:123456789abcdefghi#key-1",
-    "type": "RsaVerificationKey2018",
+    "type": "Ed25519VerificationKey2018",
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
   }, ...],
   "authentication": [
 <span class="comment">    // a relative DID URL used to reference a verification method above</span>
@@ -1533,16 +1533,11 @@ Example:
     }
   }, {
     "id": "did:example:123456789abcdefghi#keys-1",
-    "type": "RsaVerificationKey2018",
-    "controller": "did:example:123456789abcdefghi",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
-  }, {
-    "id": "did:example:123456789abcdefghi#keys-2",
     "type": "Ed25519VerificationKey2018",
     "controller": "did:example:pqrstuvwxyz0987654321",
     "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
   }, {
-    "id": "did:example:123456789abcdefghi#keys-3",
+    "id": "did:example:123456789abcdefghi#keys-2",
     "type": "Secp256k1VerificationKey2018",
     "controller": "did:example:123456789abcdefghi",
     "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"
@@ -3240,9 +3235,15 @@ A future-facing real-world context is provided below:
 
   "publicKey": [{
     "id": "did:example:123456789abcdefghi#keys-1",
-    "type": "RsaVerificationKey2018",
+    "type": "JwsVerificationKey2020",
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyPem": "-----BEGIN PUBLIC KEY...END PUBLIC KEY-----\r\n"
+    "publicKeyJwk": {
+      "crv": "Ed25519",
+      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+      "kty": "OKP",
+      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
+    }
+
   }, {
     "id": "did:example:123456789abcdefghi#keys-3",
     "type": "Ieee2410VerificationKey2018",


### PR DESCRIPTION
Replaced with `Ed25519VerificationKey2018` examples. Should close issues #9 and #10.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/307.html" title="Last updated on Jun 1, 2020, 6:45 PM UTC (db1a03a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/307/490cccb...db1a03a.html" title="Last updated on Jun 1, 2020, 6:45 PM UTC (db1a03a)">Diff</a>