### PR TITLE
Remove interop registries appendix.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3598,18 +3598,6 @@ standard lengths.
 
   <section class="appendix">
     <h1>
-Interoperability Registries
-    </h1>
-
-    <p>
-The registries that list <a>DID methods</a> and extensions to this
-specification can be found in [[DID-SPEC-REGISTRIES]].
-    </p>
-
-  </section>
-
-  <section class="appendix">
-    <h1>
 Real World Example
     </h1>
 


### PR DESCRIPTION
Remove the interop registries appendix as we refer to the registries throughout the document now and the appendix duplicates content earlier in the specification as well as in the section on interop. 