### PR TITLE
Add 'relative-ref' DID URL parameter. Fixes #349.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,9 +1030,7 @@ Also discuss hierarchical method namespaces in DID parameter names.
         <p>
 A <a>DID path</a> is identical to a generic URI path and MUST conform to the <a
 data-cite="!rfc3986#section-3.3"><code>path-abempty</code></a> ABNF rule in
-[[!RFC3986]]. A <a>DID path</a> SHOULD be used to address <a>resources</a>
-available through a <a>service endpoint</a>. For more information, see Section
-<a href="#service-endpoints"></a>.
+[[!RFC3986]].
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -901,6 +901,21 @@ The associated value MUST be an
 <a data-lt="ascii string">ASCII string</a>.
               </td>
             </tr>
+
+            <tr>
+              <td>
+<code>relative-ref</code>
+              </td>
+              <td>
+A relative URI reference according to <a
+data-cite="RFC3986#section-4.2">RFC3986 Section 4.2</a>
+that identifies a resource at a <a>service endpoint</a>, which is selected from
+a <a>DID document</a> by using the <code>service</code> parameter. The
+associated value MUST be an <a data-lt="ascii string">ASCII string</a> and MUST
+use percent-encoding for certain characters as specified in <a
+data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>.
+              </td>
+            </tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
This fixes https://github.com/w3c/did-core/issues/349


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/357.html" title="Last updated on Jul 29, 2020, 8:53 AM UTC (73e89f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/357/6988450...73e89f7.html" title="Last updated on Jul 29, 2020, 8:53 AM UTC (73e89f7)">Diff</a>