### PR TITLE
Define the JSON representation as JSON (without excluding directives)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2367,11 +2367,6 @@ the root object. Properties MAY define additional data sub structures subject
 to the value representation rules in the list above.
         </p>
 
-        <p>
-The member name <code>@context</code> MUST NOT be used as this property is
-reserved for JSON-LD producers.
-        </p>
-
       </section>
 
       <section>
@@ -2437,11 +2432,7 @@ An "empty" value is not specified by this document. It seems to imply a null
 value, but this is unclear.
         </p>
 
-        <p>
-The value of the <code>@context</code> object member MUST be ignored as this is
-reserved for JSON-LD consumers.
-        </p>
-
+ 
         <p>
 Unknown object member names MUST be ignored as unknown properties.
         </p>


### PR DESCRIPTION
### Producer

1. Unknown/not understood properties MUST be preserved (ignored / serialized).
2. No specific language should be added regarding directives to `application/did+json`

### Consumer

1. Unknown/not understood properties MUST be preserved (ignored / serialized).
2. No specific language should be added regarding directives to `application/did+json`

The JSON section should not reference the JSON-LD representation at all.

https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#61-ignore-rule

> For loosely coupled clients where the exact shape of the data is not known before the call, if the server returns something the client wasn't expecting, the client MUST safely ignore it.

> Some services MAY add fields to responses without changing versions numbers. Services that do so MUST make this clear in their documentation and clients MUST ignore unknown fields.

https://developers.google.com/knowledge-graph/reference/rest/v1?apix_params=%7B%22query%22%3A%22chuck%20norris%22%7D#http_request

Google Knowledge Graph return JSON-LD with  `content-type: application/json; charset=UTF-8`

https://developers.google.com/knowledge-graph/reference/rest/v1

Azure Digital Twin API returns JSON-LD with `content-type` `application/json`

https://docs.microsoft.com/en-us/azure/digital-twins/how-to-manage-routes-apis-cli

JSON Schema has this to say: https://json-schema.org/draft-06/json-schema-core.html

> A JSON document is an information resource (series of octets) described by the application/json media type.

> In JSON Schema, the terms "JSON document", "JSON text", and "JSON value" are interchangeable because of the data model it defines.

> JSON Schema is only defined over JSON documents. However, any document or memory structure that can be parsed into or processed according to the JSON Schema data model can be interpreted against a JSON Schema, including media types like CBOR [RFC7049].

http://json-schema.org/understanding-json-schema/about.html

> You may have noticed that the JSON Schema itself is written in JSON. It is data itself, not a computer program. It’s just a declarative format for “describing the structure of other data”. This is both its strength and its weakness (which it shares with other similar schema languages).

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/JSON

> A JSON object can be stored in its own file, which is basically just a text file with an extension of .json, and a MIME type of application/json.

https://tools.ietf.org/html/rfc4627

>  JSON's design goals were for it to be minimal, portable, textual, and a subset of JavaScript.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/396.html" title="Last updated on Sep 22, 2020, 2:50 PM UTC (5a86fa4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/396/fbff723...5a86fa4.html" title="Last updated on Sep 22, 2020, 2:50 PM UTC (5a86fa4)">Diff</a>