### PR TITLE
Remove obsolete sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,12 +946,6 @@ RDF / JSON-LD documents.
         </p>
 
         <p>
-DID parameters SHOULD NOT be used if there are already other, equivalent ways of
-constructing URIs that fulfill the same purpose (for example, using other
-syntactical constructs such as URI query strings or URI fragments).
-        </p>
-
-        <p>
 DID parameters SHOULD NOT be used if the same functionality can be expressed by
 passing options to a <a>DID resolver</a>, and if there is no need to construct a
 URI for use as a link, or as a <a>resource</a> in RDF / JSON-LD documents.


### PR DESCRIPTION
> @peacekeeper  wrote: this is a remnant of the version of the spec that had matrix parameters. I think the sentence should simply be removed.

fixes #353


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Fak3/did-core/pull/354.html" title="Last updated on Jul 22, 2020, 1:13 PM UTC (5ee6aba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/354/78f1148...Fak3:5ee6aba.html" title="Last updated on Jul 22, 2020, 1:13 PM UTC (5ee6aba)">Diff</a>