### PR TITLE
Markup / structural fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@ did:example:123456789abcdefghi
 The example <a>DID</a> above resolves to a <a>DID document</a>. A <a>DID
 document</a> contains information associated with the <a>DID</a>, such as ways
 to cryptographically <a>authenticate</a> the <a>DID controller</a>, as
-well as services that can be used to interact with the <a>DID subject</a>.
+well as <a>services</a> that can be used to interact with the <a>DID subject</a>.
       </p>
 
       <pre class="example nohighlight" title="Minimal self-managed DID document">
@@ -579,7 +579,7 @@ DID documents
         </dt>
         <dd>
 <a>DID documents</a> contain metadata associated with a <a>DID</a>. They
-typically express verification methods (such as public keys) and services
+typically express verification methods (such as public keys) and <a>services</a>
 relevant to interactions with the DID subject. A DID document is serialized
 according to a particular syntax (see <a href="#core-representations"></a>). The
 <a>DID</a> itself is the value of the `id` property. The generic properties
@@ -2128,18 +2128,18 @@ Example:
 
       <p>
 <a>Service endpoints</a> are used in <a>DID documents</a> to express ways of
-communicating with the <a>DID subject</a> or associated entities. Services
+communicating with the <a>DID subject</a> or associated entities. <a>Services</a>
 listed in the <a>DID document</a> can contain information about privacy
 preserving messaging services, or more public information, such as social media
 accounts, personal websites, and email addresses although this is discouraged.
 See <a href="#keep-personally-identifiable-information-pii-private"></a> for
-additional details. The metadata associated with services are often
+additional details. The metadata associated with <a>services</a> are often
 service-specific. For example, the metadata associated with an encrypted
 messaging service can express how to initiate the encrypted link before
 messaging begins.
       </p>
       <p>
-Pointers to services are expressed using the <code><a>service</a></code>
+Pointers to <a>services</a> are expressed using the <code><a>service</a></code>
 property. Each service has its own <code>id</code> and <code>type</code>
 properties, as well as a <code><a>serviceEndpoint</a></code> property with a
 <a>URI</a> or a set of other properties describing the service.
@@ -2179,7 +2179,7 @@ The value of the <code><dfn>serviceEndpoint</dfn></code> property MUST be a
 valid <a>URI</a> conforming to [[RFC3986]] and normalized according to the
 rules in section 6 of [[RFC3986]] and to any normalization rules in its
 applicable <a>URI</a> scheme specification, <em>OR</em> a set of properties
-which describe the service endpoint further.
+which describe the <a>service endpoint</a> further.
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@ did:example:123456789abcdefghi
       <p>
 The example <a>DID</a> above resolves to a <a>DID document</a>. A <a>DID
 document</a> contains information associated with the <a>DID</a>, such as ways
-to cryptographically authenticate the <a>DID controller</a>, as
+to cryptographically <a>authenticate</a> the <a>DID controller</a>, as
 well as services that can be used to interact with the <a>DID subject</a>.
       </p>
 
@@ -1805,23 +1805,23 @@ be embedded or referenced.
 
         <p>
 This statement is useful to any <em>authentication verifier</em> that needs
-to check to see if an entity that is attempting to authenticate is, in fact,
-presenting a valid proof of authentication. When a <em>verifier</em> receives
-some data (in some protocol-specific format) that contains a proof that was
-made for the purpose of "authentication", and that says that an entity is
-identified by the <a>DID</a>, then that <em>verifier</em> checks to ensure
-that the proof can be verified using a <a>verification method</a> (e.g.,
+to check to see if an entity that is attempting to <a>authenticate</a> is, in
+fact, presenting a valid proof of authentication. When a <em>verifier</em>
+receives some data (in some protocol-specific format) that contains a proof
+that was made for the purpose of "authentication", and that says that an
+entity is identified by the <a>DID</a>, then that <em>verifier</em> checks to
+ensure that the proof can be verified using a <a>verification method</a> (e.g.,
 public key) listed under <code><a>authentication</a></code> in the
 <a>DID Document</a>.
         </p>
 
         <p>
 The <a>verification method</a> indicated by the <code><a>authentication</a></code>
-property of a <a>DID document</a> can only be used to authenticate the
-<a>DID subject</a>. To authenticate the <a>DID controller</a> (in cases
+property of a <a>DID document</a> can only be used to <a>authenticate</a> the
+<a>DID subject</a>. To <a>authenticate</a> the <a>DID controller</a> (in cases
 where the <a>DID controller</a> is not <em>also</em> the <a>DID subject</a>)
 the entity associated with the value of <code>controller</code> (see
-Section <a href="#control"></a>) needs to authenticate itself with its
+Section <a href="#control"></a>) needs to <a>authenticate</a> itself with its
 <em>own</em> <a>DID document</a> and attached <code><a>authentication</a></code>
 <a>verification relationship</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -3214,7 +3214,7 @@ This input is REQUIRED.
 did-resolution-input-metadata
             </dt>
             <dd>
-A <a href="metadata-structure">metadata structure</a> consisting of input
+A <a href="#metadata-structure">metadata structure</a> consisting of input
 options to the <code>resolve</code> and <code>resolveStream</code> functions in addition to the <code>did</code>
 itself.
 Properties defined by this specification are in <a href="#did-resolution-input-metadata-properties"></a>.
@@ -3231,7 +3231,7 @@ The output variables of these functions MUST be as follows:
 did-resolution-metadata
             </dt>
             <dd>
-A <a href="metadata-structure">metadata structure</a> consisting of values
+A <a href="#metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID resolution</a> process. This structure is
 REQUIRED and MUST NOT be empty. This metadata typically changes between
 invocations of the <code>resolve</code> and <code>resolveStream</code> functions as it represents data about the
@@ -3263,13 +3263,13 @@ did-document-metadata
             </dt>
             <dd>
 If the resolution is successful, this MUST be a <a
-href="metadata-structure">metadata structure</a>. This structure contains
+href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the <code>did-document</code> or
 <code>did-document-stream</code>. This metadata typically does not change
 between invocations of the <code>resolve</code> function unless the <a>DID
 document</a> changes, as it represents data about the <a>DID document</a>. If
 the resolution is unsuccessful, this output MUST be an empty <a
-href="metadata-structure">metadata structure</a>.
+href="#metadata-structure">metadata structure</a>.
 Properties defined by this specification are in <a href="#did-document-metadata-properties"></a>.
             </dd>
         </dl>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 
     // if there is a previously published draft, uncomment this and set its
     // YYYY-MM-DD date and its maturity status
-    previousPublishDate:  "2019-12-09",
+    previousPublishDate:  "2020-07-31",
     previousMaturity:  "WD",
 
     // automatically allow term pluralization
@@ -1458,7 +1458,7 @@ formats such as JWK [[RFC7517]]. It is RECOMMENDED that JWK <code>kid</code>
 values are set to the public key fingerprint [[RFC7638]]. It is RECOMMENDED
 that verification methods that use JWKs to represent their public keys utilize
 the value of <code>kid</code> as their fragment identifier. See the first key
-in <a href="#example-15-various-public-keys">example of various public keys</a>
+in <a href="#example-17-various-public-keys">example of various public keys</a>
 for an example of a public key with a compound key identifier.
           </p>
 
@@ -1617,6 +1617,10 @@ expressed and encoded.
         </p>
 
         <table class="simple" id="public-key-support">
+          <caption>
+This table defines the support for public key expression in a DID document.
+For each public key type, a maximum of two encoding formats are supported.
+          </caption>
           <thead>
             <tr>
               <th>
@@ -1626,10 +1630,6 @@ Key&nbsp;Type<br/>(<code>type</code> value)
 Support
               </th>
             </tr>
-            <caption>
-This table defines the support for public key expression in a DID document.
-For each public key type, a maximum of two encoding formats are supported.
-            </caption>
           </thead>
 
           <tbody>

--- a/terms.html
+++ b/terms.html
@@ -254,9 +254,9 @@ section of the <a href="https://w3.org/TR/did-core">DID Core specification</a>
 defines several representation formats for a <a>DID document</a>.
   </dd>
 
-  <dt><dfn data-lt="services">service</dfn></dt>
+  <dt><dfn>services</dfn></dt>
   <dd>
-A means of communicating or interacting with the <a>DID subject</a> or
+Means of communicating or interacting with the <a>DID subject</a> or
 associated entities via one or more <a>service endpoints</a>.
 Examples  include discovery services, agent services, social networking
 services, file storage services, and verifiable credential repository services.
@@ -265,7 +265,7 @@ services, file storage services, and verifiable credential repository services.
   <dt><dfn data-lt="service endpoints">service endpoint</dfn></dt>
 
   <dd>
-A network address (such as an HTTP URL) at which a <a>service</a> operates on
+A network address (such as an HTTP URL) at which <a>services</a> operate on
 behalf of a <a>DID subject</a>.
   </dd>
 

--- a/terms.html
+++ b/terms.html
@@ -65,7 +65,7 @@ and most national ID systems.
 <a>DID documents</a>) to discover and verify <a>public key descriptions</a>.
   </dd>
 
-  <dt><dfn data-lt="did controllers|did controller(s)|controller">DID controller</dfn></dt>
+  <dt><dfn data-lt="did controllers|did controller(s)">DID controller</dfn></dt>
 
   <dd>
 An entity that has the capability to make changes to a <a>DID document</a>.

--- a/terms.html
+++ b/terms.html
@@ -6,12 +6,13 @@ included whenever they appear in this specification.
 
 <dl class="termlist">
 
-  <dt><dfn data-lt="authenticate">authentication</dfn></dt>
+  <dt><dfn>authenticate</dfn></dt>
   <dd>
-A process (typically some type of protocol) by which an entity can prove it has
-a specific attribute or controls a specific secret using one or more
-<a>verification methods</a>. With <a>DIDs</a>, a common example would be proving
-control of the private key associated with a public key published in a
+Authentication is a process (typically some type of protocol) by which an
+entity can prove it has a specific attribute or controls a specific secret
+using one or more <a>verification methods</a>. With <a>DIDs</a>, a common
+example would be proving control of the private key associated with a public
+key published in a
 <a>DID document</a>.
   </dd>
 
@@ -80,7 +81,7 @@ document</a>. Note that one <a>DID controller</a> may be the <a>DID subject</a>.
 An entity to whom a <a>DID controller</a> has granted permission to use
 a <a>verification method</a> associated with a <a>DID</a> via a <a>DID document</a>.
 For example, a parent who controls a child's <a>DID document</a> might permit
-the child to use their personal device for <a>authentication</a> purposes. In
+the child to use their personal device in order to <a>authenticate</a>. In
 this case, the child is the <a>DID delegate</a>. The child's personal device
 would contain the private cryptographic material enabling the child to
 <a>authenticate</a> using the DID. However the child may not be permitted to


### PR DESCRIPTION
Fixes the markup error that was causing ECHIDNA to fail.

Also disambiguates definitions for controller, authentication and service, as they were duplicated by their respective property definitions. There should be no respec errors on this now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/383.html" title="Last updated on Aug 31, 2020, 8:20 PM UTC (e6a3732)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/383/ce2f9a9...e6a3732.html" title="Last updated on Aug 31, 2020, 8:20 PM UTC (e6a3732)">Diff</a>