### PR TITLE
Fix typos.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1418,6 +1418,7 @@ authorization mechanisms of <a>DID</a> method operations (see Section
 <a href="#method-operations"></a>), which can be defined by <a>DID method</a>
 specifications.
       </p>
+
       <p>
 Public keys can be included in a <a>DID document</a> using the
 <code>publicKey</code> or <code>authentication</code> properties, depending on
@@ -1425,6 +1426,7 @@ what they are to be used for. Each public key has an identifier (<code>id</code>
 of its own, a <code>type</code>, and a <code>controller</code>, as well as
 other properties that depend on the type of key it is.
       </p>
+
       <p>
 This specification strives to limit the number of formats for expressing public
 key material in a DID Document to the fewest possible, to increase the

--- a/index.html
+++ b/index.html
@@ -1014,7 +1014,7 @@ any order.
         </p>
 
         <pre class="example nohighlight">
-did:example:21tDAKCERh95uGgKbJNHYp?service=agent&foo:bar=high
+did:example:21tDAKCERh95uGgKbJNHYp?service=agent&amp;foo:bar=high
         </pre>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -575,9 +575,8 @@ and its associated <a>DID document</a> are created, resolved, updated, and
 deactivated using a particular <a>verifiable data registry</a>. <a>DID
 methods</a> are defined using separate DID method specifications (see
 <a href="#methods"></a>).
-        </dd>
 
-        <p class="note">
+          <p class="note">
 Conceptually, the relationship between this specification and a <a>DID
 method</a> specification is similar to the relationship between the IETF generic
 <a>URI</a> specification ([[RFC3986]]) and a specific <a>URI</a> scheme
@@ -589,7 +588,8 @@ a DID method specification, as well as defining a specific DID scheme, also
 specifies the methods creating, resolving, updating, and deactivating
 <a>DIDs</a> and <a>DID documents</a> using a specific type of <a>verifiable data
 registry</a>.
-        </p>
+          </p>
+        </dd>
 
         <dt>
 DID resolvers and DID resolution

--- a/index.html
+++ b/index.html
@@ -615,6 +615,7 @@ The inputs and outputs of the DID URL dereferencing process are defined in <a
 href="#did-url-dereferencing"></a>. Additional considerations for implementing a
 DID URL dereferencer are discussed in [[DID-RESOLUTION]].
         </dd>
+      </dl>
 
     </section>
 
@@ -2669,7 +2670,6 @@ data compromise, unsolicited traffic, misattribution, correlation,
 identification, secondary use, disclosure, exclusion.
       </p>
     </section>
-  </section>
   </section>
 
   <section class='normative'>

--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@ numbers, email addresses, usernames on social media), ID numbers (for passports,
 drivers licenses, tax IDs, health insurance), and product identifiers (serial
 numbers, barcodes, RFIDs). Resources on the Internet are identified by globally
 unique identifiers in the form of <abbr title="Media Access Control">MAC</abbr>
-addresses; URIs (Uniform Resource Identfiers) are used for resources on the Web
+addresses; URIs (Uniform Resource Identifiers) are used for resources on the Web
 and each web page you view in a browser has a globally unique URL (Uniform
 Resource Locator).
     </p>

--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@ Resource Locator).
 The vast majority of these globally unique identifiers are not under our
 control. They are issued by external authorities that decide who or what they
 identify and when they can be revoked. They are useful only in certain contexts
-and recognised only by certain bodies (not of our choosing). They may disappear
+and recognized only by certain bodies (not of our choosing). They may disappear
 or cease to be valid with the failure of an organization. They may unnecessarily
 reveal personal information. And in many cases they can be fraudulently
 replicated and asserted by a malicious third-party ("identity theft").


### PR DESCRIPTION
- Some various small fixes.
- I *think* the note after "DID Methods" is supposed to be inside that `dd`?  It's invalid markup when up a level as a `dl` child.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/did-core/pull/310.html" title="Last updated on Jun 8, 2020, 3:26 AM UTC (e7b838a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/310/948d850...davidlehn:e7b838a.html" title="Last updated on Jun 8, 2020, 3:26 AM UTC (e7b838a)">Diff</a>