### PR TITLE
Remove method-specific DID parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,6 +915,14 @@ data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>.
         </table>
 
         <p>
+Implementers as well as <a>DID method</a> specification authors MAY use additional
+DID parameters that are not listed here.
+For maximum interoperability, it is RECOMMENDED that DID parameters use the official
+W3C DID Specification Registries mechanism [[DID-SPEC-REGISTRIES]], to avoid collision
+with other uses of the same DID parameter with different semantics.
+        </p>
+
+        <p>
 Additional considerations for processing these parameters are discussed in
 [[?DID-RESOLUTION]].
         </p>

--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@ possible future use as a sub-delimiter for parameters as described in
       </p>
 
       <section>
-        <h2>Generic DID URL Parameters</h2>
+        <h2>DID URL Parameters</h2>
 
         <p>
 The <a>DID URL</a> syntax supports a simple, generalized format for parameters
@@ -832,18 +832,14 @@ specifies the basic syntax (the <code>param</code> rule) but does not specify
 any concrete parameter names.
         </p>
         <p>
-Some generic DID parameter names (for example, for service selection) are
+Some DID parameter names (for example, for service selection) are
 completely independent of any specific <a>DID method</a> and MUST always
 function the same way for all <a>DIDs</a>. Other DID parameter names (for
 example, for versioning) MAY be supported by certain <a>DID methods</a>, but
 MUST operate uniformly across those <a>DID methods</a> that do support them.
         </p>
         <p>
-Parameter names that are completely method-specific are described in Section
-<a href="#method-specific-did-url-parameters"></a>.
-        </p>
-        <p>
-The following table defines a set of generic DID parameter names.
+The following table defines a set of DID parameter names.
         </p>
 
         <table class="simple">
@@ -927,7 +923,7 @@ Additional considerations for processing these parameters are discussed in
 
         <p>
 Two example <a>DID URLs</a> using the <code><a>service</a></code> and
-<code>version-time</code> generic DID parameters are shown below.
+<code>version-time</code> DID parameters are shown below.
         </p>
 
         <pre class="example nohighlight" title="A DID URL with a 'service' DID parameter">
@@ -971,62 +967,6 @@ URI for use as a link, or as a <a>resource</a> in RDF / JSON-LD documents.
       </section>
 
       <section>
-        <h2>Method-Specific DID URL Parameters</h2>
-
-        <p>
-A <a>DID method</a> specification MAY specify additional method-specific
-parameter names. A method-specific parameter name MUST be prefixed by the method
-name, as defined by the <code>method-name</code> rule.
-        </p>
-
-        <p>
-For example, if the method <code>did:foo:</code> defines the parameter bar, the
-parameter name must be <code>foo:bar</code>. An example <a>DID URL</a> using
-this method and this method-specific parameter would be as shown below.
-        </p>
-
-        <pre class="example nohighlight">
-did:foo:21tDAKCERh95uGgKbJNHYp?foo:bar=high
-        </pre>
-
-        <p>
-A method-specific parameter name defined by one <a>DID method</a> MAY be used by
-other <a>DID methods</a>.
-        </p>
-
-        <pre class="example nohighlight">
-did:example:21tDAKCERh95uGgKbJNHYp?foo:bar=low
-        </pre>
-
-        <p>
-Method-specific parameter names MAY be combined with generic parameter names in
-any order.
-        </p>
-
-        <pre class="example nohighlight">
-did:example:21tDAKCERh95uGgKbJNHYp?service=agent&amp;foo:bar=high
-        </pre>
-
-        <p>
-Both <a>DID method</a> namespaces and method-specific parameter namespaces MAY
-include colons, so they might be partitioned hierarchically, as defined by a
-<a>DID method</a> specification. The following example <a>DID URL</a>
-illustrates both.
-        </p>
-
-        <pre class="example nohighlight">
-did:foo:baz:21tDAKCERh95uGgKbJNHYp?foo:baz:hex=b612
-        </pre>
-
-        <p class="issue" data-number="36">
-Review what exactly we want to say about method-specific parameters
-defined by one method but used in a <a>DID URL</a> with a different method.
-Also discuss hierarchical method namespaces in DID parameter names.
-        </p>
-
-      </section>
-
-      <section>
         <h2>Path</h2>
 
         <p>
@@ -1052,8 +992,7 @@ did:example:123456/path
 A <a>DID query</a> is derived from a generic URI query and MUST conform to the
 <code>did-query</code> ABNF rule in Section <a href="#did-url-syntax">
 </a>. If a <a>DID query</a> is present, it MUST be used
-as described in Sections <a href="#generic-did-url-parameters"></a> and
-<a href="#method-specific-did-url-parameters"></a>.
+as described in Section <a href="#generic-did-url-parameters"></a>.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -862,7 +862,7 @@ Description
               <td>
 A resource hash of the <a>DID document</a> to add integrity protection, as
 specified in [[?HASHLINK]]. The associated value MUST be an
-<a data-lt="ascii string">ASCII string</a>.
+<a data-lt="ascii string">ASCII string</a>. <i>This parameter is non-normative.</i>
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -823,13 +823,11 @@ possible future use as a sub-delimiter for parameters as described in
       </p>
 
       <section>
-        <h2>DID URL Parameters</h2>
+        <h2>DID Parameters</h2>
 
         <p>
-The <a>DID URL</a> syntax supports a simple, generalized format for parameters
-based on the query component (See <a href="#query"></a>). The ABNF above
-specifies the basic syntax (the <code>param</code> rule) but does not specify
-any concrete parameter names.
+The <a>DID URL</a> syntax supports a simple format for parameters
+based on the <code>query</code> component (See <a href="#query"></a>).
         </p>
         <p>
 Some DID parameter names (for example, for service selection) are
@@ -992,7 +990,7 @@ did:example:123456/path
 A <a>DID query</a> is derived from a generic URI query and MUST conform to the
 <code>did-query</code> ABNF rule in Section <a href="#did-url-syntax">
 </a>. If a <a>DID query</a> is present, it MUST be used
-as described in Section <a href="#generic-did-url-parameters"></a>.
+as described in Section <a href="#did-parameters"></a>.
         </p>
 
         <p>


### PR DESCRIPTION
This PR does the following:
- Remove method-specific DID parameters. Addresses https://github.com/w3c/did-core/issues/36
- Mark 'hl' DID parameter as non-normative. Addresses https://github.com/w3c/did-core/issues/137.
- Some minor editorial changes to DID Parameters section.
- Add paragraph on using the DID Spec Registries for DID parameters. See this comment https://github.com/w3c/did-core/issues/36#issuecomment-648468519.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/378.html" title="Last updated on Aug 26, 2020, 1:22 PM UTC (b9715e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/378/8c47db8...b9715e2.html" title="Last updated on Aug 26, 2020, 1:22 PM UTC (b9715e2)">Diff</a>