### PR TITLE
Define alsoKnownAs property

### DIFF
--- a/index.html
+++ b/index.html
@@ -1272,6 +1272,9 @@ property.
 <code><a>id</a></code>: defined in <a href="#did-subject"></a>
       </li>
       <li>
+<code><a>alsoKnownAs</a></code>: defined in <a href="#did-subject"></a>
+      </li>
+      <li>
 <code><a>controller</a></code>: defined in <a href="#control"></a>
       </li>
       <li>
@@ -1341,6 +1344,50 @@ resolved, or be populated with the equivalent canonical <a>DID</a>
 specified by the <a>DID method</a>, which SHOULD be used by the resolving 
 party going forward.
       </p>
+
+      <p>
+A <a>DID subject</a> can have multiple identifiers for different purposes, or
+at different times. The assertion that two or more <a>DIDs</a> (or other types
+of <a>URI</a>) identify the same <a>DID subject</a> can be made using the
+<code><a>alsoKnownAs</a></code> property.
+      </p>
+
+      <p>
+<a>DID documents</a> MAY include the <code><a>alsoKnownAs</a></code> property.
+      </p>
+
+      <dl>
+        <dt><dfn>alsoKnownAs</dfn></dt>
+        <dd>
+The value of <code>alsoKnownAs</code> MUST be a
+<a data-cite="INFRA#lists">list</a> where each item in the list is a
+<a>URI</a> conforming to [[RFC3986]].
+        </dd>
+        <dd>
+This relationship is a statement that the subject of this identifier is
+also identified by one or more other identifiers.
+        </dd>
+      </dl>
+
+      <div class="note" title="Equivalence and alsoKnownAs">
+        <p>
+Applications may choose to consider two identifiers related by
+<code><a>alsoKnownAs</a></code> to be equivalent <em>if</em> the
+<code><a>alsoKnownAs</a></code> relationship is reciprocated in the reverse
+direction. It is best practice <em>not</em> to consider them equivalent in the
+absence of this inverse relationship. In other words, the presence of an
+<code><a>alsoKnownAs</a></code> assertion does not prove that this assertion
+is true. Therefore it is strongly advised that a requesting party obtain
+independent verification of an <code>alsoKnownAs</code> assertion.
+        </p>
+        <p>
+Given that the <a>DID subject</a> may use different identifiers for different
+purposes, an expectation of strong equivalence between the two identifiers, or
+merging the graphs of the two corresponding <a>DID documents</a>, is not
+necessarily appropriate, <em>even with</em> a reciprocal relationship.
+        </p>
+      </div>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1371,7 +1371,7 @@ also identified by one or more other identifiers.
 
       <div class="note" title="Equivalence and alsoKnownAs">
         <p>
-Applications may choose to consider two identifiers related by
+Applications might choose to consider two identifiers related by
 <code><a>alsoKnownAs</a></code> to be equivalent <em>if</em> the
 <code><a>alsoKnownAs</a></code> relationship is reciprocated in the reverse
 direction. It is best practice <em>not</em> to consider them equivalent in the

--- a/index.html
+++ b/index.html
@@ -1381,7 +1381,7 @@ is true. Therefore it is strongly advised that a requesting party obtain
 independent verification of an <code>alsoKnownAs</code> assertion.
         </p>
         <p>
-Given that the <a>DID subject</a> may use different identifiers for different
+Given that the <a>DID subject</a> might use different identifiers for different
 purposes, an expectation of strong equivalence between the two identifiers, or
 merging the graphs of the two corresponding <a>DID documents</a>, is not
 necessarily appropriate, <em>even with</em> a reciprocal relationship.


### PR DESCRIPTION
Supersedes https://github.com/w3c/did-core/pull/355

I tried to write the main definition of the property in a generic way that should be acceptable to other communities (ie ActivityPub) who are using this property already. 

There is additional introductory text and a note that are more specific to DIDs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/389.html" title="Last updated on Sep 8, 2020, 8:51 AM UTC (76c1861)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/389/1547e0a...76c1861.html" title="Last updated on Sep 8, 2020, 8:51 AM UTC (76c1861)">Diff</a>