### PR TITLE
Fill DID URL Dereferencing Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3475,9 +3475,8 @@ content-stream
             </dt>
             <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
-contain a resource corresponding to the <a>DID URL</a>. 
-Especially in the case that the <a>DID URL</a> is a <a>DID</a>, the
-<code>content-stream</code> MAY be a <a>DID document</a> in one of the
+contain a resource corresponding to the <a>DID URL</a>.
+The <code>content-stream</code> MAY be a <a>DID document</a> in one of the
 conformant <a href="#representations">representations</a> obtained through
 the resolution process.
 

--- a/index.html
+++ b/index.html
@@ -3410,6 +3410,191 @@ property.
         <h2>
 DID URL Dereferencing
         </h2>
+        <p>
+The DID URL dereferencing function dereferences a <a>DID URL</a> into
+a resource with contents depending on the <a>DID URL</a>'s components,
+including the <a>DID method</a>, method-specific identifier, query parameters,
+and fragment. When a <a>DID URL</a> is also a <a>DID</a>, this process
+ performs <a>DID Resolution</a>. The details of how this
+process is accomplished are outside the scope of this specification, but all
+conformant implementations MUST implement two functions which have the
+following abstract forms:
+        </p>
+
+        <p><code>
+dereference ( did-url, did-url-dereferencing-input-metadata ) <br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereferencing-metadata, content, content-metadata )
+        </code></p>
+
+        <p>
+The input variables of these functions MUST be as follows:
+        </p>
+
+        <dl>
+            <dt>
+did-url
+            </dt>
+            <dd>
+A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to dereference.
+This input is REQUIRED.
+            </dd>
+            <dt>
+did-url-dereferencing-input-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of input
+options to the <code>dereference</code> function in addition to the <code>did-url</code>
+itself.
+Properties defined by this specification are in <a href="#did-url-dereferencing-input-metadata-properties"></a>.
+This input is REQUIRED, but the structure MAY be empty.
+            </dd>
+        </dl>
+
+        <p>
+The output variables of these functions MUST be as follows:
+        </p>
+
+        <dl>
+            <dt>
+did-url-dereferencing-metadata
+            </dt>
+            <dd>
+A <a href="metadata-structure">metadata structure</a> consisting of values
+relating to the results of the <a>DID URL Dereferencing</a> process. This
+structure is REQUIRED and MUST NOT be empty.
+Properties defined by this specification are in 
+<a href="#did-url-dereferencing-metadata-properties"></a>.
+If the dereferencing is not successful, this structure MUST contain an
+<code>error</code> property describing the error.
+            </dd>
+            <dt>
+content
+            </dt>
+            <dd>
+If the <code>dereferencing</code> function was called and successful, this MUST
+contain a resource corresponding to the <a>DID URL</a>.
+Additionally, in the case that the <a>DID URL</a> is a <a>DID</a>, then this
+MUST be a <code>did-document</code> as described in <a>DID Resolution</a>,
+obtained through the resolution process.
+
+If the dereferencing is unsuccessful, this value MUST be empty.
+            </dd>
+            <dt>
+content-metadata
+            </dt>
+            <dd>
+If the dereferencing is successful, this MUST be a <a href="metadata-structure">
+metadata structure</a>. This structure contains
+metadata about the <code>content</code>.  
+Additionally, in the case that the <a>DID URL</a> is a <a>DID</a>, then this
+MUST be a <code>did-document-metadata</code> as described in <a>DID Resolution</a>,
+obtained through the resolution process.
+
+If the dereferencing is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
+            </dd>
+        </dl>
+
+        <p>
+<a>DID URL Dereferencing</a> implementations MUST NOT alter the signature of
+these functions in any way. <a>DID URL Dereferencing</a> implementations MAY
+map the <code>dereference</code> function to a method-specific internal
+function to perform the actual <a>DID URL Dereferencing</a> process. <a>DID
+URL Dereferencing</a> implementations MAY implement and expose additional
+functions with different signatures in addition to the <code>dereference</code>
+function specified here.
+        </p>
+
+        <section>
+            <h3>
+DID URL Dereferencing Input Metadata Properties
+            </h3>
+
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+            <dl>
+                <dt>
+accept
+                </dt>
+                <dd>
+The MIME type the caller prefers for <code>content</code>. The <a>DID URL
+Dereferencing</a> implementation SHOULD use this value to determine the
+representation contained in the returned value if such a representation is
+supported and available. This property is OPTIONAL.
+                </dd>
+            </dl>
+        </section>
+
+        <section>
+            <h3>
+DID URL Dereferencing Metadata Properties
+            </h3>
+
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+            <dl>
+                <dt>
+content-type
+                </dt>
+                <dd>
+The MIME type of the returned <code>content</code>.
+This property is REQUIRED if dereferencing is successful.
+                </dd>
+                <dt>
+error
+                </dt>
+                <dd>
+The error code from the dereferencing process.
+This property is REQUIRED when there is an error in the dereferencing process.
+The value of this property is a single keyword string.
+The possible property values of this field are defined by [[DID-SPEC-REGISTRIES]].
+This specification defines the following error values:
+                    <dl>
+                        <dt>
+invalid-url
+                        </dt>
+                        <dd>
+The <a>DID URL</a> supplied to the <a>DID URL Dereferencing</a> function does not
+conform to valid syntax. (See <a href="#did-url-syntax"></a>.)
+                        </dd>
+                        <dt>
+unauthorized
+                        </dt>
+                        <dd>
+The caller is not authorized to dereference this <a>DID URL</a> with
+this <a>DID URL dereferencer</a>.
+                        </dd>
+                        <dt>
+not-found
+                        </dt>
+                        <dd>
+The <a>DID URL dereferencer</a> was unable to return the <code>content</code>
+resulting from this dereferencing request.
+                        </dd>
+                    </dl>
+                </dd>
+            </dl>
+
+        </section>
+
+        <section>
+            <h3>
+DID URL Dereferencing Metadata Properties
+            </h3>
+
+            <p>
+The possible properties within this structure and their possible values are defined by [[DID-SPEC-REGISTRIES]].
+This specification defines the following common properties.
+            </p>
+
+        </section>
+
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -3418,13 +3418,13 @@ and fragment. This process depends on <a>DID resolution</a>
 of the <a>DID</a> contained in the <a>DID URL</a>.
 The details of how this
 process is accomplished are outside the scope of this specification, but all
-conformant implementations MUST implement two functions which have the
-following abstract forms:
+conformant implementations MUST implement a function which has the
+following abstract form:
         </p>
 
         <p><code>
 dereference ( did-url, did-url-dereferencing-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereferencing-metadata, content, content-metadata )
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereferencing-metadata, content-stream, content-metadata )
         </code></p>
 
         <p>
@@ -3436,7 +3436,8 @@ The input variables of these functions MUST be as follows:
 did-url
             </dt>
             <dd>
-A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to dereference.
+A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to
+dereference.
 This input is REQUIRED.
             </dd>
             <dt>
@@ -3462,20 +3463,23 @@ did-url-dereferencing-metadata
             <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID URL Dereferencing</a> process. This
-structure is REQUIRED and MUST NOT be empty.
+structure is REQUIRED and in the case of an error in the dereferencing process,
+this MUST NOT be empty.
 Properties defined by this specification are in 
 <a href="#did-url-dereferencing-metadata-properties"></a>.
 If the dereferencing is not successful, this structure MUST contain an
 <code>error</code> property describing the error.
             </dd>
             <dt>
-content
+content-stream
             </dt>
             <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
-contain a resource corresponding to the <a>DID URL</a>.
-The content MAY be a <a>DID document</a> in one of the conformant <a href="#representations">representations</a>.
-obtained through the resolution process.
+contain a resource corresponding to the <a>DID URL</a>. 
+Especially in the case that the <a>DID URL</a> is a <a>DID</a>, the
+<code>content-stream</code> MAY be a <a>DID document</a> in one of the
+conformant <a href="#representations">representations</a> obtained through
+the resolution process.
 
 If the dereferencing is unsuccessful, this value MUST be empty.
             </dd>
@@ -3484,11 +3488,11 @@ content-metadata
             </dt>
             <dd>
 If the dereferencing is successful, this MUST be a <a href="metadata-structure">
-metadata structure</a>. This structure contains
-metadata about the <code>content</code>.  
-Additionally, in the case that the <a>DID URL</a> is a <a>DID</a>, then this
-MUST be a <code>did-document-metadata</code> as described in <a>DID Resolution</a>,
-obtained through the resolution process.
+metadata structure</a>, but the structure MAY be empty. This structure contains
+metadata about the <code>content-stream</code>.  
+Especially in the case that the <a>DID URL</a> is a <a>DID</a>, this MAY be a
+<code>did-document-metadata</code> structure as described in <a>DID
+Resolution</a>.
 
 If the dereferencing is unsuccessful, this output MUST be an empty <a href="metadata-structure">metadata structure</a>.
             </dd>
@@ -3542,8 +3546,8 @@ This specification defines the following common properties.
 content-type
                 </dt>
                 <dd>
-The MIME type of the returned <code>content</code>.
-This property is REQUIRED if dereferencing is successful.
+The MIME type of the returned <code>content-stream</code>.
+This property is OPTIONAL if dereferencing is successful.
                 </dd>
                 <dt>
 error
@@ -3566,15 +3570,15 @@ conform to valid syntax. (See <a href="#did-url-syntax"></a>.)
 unauthorized
                         </dt>
                         <dd>
-The caller is not authorized to dereference this <a>DID URL</a> with
-this <a>DID URL dereferencer</a>.
+The caller is not authorized to dereference the given <a>DID URL</a> with the
+given <a>DID URL dereferencer</a>.
                         </dd>
                         <dt>
 not-found
                         </dt>
                         <dd>
-The <a>DID URL dereferencer</a> was unable to return the <code>content</code>
-resulting from this dereferencing request.
+The <a>DID URL dereferencer</a> was unable to return the
+<code>content-stream</code> resulting from this dereferencing request.
                         </dd>
                     </dl>
                 </dd>

--- a/index.html
+++ b/index.html
@@ -3413,7 +3413,7 @@ DID URL Dereferencing
         <p>
 The DID URL dereferencing function dereferences a <a>DID URL</a> into
 a resource with contents depending on the <a>DID URL</a>'s components,
-including the <a>DID method</a>, method-specific identifier, query parameters,
+including the <a>DID method</a>, method-specific identifier, path, query,
 and fragment. When a <a>DID URL</a> is also a <a>DID</a>, this process
  performs <a>DID Resolution</a>. The details of how this
 process is accomplished are outside the scope of this specification, but all

--- a/index.html
+++ b/index.html
@@ -3474,7 +3474,7 @@ content
             <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a resource corresponding to the <a>DID URL</a>.
-The content MAY be a <a>DID document</a> in one of the conformant <a href="#core-representations">.
+The content MAY be a <a>DID document</a> in one of the conformant <a href="#representations">representations</a>.
 obtained through the resolution process.
 
 If the dereferencing is unsuccessful, this value MUST be empty.

--- a/index.html
+++ b/index.html
@@ -3556,7 +3556,7 @@ The possible property values of this field are defined by [[DID-SPEC-REGISTRIES]
 This specification defines the following error values:
                     <dl>
                         <dt>
-invalid-url
+invalid-did-url
                         </dt>
                         <dd>
 The <a>DID URL</a> supplied to the <a>DID URL Dereferencing</a> function does not

--- a/index.html
+++ b/index.html
@@ -3428,7 +3428,7 @@ dereference ( did-url, did-url-dereferencing-input-metadata ) <br>
         </code></p>
 
         <p>
-The input variables of these functions MUST be as follows:
+The input variables of this function MUST be as follows:
         </p>
 
         <dl>
@@ -3522,7 +3522,7 @@ This specification defines the following common properties.
 accept
                 </dt>
                 <dd>
-The MIME type the caller prefers for <code>content</code>. The <a>DID URL
+The MIME type the caller prefers for <code>content-stream</code>. The <a>DID URL
 Dereferencing</a> implementation SHOULD use this value to determine the
 representation contained in the returned value if such a representation is
 supported and available. This property is OPTIONAL.

--- a/index.html
+++ b/index.html
@@ -3489,7 +3489,7 @@ content-metadata
 If the dereferencing is successful, this MUST be a <a href="metadata-structure">
 metadata structure</a>, but the structure MAY be empty. This structure contains
 metadata about the <code>content-stream</code>.  
-Especially in the case that the <a>DID URL</a> is a <a>DID</a>, this MAY be a
+If the <code>content-stream</code> is a <a>DID document</a>, this MUST be a
 <code>did-document-metadata</code> structure as described in <a>DID
 Resolution</a>.
 

--- a/index.html
+++ b/index.html
@@ -3473,8 +3473,7 @@ content
             <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a resource corresponding to the <a>DID URL</a>.
-Additionally, in the case that the <a>DID URL</a> is a <a>DID</a>, then this
-MUST be a <code>did-document</code> as described in <a>DID Resolution</a>,
+The content MAY be a <a>DID document</a> in one of the conformant <a href="#core-representations">.
 obtained through the resolution process.
 
 If the dereferencing is unsuccessful, this value MUST be empty.

--- a/index.html
+++ b/index.html
@@ -3414,8 +3414,9 @@ DID URL Dereferencing
 The DID URL dereferencing function dereferences a <a>DID URL</a> into
 a resource with contents depending on the <a>DID URL</a>'s components,
 including the <a>DID method</a>, method-specific identifier, path, query,
-and fragment. When a <a>DID URL</a> is also a <a>DID</a>, this process
- performs <a>DID Resolution</a>. The details of how this
+and fragment. This process depends on <a>DID resolution</a>
+of the <a>DID</a> contained in the <a>DID URL</a>.
+The details of how this
 process is accomplished are outside the scope of this specification, but all
 conformant implementations MUST implement two functions which have the
 following abstract forms:

--- a/index.html
+++ b/index.html
@@ -3451,7 +3451,7 @@ This input is REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The output variables of these functions MUST be as follows:
+The output variables of this function MUST be as follows:
         </p>
 
         <dl>


### PR DESCRIPTION
As per: https://github.com/w3c/did-core/issues/364

- Fill the DID URL Dereferencing section with abstract function, function
  parameters, return values, and their definitions, using language and format
  consistent to (and drawn from) the DID Resolution section.
- Delegate the handling of DID URLs which are also DIDs to the DID Resolution
  process, thereby ensuring that DID URL Dereferencing is a superset of DID
  Resolution, just as DID URLs are a superset of DIDs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wyc/did-core/pull/381.html" title="Last updated on Sep 8, 2020, 11:38 PM UTC (3ce1d0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/381/8c47db8...wyc:3ce1d0e.html" title="Last updated on Sep 8, 2020, 11:38 PM UTC (3ce1d0e)">Diff</a>