### PR TITLE
Put all term dfns in terms.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,13 +651,13 @@ implementations of a given DID method must be interoperable for that method).
       </p>
 
      <p>
-A <a>conforming DID</a> is any concrete expression of the rules specified in
+A <dfn>conforming DID</dfn> is any concrete expression of the rules specified in
 Section <a href="#identifier"></a> and MUST comply with relevant normative
 statements in that section.
      </p>
 
       <p>
-A <a>conforming DID document</a> is any concrete expression of the data
+A <dfn>conforming DID document</dfn> is any concrete expression of the data
 model described in this specification and MUST comply with the relevant
 normative statements in Sections <a href="#data-model"></a> and  <a
 href="#core-properties"></a>. A serialization format for the conforming document
@@ -667,21 +667,21 @@ transmitted or stored in any such serialization format.
       </p>
 
       <p>
-A <a>conforming DID method</a> is any specification that complies with the
+A <dfn>conforming DID method</dfn> is any specification that complies with the
 relevant normative statements in Section <a href="#methods"></a>.
       </p>
 
       <p>
-A <a>conforming producer</a> is any algorithm realized as software and/or
+A <dfn>conforming producer</dfn> is any algorithm realized as software and/or
 hardware and conforms to this specification if it generates <a>conforming
-DID</a>s or <a>conforming DID Document</a>s. A <a>conforming producer</a> MUST
+DID</a>s or <a>conforming DID Document</a>s. A conforming producer MUST
 NOT produce non-conforming <a>DIDs</a> or <a>DID documents</a>.
       </p>
 
       <p>
-A <a>conforming consumer</a> is any algorithm realized as software and/or
+A <dfn>conforming consumer</dfn> is any algorithm realized as software and/or
 hardware and conforms to this specification if it consumes <a>conforming
-DID</a>s or <a>conforming DID document</a>s. A <a>conforming consumer</a> MUST
+DID</a>s or <a>conforming DID document</a>s. A conforming consumer MUST
 produce errors when consuming non-conforming <a>DIDs</a> or <a>DID documents</a>.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -651,13 +651,13 @@ implementations of a given DID method must be interoperable for that method).
       </p>
 
      <p>
-A <dfn>conforming DID</dfn> is any concrete expression of the rules specified in
+A <a>conforming DID</a> is any concrete expression of the rules specified in
 Section <a href="#identifier"></a> and MUST comply with relevant normative
 statements in that section.
      </p>
 
       <p>
-A <dfn>conforming DID Document</dfn> is any concrete expression of the data
+A <a>conforming DID document</a> is any concrete expression of the data
 model described in this specification and MUST comply with the relevant
 normative statements in Sections <a href="#data-model"></a> and  <a
 href="#core-properties"></a>. A serialization format for the conforming document
@@ -667,24 +667,22 @@ transmitted or stored in any such serialization format.
       </p>
 
       <p>
-A <dfn>conforming DID Method</dfn> is any specification that complies with the
+A <a>conforming DID method</a> is any specification that complies with the
 relevant normative statements in Section <a href="#methods"></a>.
       </p>
 
       <p>
-A <dfn>producer</dfn> is any algorithm realized as software and/or hardware and
-conforms to this specification if it generates <a>conforming DID</a>s or
-<a>conforming DID Document</a>s. A <a>producer</a> that is conformant with this
-specification MUST NOT produce non-conforming <a>DIDs</a> or <a>DID
-Documents</a>.
+A <a>conforming producer</a> is any algorithm realized as software and/or
+hardware and conforms to this specification if it generates <a>conforming
+DID</a>s or <a>conforming DID Document</a>s. A <a>conforming producer</a> MUST
+NOT produce non-conforming <a>DIDs</a> or <a>DID documents</a>.
       </p>
 
       <p>
-A <dfn>consumer</dfn> is any algorithm realized as software and/or hardware and
-conforms to this specification if it consumes <a>conforming DID</a>s or
-<a>conforming DID Document</a>s. A <a>consumer</a> that is conformant with this
-specification MUST produce errors when consuming non-conforming <a>DIDs</a> or
-<a>DID Documents</a>.
+A <a>conforming consumer</a> is any algorithm realized as software and/or
+hardware and conforms to this specification if it consumes <a>conforming
+DID</a>s or <a>conforming DID document</a>s. A <a>conforming consumer</a> MUST
+produce errors when consuming non-conforming <a>DIDs</a> or <a>DID documents</a>.
       </p>
 
     </section>
@@ -1292,7 +1290,7 @@ it is the entity identified by the <a>DID</a> and described by the
       </p>
 
       <dl>
-        <dt><dfn>id</dfn></dt>
+        <dt>id</dt>
         <dd>
 The value of <code>id</code> MUST be a single valid <a>DID</a>.
         </dd>
@@ -1338,7 +1336,7 @@ A <a>DID document</a> MAY include a <code>verificationMethod</code> property.
       </p>
 
       <dl>
-        <dt><dfn>verificationMethod</dfn></dt>
+        <dt>verificationMethod</dt>
         <dd>
 If a <a>DID document</a> includes a <code>verificationMethod</code> property,
 the value of the property MUST be an array of verification method objects.
@@ -1449,7 +1447,7 @@ A <a>DID document</a> MAY include a <code>publicKey</code> property.
       </p>
 
       <dl>
-        <dt><dfn>publicKey</dfn></dt>
+        <dt>publicKey</dt>
         <dd>
 If a <a>DID document</a> includes a <code>publicKey</code> property, the value
 of the property MUST be an array of public key objects. Each public key object
@@ -1743,7 +1741,7 @@ relationship</a>.
       </p>
 
       <dl>
-          <dt><dfn>authentication</dfn></dt>
+          <dt>authentication</dt>
           <dd>
 The <code>authentication</code> property is a relationship between the <a>DID
 subject</a> and a set of verification methods (such as, but not limited to,
@@ -1835,7 +1833,7 @@ If so:
       </p>
 
       <dl>
-          <dt><dfn>controller</dfn></dt>
+          <dt>controller</dt>
           <dd>
 The value of the <code>controller</code> property MUST be a valid <a>DID</a>
 or an array of valid <a>DIDs</a>. The corresponding <a>DID document</a>(s)
@@ -1918,7 +1916,7 @@ A <a>DID document</a> MAY include a <code>service</code> property.
       </p>
 
       <dl>
-        <dt><dfn>service</dfn></dt>
+        <dt>service</dt>
         <dd>
 If a <a>DID document</a> includes a <code>service</code> property, the value of
 the property SHOULD be an array of <a>service endpoint</a> objects. Each
@@ -2009,7 +2007,7 @@ A <a>DID document</a> SHOULD include a <code>created</code> property.
       </p>
 
       <dl>
-          <dt><dfn>created</dfn></dt>
+          <dt>created</dt>
           <dd>
 If a <a>DID document</a> includes a <code>created</code> property, the value of
 the property MUST be a valid XML datetime value, as defined in section 3.3.7 of
@@ -2039,7 +2037,7 @@ A <a>DID document</a> SHOULD include an <code>updated</code> property.
       </p>
 
       <dl>
-          <dt><dfn>updated</dfn></dt>
+          <dt>updated</dt>
           <dd>
 If a <a>DID document</a> includes an <code>updated</code> property, the value of
 the property MUST follow the same formatting rules as the <code>created</code>

--- a/terms.html
+++ b/terms.html
@@ -32,41 +32,6 @@ A concrete mechanism through which a caller invokes a <a>DID resolver</a> or a
 software library, or a network call such as an HTTPS request.
   </dd>
 
-  <dt><dfn>conforming DID</dfn></dt>
-  <dd>
-Any concrete expression of the rules specified for the formal syntax of a
-<a>DID</a>, compliant with the relevant normative statements.
-  </dd>
-
-  <dt><dfn>conforming DID document</dfn></dt>
-  <dd>
-Any concrete expression of the data model described in the
-<a href="https://w3.org/TR/did-core">DID Core specification</a>, compliant
-with the relevant normative statements for the data model, core properties,
-and representations.
-  </dd>
-
-  <dt><dfn>conforming DID method</dfn></dt>
-  <dd>
-Any specification that complies with the relevant normative statements in the
-<a href="https://w3.org/TR/did-core">DID Core specification</a> regarding
-<a>DID methods</a>.
-  </dd>
-
-  <dt><dfn>conforming consumer</dfn></dt>
-  <dd>
-Any algorithm realized as software and/or hardware that consumes <a>conforming
-DID</a>s or <a>conforming DID document</a>s, and produces errors when
-consuming non-conforming <a>DIDs</a> or <a>DID documents</a>.
-  </dd>
-
-  <dt><dfn>conforming producer</dfn></dt>
-  <dd>
-Any algorithm realized as software and/or hardware that generates <a>conforming
-DID</a>s or <a>conforming DID Document</a>s, and which does not produce
-non-conforming <a>DIDs</a> or <a>DID documents</a>.
-  </dd>
-
   <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn> (DID)</dt>
 
   <dd>
@@ -187,7 +152,7 @@ in <a href="#did-resolution"></a>.
 
   <dd>
 A <a>DID resolver</a> is a software and/or hardware component that takes
-a <a>DID</a> as input and produces a <a>conforming DID document</a> as
+a <a>DID</a> as input and produces a conforming <a>DID document</a> as
 output by performing <a>DID resolution</a>.
   </dd>
 

--- a/terms.html
+++ b/terms.html
@@ -7,6 +7,13 @@ the document to aid the reader:
 
 <dl class="termlist">
 
+  <dt><dfn>authentication</dfn></dt>
+  <dd>
+Authentication is a mechanism by which an entity can prove it is the <a>DID
+subject</a>, using one or more of a set of verification methods (such as, but
+not limited to, public keys).
+  </dd>
+
   <dt><dfn data-lt="blockchains|blockchain technology">blockchain</dfn></dt>
 
   <dd>
@@ -25,14 +32,49 @@ A concrete mechanism through which a caller invokes a <a>DID resolver</a> or a
 software library, or a network call such as an HTTPS request.
   </dd>
 
+  <dt><dfn>conforming DID</dfn></dt>
+  <dd>
+Any concrete expression of the rules specified for the formal syntax of a
+<a>DID</a>, compliant with the relevant normative statements.
+  </dd>
+
+  <dt><dfn>conforming DID document</dfn></dt>
+  <dd>
+Any concrete expression of the data model described in the
+<a href="https://w3.org/TR/did-core">DID Core specification</a>, compliant
+with the relevant normative statements for the data model, core properties,
+and representations.
+  </dd>
+
+  <dt><dfn>conforming DID method</dfn></dt>
+  <dd>
+Any specification that complies with the relevant normative statements in the
+<a href="https://w3.org/TR/did-core">DID Core specification</a> regarding
+<a>DID methods</a>.
+  </dd>
+
+  <dt><dfn>conforming consumer</dfn></dt>
+  <dd>
+Any algorithm realized as software and/or hardware that consumes <a>conforming
+DID</a>s or <a>conforming DID document</a>s, and produces errors when
+consuming non-conforming <a>DIDs</a> or <a>DID documents</a>.
+  </dd>
+
+  <dt><dfn>conforming producer</dfn></dt>
+  <dd>
+Any algorithm realized as software and/or hardware that generates <a>conforming
+DID</a>s or <a>conforming DID Document</a>s, and which does not produce
+non-conforming <a>DIDs</a> or <a>DID documents</a>.
+  </dd>
+
   <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn> (DID)</dt>
 
   <dd>
 A globally unique identifier that does not require a centralized registration
 authority because it is registered with <a>distributed ledger technology</a>
 (DLT) or other form of decentralized network. The generic format of a DID is
-defined in this specification. A specific <a>DID scheme</a> is defined in a
-<a>DID method</a> specification.
+defined in the <a href="https://w3.org/TR/did-core">DID Core specification</a>.
+A specific <a>DID scheme</a> is defined in a <a>DID method</a> specification.
   </dd>
 
   <dt><dfn>decentralized identity management</dfn></dt>
@@ -55,7 +97,7 @@ records (for example, <a>DID documents</a>) containing verifiable
 <a>public key descriptions</a>.
   </dd>
 
-  <dt><dfn data-lt="did controllers|did controller(s)">DID controller</dfn></dt>
+  <dt><dfn data-lt="did controllers|did controller(s)|controller">DID controller</dfn></dt>
 
   <dd>
 The entity that has the ability to make changes to a <a>DID document</a>.
@@ -153,8 +195,9 @@ output by performing <a>DID resolution</a>.
 
   <dd>
 The formal syntax of a <a>decentralized identifier</a>. The generic DID scheme
-is defined in this specification. Separate <a>DID method</a> specifications
-define a specific DID scheme that works with that specific <a>DID method</a>.
+is defined in the <a href="https://w3.org/TR/did-core">DID Core specification</a>.
+Separate <a>DID method</a> specifications define a specific DID scheme that
+works with that specific <a>DID method</a>.
   </dd>
 
   <dt><dfn data-lt="DID subjects">DID subject</dfn></dt>
@@ -238,19 +281,25 @@ metadata necessary to use a public key or verification key.
   <dd>
 The term resource is used in the same way as defined for HTTP in [[RFC7231]];
 that is, a resource is the target of a request and is identified by a URI.
-This specification does not limit the nature of a resource, but defines an
-interface that might be used to interact with resources when identified by
-a <a>DID</a>.
+The <a href="https://w3.org/TR/did-core">DID Core specification</a> does not
+limit the nature of a resource, but defines an interface that might be used to
+interact with resources when identified by a <a>DID</a>.
+  </dd>
+
+  <dt><dfn>service</dfn></dt>
+  <dd>
+Services provide ways of communicating or interacting with the <a>DID
+subject</a> or associated entities. Examples of specific services include
+discovery services, social networks, file storage services, and verifiable
+claim repository services.
   </dd>
 
   <dt><dfn data-lt="service endpoints">service endpoint</dfn></dt>
 
   <dd>
-A network address at which a service operates on behalf of a <a>DID subject</a>.
-Examples of specific services include discovery services, social networks, file
-storage services, and verifiable claim repository services. Service endpoints
-might also be provided by a generalized data interchange protocol, such as
-<a>extensible data interchange</a>.
+A network address at which a <a>service</a> operates on behalf of a <a>DID
+subject</a>. Service endpoints might also be provided by a generalized data
+interchange protocol, such as <a>extensible data interchange</a>.
   </dd>
 
   <dt><dfn data-lt="URI|URIs">Uniform Resource Identifier</dfn> (URI)</dt>
@@ -295,7 +344,7 @@ might not use the words "verification" and "proof."
     <p>
 A verification relationship expresses the relationship between the <a>DID
 subject</a> and a <a>verification method</a>. An example of a verification
-relationship is <a href="#authentication"></a>. 
+relationship is <a href="#authentication"></a>.
     </p>
   </dd>
 


### PR DESCRIPTION
Also replaces references to 'this specification' in the terms file with 'the DID Core specification' (and a link), for when the terms file is included elsewhere (ie. use cases).

Fixes #311.