### PR TITLE
Added missing reference to the diagram in ECHIDNA

### DIFF
--- a/ECHIDNA
+++ b/ECHIDNA
@@ -1,2 +1,4 @@
 # ECHIDNA configuration
 index.html?specStatus=WD&shortName=did-core respec
+diagrams/did_architecture_overview.svg
+


### PR DESCRIPTION
The reference to the diagram was missing, as reported in 

https://lists.w3.org/Archives/Public/public-did-wg/2020Jul/0009.html

