### PR TITLE
Make alsoKnownAs a subsection of DID Subject.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1217,7 +1217,7 @@ property.
 <code><a>id</a></code>: defined in <a href="#did-subject"></a>
       </li>
       <li>
-<code><a>alsoKnownAs</a></code>: defined in <a href="#did-subject"></a>
+<code><a>alsoKnownAs</a></code>: defined in <a href="#alsoknownas"></a>
       </li>
       <li>
 <code><a>controller</a></code>: defined in <a href="#control"></a>
@@ -1290,32 +1290,35 @@ specified by the <a>DID method</a>, which SHOULD be used by the resolving
 party going forward.
       </p>
 
-      <p>
+    <section>
+      <h3>alsoKnownAs</h3>
+
+        <p>
 A <a>DID subject</a> can have multiple identifiers for different purposes, or
 at different times. The assertion that two or more <a>DIDs</a> (or other types
 of <a>URI</a>) identify the same <a>DID subject</a> can be made using the
 <code><a>alsoKnownAs</a></code> property.
-      </p>
+        </p>
 
-      <p>
+        <p>
 <a>DID documents</a> MAY include the <code><a>alsoKnownAs</a></code> property.
-      </p>
+        </p>
 
-      <dl>
-        <dt><dfn>alsoKnownAs</dfn></dt>
-        <dd>
+        <dl>
+          <dt><dfn>alsoKnownAs</dfn></dt>
+          <dd>
 The value of <code>alsoKnownAs</code> MUST be a
 <a data-cite="INFRA#lists">list</a> where each item in the list is a
 <a>URI</a> conforming to [[RFC3986]].
-        </dd>
-        <dd>
+          </dd>
+          <dd>
 This relationship is a statement that the subject of this identifier is
 also identified by one or more other identifiers.
-        </dd>
-      </dl>
+          </dd>
+        </dl>
 
-      <div class="note" title="Equivalence and alsoKnownAs">
-        <p>
+        <div class="note" title="Equivalence and alsoKnownAs">
+          <p>
 Applications might choose to consider two identifiers related by
 <code><a>alsoKnownAs</a></code> to be equivalent <em>if</em> the
 <code><a>alsoKnownAs</a></code> relationship is reciprocated in the reverse
@@ -1324,15 +1327,16 @@ absence of this inverse relationship. In other words, the presence of an
 <code><a>alsoKnownAs</a></code> assertion does not prove that this assertion
 is true. Therefore it is strongly advised that a requesting party obtain
 independent verification of an <code>alsoKnownAs</code> assertion.
-        </p>
-        <p>
+          </p>
+          <p>
 Given that the <a>DID subject</a> might use different identifiers for different
 purposes, an expectation of strong equivalence between the two identifiers, or
 merging the graphs of the two corresponding <a>DID documents</a>, is not
 necessarily appropriate, <em>even with</em> a reciprocal relationship.
-        </p>
-      </div>
+          </p>
+        </div>
 
+      </section>
     </section>
 
     <section>


### PR DESCRIPTION
This is just a small formatting idea which I mentioned in https://github.com/w3c/did-core/pull/389#pullrequestreview-484539080.

Right now, all the [Core Properties](https://w3c.github.io/did-core/#core-properties) have their own (sub-)section, except for the new `alsoKnownAs`. The PR simply creates a subsection for this property as well.

I don't feel strongly about it, feel free to simply upvote or downvote..


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/397.html" title="Last updated on Sep 17, 2020, 10:24 AM UTC (a247c30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/397/fbff723...a247c30.html" title="Last updated on Sep 17, 2020, 10:24 AM UTC (a247c30)">Diff</a>