### PR TITLE
Allow resolve() to return abstract DID document (option 1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3013,7 +3013,7 @@ implementations MUST implement a function which has the following abstract form:
 
         <p><code>
 resolve ( did, did-resolution-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document, did-document-metadata )
         </code></p>
 
         <p>
@@ -3055,19 +3055,15 @@ REQUIRED and MUST NOT be empty. This metadata typically changes between
 invocations of the <code>resolve</code> function as it represents data about the
 resolution process itself.
 Properties defined by this specification are in <a href="#did-resolution-metadata-properties"></a>.
-If the resolution is successful, this structure MUST contain a <code>content-type</code> property containing the mime-type <a>representation</a> of the <code>did-document-stream</code> in this result.
 If the resolution is not successful, this structure MUST contain an <code>error</code> property describing the error.
             </dd>
             <dt>
-did-document-stream
+did-document
             </dt>
             <dd>
-If the resolution is successful, this MUST be a byte stream of the resolved
-<a>DID document</a> in one of the conformant <a href="#representations">representations</a>. The byte
-stream MAY then be parsed by the caller of the <code>resolve</code> function
-into a <a>DID document</a> abstract data model, which can in turn be validated
-and processed. If the resolution is unsuccessful, this value MUST be an empty
-stream.
+If the resolution is successful, this MUST be a <a>DID document</a> conforming to
+the abstract data model, which can be validated and processed.
+If the resolution is unsuccessful, this value MUST be empty.
             </dd>
             <dt>
 did-document-metadata
@@ -3076,7 +3072,7 @@ did-document-metadata
 If the resolution is successful, this MUST be a <a
 href="metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>did-document-stream</code>. This metadata typically does not change
+<code>did-document</code> output variable. This metadata typically does not change
 between invocations of the <code>resolve</code> function unless the <a>DID
 document</a> changes, as it represents data about the <a>DID document</a>. If
 the resolution is unsuccessful, this output MUST be an empty <a
@@ -3102,19 +3098,7 @@ DID Resolution Input Metadata Properties
             
             <p>
 The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
-This specification defines the following common properties.
             </p>
-            
-            <dl>
-                <dt>
-accept
-                </dt>
-                <dd>
-The MIME type of the caller's preferred representation of the <a>DID document</a>. The <a>DID resolver</a> implementation 
-MAY use this value to determine the representation contained in the returned <code>did-document-stream</code> if such
-a representation is supported and available. This property is OPTIONAL.
-                </dd>
-            </dl>
         </section>
 
         <section>
@@ -3128,16 +3112,6 @@ This specification defines the following common properties.
             </p>
 
             <dl>
-                <dt>
-content-type
-                </dt>
-                <dd>
-The mime-type of the returned conformant representation of the contained in the returned <code>did-document-stream</code>.
-This property is REQUIRED if resolution is successful and a <code>did-document-stream</code> is returned. 
-The caller of the <code>resolve</code> function MUST use this value when determining how to
-parse and process the <code>did-document-stream</code> returned by this function into a
-<a>DID document</a> abstract data model.
-                </dd>
                 <dt>
 error
                 </dt>
@@ -3193,6 +3167,180 @@ This specification defines the following common properties.
         <h2>
 DID URL Dereferencing
         </h2>
+        <p>
+The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into content
+identified by that <a>DID URL</a>. This content MAY be a <a>DID document</a>, a
+portion of a <a>DID document</a>, a service endpoint, or some other data. The details of the implementation of this function
+are outside the scope of this specification, but all implementations MUST implement
+a function which has the following abstract form:
+        </p>
+
+        <p><code>
+dereference ( did-url, did-dereference-input-metadata ) <br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereference-metadata, content-stream, did-document-metadata )
+        </code></p>
+
+        <p>
+The input variables of this function MUST be as follows:
+        </p>
+
+        <dl>
+            <dt>
+did-url
+            </dt>
+            <dd>
+A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to dereference.
+This input is REQUIRED.
+            </dd>
+            <dt>
+did-url-dereference-input-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of input
+options to the <code>dereference</code> function in addition to the <code>did-url</code>
+itself.
+Properties defined by this specification are in <a href="#did-url-dereferencing-input-metadata-properties"></a>.
+This input is REQUIRED, but the structure MAY be empty.
+            </dd>
+        </dl>
+
+        <p>
+The output variables of this function MUST be as follows:
+        </p>
+
+        <dl>
+            <dt>
+did-url-dereference-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of values
+relating to the results of the <a>DID URL dereferencing</a> process. This structure is
+REQUIRED and MUST NOT be empty. This metadata typically changes between
+invocations of the <code>dereference</code> function as it represents data about the
+dereferencing process itself.
+Properties defined by this specification are in <a href="#did-url-dereferencing-metadata-properties"></a>.
+If the resolution is successful, this structure MUST contain a <code>content-type</code> property containing the mime-type of the <code>did-document-stream</code> in this result.
+If the resolution is not successful, this structure MUST contain an <code>error</code> property describing the error.
+            </dd>
+            <dt>
+content-stream
+            </dt>
+            <dd>
+If the dereferencing is successful, this MUST be a byte stream of the dereferenced
+content. The content MAY be a <a>DID document</a> in one of the conformant
+<a href="#core-representations">representations</a>. In this case, the byte
+stream MAY then be parsed by the caller of the <code>dereference</code> function
+into a <a>DID document</a> abstract data model, which can in turn be validated
+and processed. If the dereferencing is unsuccessful, this value MUST be an empty
+stream.
+            </dd>
+            <dt>
+did-document-metadata
+            </dt>
+            <dd>
+If the dereferencing is successful and the dereferenced content is a
+<a>DID document</a>, this MUST be a <a href="metadata-structure">metadata
+structure</a>. This structure contains
+metadata about the <a>DID document</a> contained in the
+<code>content-stream</code> output variable. This metadata typically does not change
+between invocations of the <code>dereference</code> function unless the <a>DID
+document</a> changes, as it represents data about the <a>DID document</a>. If
+the dereferencing is unsuccessful, or if the dereferenced content is not
+a <a>DID document</a>, this output MUST be an empty
+<a href="metadata-structure">metadata structure</a>.
+Properties defined by this specification are in <a href="#did-document-metadata-properties"></a>.
+            </dd>
+        </dl>
+
+        <p>
+<a>DID URL dereferencer</a> implementations MUST NOT alter the signature of this
+function in any way. <a>DID URL dereferencer</a> implementations
+MAY implement  and expose additional
+functions with different signatures in addition to the <code>dereference</code>
+function specified here.
+        </p>
+
+        <section>
+            <h3>
+DID URL Dereferencing Input Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+            
+            <dl>
+                <dt>
+accept
+                </dt>
+                <dd>
+The MIME type of the caller's preferred representation of the <a>DID document</a> or other content. The <a>DID URL dereferencer</a> implementation 
+MAY use this value to determine the representation contained in the returned <code>content-stream</code> if such
+a representation is supported and available. This property is OPTIONAL.
+                </dd>
+            </dl>
+        </section>
+
+        <section>
+            <h3>
+DID URL Dereferencing Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+            <dl>
+                <dt>
+content-type
+                </dt>
+                <dd>
+The mime-type of the content in the returned <code>content-stream</code>.
+This property is REQUIRED if dereferencing is successful and a <code>content-stream</code> is returned.
+If the value of this property is the mime-type of one of the conformant <a href="#core-representations">representations</a> of a <a>DID document</a>,
+then the caller of the <code>dereference</code> function MUST use this value when determining how to
+parse and process the <code>content-stream</code> returned by this function into a
+<a>DID document</a> abstract data model.
+                </dd>
+                <dt>
+error
+                </dt>
+                <dd>
+The error code from the resolution process. 
+This property is REQUIRED when there is an error in the resolution process.
+The value of this property is a single keyword string.
+The possible property values of this field are defined by the DID Core Registry [[DID-CORE-REGISTRY]]. 
+This specification defines the following error values:
+                    <dl>
+                        <dt>
+invalid-did
+                        </dt>
+                        <dd>
+The <a>DID</a> supplied to the <a>DID resolution</a> function does not
+conform to valid syntax. (See <a href="#did-syntax"></a>.)
+                        </dd>
+                        <dt>
+unauthorized
+                        </dt>
+                        <dd>
+The caller is not authorized to resolve this <a>DID</a> with
+this <a>DID resolver</a>.
+                        </dd>
+                        <dt>
+not-found
+                        </dt>
+                        <dd>
+The <a>DID resolver</a> was unable to return the <a>DID document</a>
+resulting from this resolution request.
+                        </dd>
+                    </dl>
+                </dd>
+            </dl>
+
+        </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -3034,7 +3034,9 @@ did-resolution-input-metadata
             <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of input
 options to the <code>resolve</code> function in addition to the <code>did</code>
-itself. This input is REQUIRED, but the structure MAY be empty.
+itself.
+Properties defined by this specification are in <a href="#did-resolution-input-metadata-properties"></a>.
+This input is REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
 
@@ -3052,6 +3054,9 @@ relating to the results of the <a>DID resolution</a> process. This structure is
 REQUIRED and MUST NOT be empty. This metadata typically changes between
 invocations of the <code>resolve</code> function as it represents data about the
 resolution process itself.
+Properties defined by this specification are in <a href="#did-resolution-metadata-properties"></a>.
+If the resolution is successful, this structure MUST contain a <code>content-type</code> property containing the mime-type <a>representation</a> of the <code>did-document-stream</code> in this result.
+If the resolution is not successful, this structure MUST contain an <code>error</code> property describing the error.
             </dd>
             <dt>
 did-document-stream
@@ -3076,6 +3081,7 @@ between invocations of the <code>resolve</code> function unless the <a>DID
 document</a> changes, as it represents data about the <a>DID document</a>. If
 the resolution is unsuccessful, this output MUST be an empty <a
 href="metadata-structure">metadata structure</a>.
+Properties defined by this specification are in <a href="#did-document-metadata-properties"></a>.
             </dd>
         </dl>
 
@@ -3088,6 +3094,98 @@ MAY implement  and expose additional
 functions with different signatures in addition to the <code>resolve</code>
 function specified here.
         </p>
+
+        <section>
+            <h3>
+DID Resolution Input Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+            
+            <dl>
+                <dt>
+accept
+                </dt>
+                <dd>
+The MIME type of the caller's preferred representation of the <a>DID document</a>. The <a>DID resolver</a> implementation 
+MAY use this value to determine the representation contained in the returned <code>did-document-stream</code> if such
+a representation is supported and available. This property is OPTIONAL.
+                </dd>
+            </dl>
+        </section>
+
+        <section>
+            <h3>
+DID Resolution Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+            <dl>
+                <dt>
+content-type
+                </dt>
+                <dd>
+The mime-type of the returned conformant representation of the contained in the returned <code>did-document-stream</code>.
+This property is REQUIRED if resolution is successful and a <code>did-document-stream</code> is returned. 
+The caller of the <code>resolve</code> function MUST use this value when determining how to
+parse and process the <code>did-document-stream</code> returned by this function into a
+<a>DID document</a> abstract data model.
+                </dd>
+                <dt>
+error
+                </dt>
+                <dd>
+The error code from the resolution process. 
+This property is REQUIRED when there is an error in the resolution process.
+The value of this property is a single keyword string.
+The possible property values of this field are defined by the DID Core Registry [[DID-CORE-REGISTRY]]. 
+This specification defines the following error values:
+                    <dl>
+                        <dt>
+invalid-did
+                        </dt>
+                        <dd>
+The <a>DID</a> supplied to the <a>DID resolution</a> function does not
+conform to valid syntax. (See <a href="#did-syntax"></a>.)
+                        </dd>
+                        <dt>
+unauthorized
+                        </dt>
+                        <dd>
+The caller is not authorized to resolve this <a>DID</a> with
+this <a>DID resolver</a>.
+                        </dd>
+                        <dt>
+not-found
+                        </dt>
+                        <dd>
+The <a>DID resolver</a> was unable to return the <a>DID document</a>
+resulting from this resolution request.
+                        </dd>
+                    </dl>
+                </dd>
+            </dl>
+
+        </section>
+
+        <section>
+            <h3>
+DID Document Metadata Properties
+            </h3>
+            
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+        </section>
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -3097,7 +3097,7 @@ DID Resolution Input Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
             </p>
         </section>
 
@@ -3107,7 +3107,7 @@ DID Resolution Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
 
@@ -3119,7 +3119,7 @@ error
 The error code from the resolution process. 
 This property is REQUIRED when there is an error in the resolution process.
 The value of this property is a single keyword string.
-The possible property values of this field are defined by the DID Core Registry [[DID-CORE-REGISTRY]]. 
+The possible property values of this field are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following error values:
                     <dl>
                         <dt>
@@ -3155,7 +3155,7 @@ DID Document Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
 
@@ -3266,7 +3266,7 @@ DID URL Dereferencing Input Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
             
@@ -3288,7 +3288,7 @@ DID URL Dereferencing Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-CORE-REGISTRIES]].
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
 
@@ -3311,7 +3311,7 @@ error
 The error code from the resolution process. 
 This property is REQUIRED when there is an error in the resolution process.
 The value of this property is a single keyword string.
-The possible property values of this field are defined by the DID Core Registry [[DID-CORE-REGISTRY]]. 
+The possible property values of this field are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following error values:
                     <dl>
                         <dt>

--- a/index.html
+++ b/index.html
@@ -2995,7 +2995,8 @@ considerations for implementors are discussed in [[?DID-RESOLUTION]].
 
     <p>
 All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a>
-function for at least one <a>DID method</a> and MUST be able to return a <a>DID
+function for at least one <a>DID method</a>. All conformant
+<a>DID URL dereferencers</a> MUST be able to return a <a>DID
 document</a> in  at least one conformant representation.
     </p>
 
@@ -3072,7 +3073,7 @@ did-document-metadata
 If the resolution is successful, this MUST be a <a
 href="metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>did-document</code> output variable. This metadata typically does not change
+<code>did-document</code>. This metadata typically does not change
 between invocations of the <code>resolve</code> function unless the <a>DID
 document</a> changes, as it represents data about the <a>DID document</a>. If
 the resolution is unsuccessful, this output MUST be an empty <a
@@ -3097,7 +3098,7 @@ DID Resolution Input Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+The possible properties within the <code>did-resolution-input-metadata</code> structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
             </p>
         </section>
 
@@ -3107,7 +3108,7 @@ DID Resolution Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+The possible properties within the <code>did-resolution-metadata</code> structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
 
@@ -3140,24 +3141,12 @@ this <a>DID resolver</a>.
 not-found
                         </dt>
                         <dd>
-The <a>DID resolver</a> was unable to return the <a>DID document</a>
-resulting from this resolution request.
+The <a>DID resolver</a> was unable to find a <code>did-document</code>
+for this resolution request.
                         </dd>
                     </dl>
                 </dd>
             </dl>
-
-        </section>
-
-        <section>
-            <h3>
-DID Document Metadata Properties
-            </h3>
-            
-            <p>
-The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
-This specification defines the following common properties.
-            </p>
 
         </section>
 
@@ -3170,13 +3159,15 @@ DID URL Dereferencing
         <p>
 The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into content
 identified by that <a>DID URL</a>. This content MAY be a <a>DID document</a>, a
-portion of a <a>DID document</a>, a service endpoint, or some other data. The details of the implementation of this function
+portion of a <a>DID document</a>, a service endpoint, or some other data.
+The <a>DID URL dereferencer</a> first MUST resolve the <a>DID</a> within the <a>DID URL</a> into a <a>DID document</a> using a <a>DID resolution</a> process.
+The details of the implementation of this function
 are outside the scope of this specification, but all implementations MUST implement
 a function which has the following abstract form:
         </p>
 
         <p><code>
-dereference ( did-url, did-dereference-input-metadata ) <br>
+dereference ( did-url, did-url-dereference-input-metadata ) <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereference-metadata, content-stream, did-document-metadata )
         </code></p>
 
@@ -3219,7 +3210,7 @@ REQUIRED and MUST NOT be empty. This metadata typically changes between
 invocations of the <code>dereference</code> function as it represents data about the
 dereferencing process itself.
 Properties defined by this specification are in <a href="#did-url-dereferencing-metadata-properties"></a>.
-If the resolution is successful, this structure MUST contain a <code>content-type</code> property containing the mime-type of the <code>did-document-stream</code> in this result.
+If the resolution is successful, this structure MUST contain a <code>content-type</code> property containing the mime-type of the <code>content-stream</code> in this result.
 If the resolution is not successful, this structure MUST contain an <code>error</code> property describing the error.
             </dd>
             <dt>
@@ -3242,7 +3233,7 @@ If the dereferencing is successful and the dereferenced content is a
 <a>DID document</a>, this MUST be a <a href="metadata-structure">metadata
 structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>content-stream</code> output variable. This metadata typically does not change
+<code>content-stream</code>. This metadata typically does not change
 between invocations of the <code>dereference</code> function unless the <a>DID
 document</a> changes, as it represents data about the <a>DID document</a>. If
 the dereferencing is unsuccessful, or if the dereferenced content is not
@@ -3266,7 +3257,7 @@ DID URL Dereferencing Input Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+The possible properties within the <code>did-url-dereferencing-input-metadata</code> structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
             
@@ -3275,7 +3266,7 @@ This specification defines the following common properties.
 accept
                 </dt>
                 <dd>
-The MIME type of the caller's preferred representation of the <a>DID document</a> or other content. The <a>DID URL dereferencer</a> implementation 
+The MIME type of the caller's preferred representation of the <a>DID document</a> or other content identified by the <a>DID URL</a>. The <a>DID URL dereferencer</a> implementation 
 MAY use this value to determine the representation contained in the returned <code>content-stream</code> if such
 a representation is supported and available. This property is OPTIONAL.
                 </dd>
@@ -3288,7 +3279,7 @@ DID URL Dereferencing Metadata Properties
             </h3>
             
             <p>
-The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+The possible properties within the <code>did-url-dereferencing-metadata</code> structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
             </p>
 
@@ -3308,38 +3299,50 @@ parse and process the <code>content-stream</code> returned by this function into
 error
                 </dt>
                 <dd>
-The error code from the resolution process. 
-This property is REQUIRED when there is an error in the resolution process.
+The error code from the dereferencing process. 
+This property is REQUIRED when there is an error in the dereferencing process.
 The value of this property is a single keyword string.
 The possible property values of this field are defined by [[DID-SPEC-REGISTRIES]].
 This specification defines the following error values:
                     <dl>
                         <dt>
-invalid-did
+invalid-did-url
                         </dt>
                         <dd>
-The <a>DID</a> supplied to the <a>DID resolution</a> function does not
-conform to valid syntax. (See <a href="#did-syntax"></a>.)
+The <a>DID URL</a> supplied to the <a>DID URL dereferencing</a> function does not
+conform to valid syntax. (See <a href="#did-url-syntax"></a>.)
                         </dd>
                         <dt>
 unauthorized
                         </dt>
                         <dd>
-The caller is not authorized to resolve this <a>DID</a> with
-this <a>DID resolver</a>.
+The caller is not authorized to dereference this <a>DID URL</a> with
+this <a>DID URL dereferencer</a>.
                         </dd>
                         <dt>
 not-found
                         </dt>
                         <dd>
-The <a>DID resolver</a> was unable to return the <a>DID document</a>
-resulting from this resolution request.
+The <a>DID URL dereferencer</a> was unable to find a <code>content-stream</code>
+for this dereferencing request.
                         </dd>
                     </dl>
                 </dd>
             </dl>
 
         </section>
+
+    </section>
+
+    <section>
+        <h2>
+DID Document Metadata Properties
+        </h2>
+            
+        <p>
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+This specification defines the following common properties.
+        </p>
 
     </section>
 


### PR DESCRIPTION
Building on https://github.com/w3c/did-core/pull/296 and https://github.com/w3c/did-core/pull/297, this is one of two proposals how `resolve()` can return a DID document in an abstract form.

- Proposal 1 https://github.com/w3c/did-core/pull/322 **(this one)**: `resolve()` always returns a DID document in an abstract form, and `dereference()` always returns a DID document or other content as a byte stream of a concrete representation.
- Proposal 2 https://github.com/w3c/did-core/pull/323: `resolve()` can return either a DID document in an abstract form or as a byte stream of a concrete representation, depending on whether the `accept` input metadata property is present.
