### PR TITLE
Add reqlist JS for listing normative statements

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     src='https://www.w3.org/Tools/respec/respec-w3c-common'>
   </script><!--script src='./respec-w3c-common.js' class='remove'></script-->
 
+  <script src="https://unpkg.com/reqlist/lib/reqlist.js" class="remove"></script>
+  <link href="https://unpkg.com/reqlist/lib/reqlist.css" class="removeOnSave" rel="stylesheet" type="text/css" />
+
   <script class='remove' src="./common.js">
   </script>
   <script class="remove" type="text/javascript">
@@ -55,6 +58,15 @@
             branch: "master"
     },
     includePermalinks: false,
+
+    // Uncomment these to use the respec extension that generates a list of
+    //   normative statements:
+    // preProcess: [
+    //   prepare_reqlist
+    // ],
+    // postProcess: [
+    //   add_reqlist_button
+    // ],
 
 
     // editors, add as many as you like


### PR DESCRIPTION
Adds the reqlist respec extension to list normative statements in a sidebar. ~~Leaving this PR here and will keep it up to date with the main branch so we can use the preview for reference for the test suite etc.~~ [preview here](https://holosuite.rhiaro.co.uk/did-core-reqlist/#list-of-requirements) (PR preview only shows the static HTML version with the JS).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/372.html" title="Last updated on Sep 3, 2020, 3:05 PM UTC (2bfca41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/372/5d5e992...2bfca41.html" title="Last updated on Sep 3, 2020, 3:05 PM UTC (2bfca41)">Diff</a>