### PR TITLE
Relationship between `controller` property and DID controller

### DIFF
--- a/index.html
+++ b/index.html
@@ -1830,10 +1830,8 @@ malicious activity by an attacker. See Section
 
       <p>
 A DID document MAY include a <code>controller</code> property to indicate
-that there are <a>DID controller(s)</a> other than the <a>DID subject</a>.
-If so:
+the <a>DID controller(s)</a>. If so:
       </p>
-
       <dl>
           <dt><dfn>controller</dfn></dt>
           <dd>
@@ -1843,6 +1841,19 @@ SHOULD contain authorization relations that explicitly permit the use of
 certain verification methods for specific purposes.
           </dd>
       </dl>
+
+      <p class="note" title="Determining the DID controller">
+If the <code>controller</code> property is not present, the
+<a>DID controller</a> can be determined by consulting the respective
+<a>DID method</a> specification. It cannot be assumed that the
+<a>DID subject</a> is also the controller of its own <a>DID</a>, nor
+can it be assumed that <em>only</em> entities identified by <a>DIDs</a>
+present in the value of <code>controller</code> are capable of exerting
+control over the <a>DID</a> in question. Similarly, <a>DID methods</a> are not
+obliged to respect the value of <code>controller</code> and can specify means
+for updating the <a>DID document</a> that are unrelated to the
+<code>controller</code> property.
+      </p>
 
       <p>
 Each <a>DID method</a> MUST define how authorization and delegation are


### PR DESCRIPTION
Issue #122 has a lot of back-and-forth about the relationship between the `controller` property and the actual DID controller, aka the entity that can edit the DID document. 

The original issue was about whether we can assume the DID subject (aka an entity that can authenticate itself with verification material contained in the DID doc.. I think?) is default controller in the absence of a `controller` property. (Short answer to that being 'no'.)

I'm not sure there's consensus, so I've added a NOTE presenting one set of perspectives from that thread, which is basically that the `controller` property is indicative but ultimately who/what can or cannot edit a DID doc, and under what circumstances, is up to the DID method, `controller` property or no.

I'm not sure if there's normative language to be developed from this, happy to iterate.