### PR TITLE
Specify format of version-time DID parameter value.

### DIFF
--- a/index.html
+++ b/index.html
@@ -904,8 +904,11 @@ value MUST be an <a data-lt="ascii string">ASCII string</a>.
 Identifies a certain version timestamp of a <a>DID document</a> to be resolved.
 That is, the <a>DID document</a> that was valid for a <a>DID</a> at a certain
 time. Note that this parameter might not be supported by all <a>DID methods</a>.
-The associated value MUST be an
-<a data-lt="ascii string">ASCII string</a>.
+The associated value MUST be an <a data-lt="ascii string">ASCII string</a>
+which is a valid XML datetime value, as defined in section 3.3.7 of
+<a href="https://www.w3.org/TR/xmlschema11-2/">W3C XML Schema Definition
+Language (XSD) 1.1 Part 2: Datatypes</a> [[XMLSCHEMA11-2]]. This datetime value
+MUST be normalized to UTC 00:00, as indicated by the trailing "Z".
               </td>
             </tr>
 


### PR DESCRIPTION
This specifies the format of the value of the `version-time` [DID parameter](https://w3c.github.io/did-core/#did-parameters).

The format specified in this PR is the same as that of the `created` [DID document metadata property](https://w3c.github.io/did-core/#did-document-metadata-properties).

Addresses https://github.com/w3c/did-core/issues/379.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/392.html" title="Last updated on Sep 8, 2020, 8:07 PM UTC (05a6d6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/392/faddd51...05a6d6d.html" title="Last updated on Sep 8, 2020, 8:07 PM UTC (05a6d6d)">Diff</a>