### PR TITLE
Simplify DID URL ABNF

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,22 +797,16 @@ used, for example, to identify a specific part of a <a>DID document</a>.
       </p>
 
       <p>
-This following is the ABNF definition using the syntax in [[!RFC5324]]. It
+This following is the ABNF definition using the syntax in [[!RFC5234]]. It
 builds on the <code>did</code> scheme defined in <a href="#did-syntax"></a>. The
-<a data-cite="!rfc3986#section-3.3"><code>path-abempty</code></a> and <a
-data-cite="!rfc3986#section-3.5"><code>fragment</code></a> components are
-identical to the ABNF rules defined in [[!RFC3986]], and the
-<code>did-query</code> component is derived from the  <a
-data-cite="!rfc3986#section-3.4"><code>query</code></a> ABNF rule.
+<a data-cite="!rfc3986#section-3.3"><code>path-abempty</code></a>,
+<a data-cite="!rfc3986#section-3.4"><code>query</code></a>, and
+<a data-cite="!rfc3986#section-3.5"><code>fragment</code></a>
+components are identical to the ABNF rules defined in [[!RFC3986]].
       </p>
 
       <pre class="nohighlight">
-did-url            = did path-abempty [ "?" did-query ]
-                     [ "#" fragment ]
-did-query          = param *( "&" param )
-param              = param-name "=" param-value
-param-name         = 1*pchar
-param-value        = *pchar
+did-url = did path-abempty [ "?" query ] [ "#" fragment ]
       </pre>
 
       <p class="note">


### PR DESCRIPTION
- Use `query` from RFC3986 (URI) instead of parsing param names and values
- Correct RFC5324 (MIB for Fibre-Channel Security) to RFC5234 (ABNF)

See discussion here for reasoning:
https://github.com/w3c/did-core/issues/344


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wyc/did-core/pull/360.html" title="Last updated on Jul 28, 2020, 10:29 PM UTC (2353f5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/360/2956430...wyc:2353f5d.html" title="Last updated on Jul 28, 2020, 10:29 PM UTC (2353f5d)">Diff</a>