### PR TITLE
Update context requirements for JSON-LD producers/consumers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2481,7 +2481,8 @@ this specification as idiomatic JSON.
         <li>
 Even though JSON-LD allows any IRI as node identifiers, <a>DID documents</a>
 are explicitly restricted to only describe DIDs. This means that the value of
-<code><a>id</a></code> MUST be a valid <a>DID</a> and not any other kind of IRI.
+<code><a>id</a></code> that refers to the <a>DID subject</a> MUST be a valid
+<a>DID</a> and not any other kind of IRI.
         </li>
         <li>
 Data types, such as integers, dates, units of measure, and URLs, are
@@ -2507,8 +2508,11 @@ property.
 The value of the <code>@context</code> property MUST be one or more <a>URIs</a>,
 where the value of the first <a>URI</a> is
 <code>https://www.w3.org/ns/did/v1</code>. All members of the
-<code>@context</code> property MUST exist be in the DID properties extension
-registry.
+<code>@context</code> property SHOULD exist in the DID specification
+registries in order to achieve interoperability across different
+representations. If a member does not exist in the DID specification
+registries, then the DID Document will not be interoperable across
+representations.
           </dd>
         </dl>
 
@@ -2543,7 +2547,11 @@ where the value of the first <a>URI</a> is
 <code>https://www.w3.org/ns/did/v1</code>. If more than one <a>URI</a> is
 provided, the <a>URIs</a> MUST be interpreted as an ordered set. It is
 RECOMMENDED that dereferencing each <a>URI</a> results in a document containing
-machine-readable information about the context.
+machine-readable information about the context. To enable interoperability
+across representations, <a>URIs</a> that exist in the DID specification
+registries SHOULD be assumed to refer to the information in the registries. In
+this case, if dereferencing is required during processing, the information from
+the registries SHOULD be used.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2548,10 +2548,13 @@ where the value of the first <a>URI</a> is
 provided, the <a>URIs</a> MUST be interpreted as an ordered set. It is
 RECOMMENDED that dereferencing each <a>URI</a> results in a document containing
 machine-readable information about the context. To enable interoperability
-across representations, <a>URIs</a> that exist in the DID specification
-registries SHOULD be assumed to refer to the information in the registries. In
-this case, if dereferencing is required during processing, the information from
-the registries SHOULD be used.
+with other representations, <a>URLs</a> registered in the 
+DID Specification Registries [[DID-SPEC-REGISTRIES]] referring to 
+JSON-LD Contexts SHOULD be associated with a cryptographic hash of 
+the content of the JSON-LD Context. This ensures that the interpretation of the
+information by JSON-LD consumers will be the same as interpretations 
+over other representations by other consumers that rely on the
+DID Specification Registries [[DID-SPEC-REGISTRIES]].
           </dd>
         </dl>
 


### PR DESCRIPTION
While fixing the language around contexts, I noticed what I believe to be an erroneous comment regarding the value of `id` that states it *must* be a DID. However, this is *only* true when referring to the DID subject. The value of `id` of a service endpoint or verification method, for example, is not a DID.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/362.html" title="Last updated on Sep 1, 2020, 7:48 PM UTC (bf5a714)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/362/ce2f9a9...bf5a714.html" title="Last updated on Sep 1, 2020, 7:48 PM UTC (bf5a714)">Diff</a>