### PR TITLE
Re-add language about colons in DID syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -2975,7 +2975,10 @@ rule.
       </p>
       <p class="note" title="Colons in method-specific-id">
 The meaning of colons in the <code>method-specific-id</code> is entirely
-method-specific. Implementers are advised to avoid assuming any meanings or
+method-specific. Colons might be used by <a>DID methods</a> for establishing
+hierarchically partitioned namespaces, for identifying specific instances or
+parts of the <a>verifiable data registry</a>, or for other purposes.        
+Implementers are advised to avoid assuming any meanings or
 behaviors associated with a colon that are generically applicable to all
 <a>DID methods</a>.
       </p>


### PR DESCRIPTION
I propose to re-add language about colons in DID syntax which was originally added in https://github.com/w3c/did-core/pull/215 but then removed again in https://github.com/w3c/did-core/pull/319.

Also see https://github.com/w3c/did-core/issues/98, https://github.com/w3c/did-core/issues/152 and https://github.com/w3c/did-spec-registries/issues/102 for additional discussion about this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/387.html" title="Last updated on Sep 3, 2020, 1:28 PM UTC (c87ee3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/387/5d5e992...c87ee3a.html" title="Last updated on Sep 3, 2020, 1:28 PM UTC (c87ee3a)">Diff</a>