### PR TITLE
Move Future Work section to implementation guide.

### DIFF
--- a/index.html
+++ b/index.html
@@ -810,8 +810,7 @@ Although not included in this version, future versions of this specification
 might support a <a>DID document</a> <code>equivID</code> property to establish
 verifiable equivalence relations between <a>DIDs</a> representing the same
 subject on multiple <a>verifiable data registries</a>. Such equivalence relations can
-produce the practical equivalent of a single persistent abstract <a>DID</a>. For
-more information, see Section <a href="#future-work"></a>.
+produce the practical equivalent of a single persistent abstract <a>DID</a>.
         </p>
       </section>
     </section>
@@ -3356,8 +3355,7 @@ specifications will recognize control from <a>DIDs</a> registered using other
 that use the same method. Access control and key recovery in a <a>DID method</a>
 specification can also include a time lock feature to protect against key
 compromise by maintaining a second track of control for recovery. Further
-specification of this type of control is a matter for future work (see Section
-<a href="#time-locks-and-did-document-recovery"></a>).
+specification of this type of control is a matter for future work.
 </p>
     </section>
 
@@ -3780,136 +3778,6 @@ result in changes to this specification.
     <div class="issue" data-number="300">Define resolution function with data types, property values, and full metadata structures, without transformation</div>
 
   </section>
-
-  <section class="appendix">
-    <h1>
-Future Work
-    </h1>
-
-    <section>
-      <h2>
-Upper Limits on DID Character Length
-      </h2>
-
-      <p>
-The current specification does not take a position on maximum length of a
-<a>DID</a>. The maximum interoperable URL length is currently about 2K
-characters. QR codes can handle about 4K characters. Clients using <a>DIDs</a>
-will be responsible for storing many <a>DIDs</a>, and some methods would be able
-to externalize some of their costs onto clients by relying on more complicated
-signature schemes or by adding state into <a>DIDs</a> intended for temporary
-use. A future version of this specification should set reasonable limits on
-<a>DID</a> character length to minimize externalities.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Equivalence
-      </h2>
-
-      <p>
-Including an equivalence property, such as <code>equivID</code>, in <a>DID
-documents</a> whose value is an array of <a>DIDs</a> would allow subjects to
-assert two or more <a>DIDs</a> that represent the same subject. This capability
-has numerous uses, including supporting migration between <a>verifiable data
-registries</a> and providing forward compatibility of existing <a>DIDs</a> to
-future <a>verifiable data registries</a>. In theory, equivalent <a>DIDs</a>
-should have the same identifier rights, allowing verifiable credentials
-[[?VC-DATA-MODEL]] made against one <a>DID</a> to apply to equivalent
-<a>DIDs</a>. Equivalence was not included in the current specification due to
-the complexity of verifying equivalence across different <a>DLTs</a> and
-different <a>DID methods</a>, and also of aggregating properties of equivalent
-<a>DID documents</a>. However equivalence should be supported in a future
-version of this specification.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Verifiable Timestamps
-      </h2>
-
-      <p>
-<a>Verifiable timestamps</a> have significant utility for identifier records.
-This is a good fit for <a>DLTs</a>, since most offer some type of timestamp
-mechanism. Despite some transactional cost, they are the among the most
-censorship-resistant transaction ordering systems at the present, so they are
-nearly ideal for <a>DID document</a> timestamping. In some cases a <a>DLT</a>'s
-immediate timing is approximate, however their sense of
-<a href="https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki%23Abstract">
-"median time past" (see Bitcoin BIP 113)</a> can be precisely defined. A generic
-<a>DID document</a> timestamping mechanism could would work across all
-<a>DLTs</a> and might operate via a mechanism including either individual
-transactions or transaction batches. The generic mechanism was deemed out of
-scope for this version, although it may be included in a future version of this
-specification.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Time Locks and DID Document Recovery
-      </h2>
-
-      <p>
-Section <a href="#key-revocation-and-recovery"></a> mentions one possible clever
-use of time locks to recover control of a <a>DID</a> after a key compromise. The
-technique relies on an ability to override the most recent update to a <a>DID
-document</a> with Authorization applied by an earlier version of the <a>DID
-document</a> in order to defeat the attacker. This protection depends on adding
-a <a href="https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki%23Abstract">
-time lock (see Bitcoin BIP 65)</a> to protect part of the transaction chain,
-enabling a Authorization block to be used to recover control. We plan to add
-support for time locks in a future version of this specification.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Smart Signatures
-      </h2>
-
-      <p>
-Not all <a>DLTs</a> can support the Authorization logic in section <a
-href="#authorization-and-delegation"></a>. Therefore, in this version of the
-specification, all Authorization logic is delegated to <a>DID method</a>
-specifications. A potential future solution is a <a
-href="http://www.weboftrust.info/downloads/smart-signatures.pdf">Smart
-Signature</a> specification that specifies the code any conformant <a>DLT</a>
-may implement to process signature control logic.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Verifiable Credentials
-      </h2>
-
-      <p>
-Although <a>DIDs</a> and <a>DID documents</a> form a foundation for
-decentralized identity, they are only the first step in describing their
-subjects. The rest of the descriptive power comes through collecting and
-selectively using Verifiable Credentials [[VC-DATA-MODEL]]. Future versions of
-the specification will describe in more detail how <a>DIDs</a> and <a>DID
-document</a> can be integrated with &mdash; and help enable &mdash; the
-Verifiable Credentials ecosystem.
-      </p>
-    </section>
-
-    <section>
-      <h2>
-Alternate Serializations and Graph Models
-      </h2>
-
-      <p>
-This version of the specification relies on JSON-LD and the RDF graph
-model for expressing a <a>DID document</a>. Future versions of this
-specification might specify other semantic graph formats for a <a>DID
-document</a>.
-      </p>
-    </section>
-</section>
 
 <section class="appendix">
     <h1>


### PR DESCRIPTION
This PR moves the Future Work section to the implementation guide. All text has been migrated here: 

https://w3c.github.io/did-imp-guide/#future-work