### PR TITLE
URI not URL in section 1.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@ A <a>DID</a> is a simple text string consisting of three parts, the:
       </p>
         <ul>
           <li>
-URL scheme identifier (<code>did</code>)
+URI scheme identifier (<code>did</code>)
           </li>
           <li>
 Identifier for the <a>DID method</a>


### PR DESCRIPTION
I think section 1.1 has a typo where it says that `did` is the scheme - surely that should be URI?
This PR changes that single character (from L to I)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/351.html" title="Last updated on Jul 16, 2020, 11:40 AM UTC (adfc367)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/351/78f1148...adfc367.html" title="Last updated on Jul 16, 2020, 11:40 AM UTC (adfc367)">Diff</a>