### PR TITLE
Swap relying party for requesting party Will fix #248

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,7 @@ selective, and progressive disclosure of attributes or other data.
 Security
             </td>
             <td>
-Enable sufficient security for relying parties to depend on <a>DID documents</a>
+Enable sufficient security for requesting parties to depend on <a>DID documents</a>
 for their required level of assurance.
             </td>
           </tr>
@@ -3615,7 +3615,7 @@ Authentication Service Endpoints
 If a <a>DID document</a> publishes a <a>service endpoint</a> intended for
 authentication or authorization of the <a>DID subject</a> (see Section <a
 href="#service-endpoints"></a>), it is the responsibility of the <a>service
-endpoint</a> provider, subject, or relying party to comply with the requirements
+endpoint</a> provider, subject, or requesting party to comply with the requirements
 of the authentication protocols supported at that <a>service endpoint</a>.
       </p>
     </section>
@@ -3879,7 +3879,7 @@ that the <a>DID subject</a> did not consent to sharing. With this privacy
 architecture, personal data can be exchanged on a private, peer-to-peer basis
 using communications channels identified and secured by <a>public key
 descriptions</a> in <a>DID documents</a>. This also enables <a>DID
-subjects</a> and relying parties to implement the <a
+subjects</a> and requesting parties to implement the <a
 href="https://en.wikipedia.org/wiki/General_Data_Protection_Regulation">GDPR</a>
 <a href="https://en.wikipedia.org/wiki/Right_to_be_forgotten">right to be
 forgotten</a>, because no personal data is written to an immutable


### PR DESCRIPTION
In line with the WG's [resolution on 2020-06-30](https://www.w3.org/2019/did-wg/Meetings/Minutes/2020-06-30-did#resolution1), this minimal PR swaps the 3 instances of 'replying party' for 'requesting party'. If merged, Issue #248 can be closed. The closely related issue in the Use Cases document, ([issue 39](https://github.com/w3c/did-use-cases/issues/39) in that repo) has been closed and the UCR now consistently refers to requesting parties (actually, it refers to Requesting Parties, with upper case R and P, which is a difference from the core spec but probably not something to worry about too much).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/350.html" title="Last updated on Jul 16, 2020, 10:48 AM UTC (3a27e63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/350/78f1148...3a27e63.html" title="Last updated on Jul 16, 2020, 10:48 AM UTC (3a27e63)">Diff</a>