### PR TITLE
Fixed ABNF for method-specific-id of DID Syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -732,7 +732,7 @@ defined in this ABNF are defined in [[RFC3986]].
 did                = "did:" method-name ":" method-specific-id
 method-name        = 1*method-char
 method-char        = %x61-7A / DIGIT
-method-specific-id = *( ":" *idchar ) 1*idchar
+method-specific-id = *( *idchar ":" ) 1*idchar
 idchar             = ALPHA / DIGIT / "." / "-" / "_"
         </pre>
 


### PR DESCRIPTION
See https://github.com/w3c/did-core/issues/333


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Crenshinibon/did-core/pull/334.html" title="Last updated on Jun 25, 2020, 12:23 PM UTC (445af8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/334/515db7b...Crenshinibon:445af8e.html" title="Last updated on Jun 25, 2020, 12:23 PM UTC (445af8e)">Diff</a>