### PR TITLE
Add JsonWebKey2020  (JWK) key representation to did core.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1683,6 +1683,14 @@ a JWK [[RFC7517]] or be encoded as the raw 32-byte public key value in Base58
 Bitcoin format [[BASE58]] using the <code>publicKeyBase58</code> property.
               </td>
             </tr>
+            <tr>
+              <td>
+JWK<br/>(<code>JsonWebKey2020</code>)
+              </td>
+              <td>
+Key types listed in <a href="https://www.iana.org/assignments/jose/jose.xhtml">JOSE</a>, represented using [[RFC7517]] using the <code>publicKeyJwk</code> property.
+              </td>
+            </tr>
           </tbody>
         </table>
 
@@ -1697,7 +1705,7 @@ Example:
   <span class="comment">...</span>
   "verificationMethod": [{
     "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
-    "type": "JwsVerificationKey2020",
+    "type": "JsonWebKey2020",
     "controller": "did:example:123",
     "publicKeyJwk": {
       "crv": "Ed25519",


### PR DESCRIPTION
addresses https://github.com/w3c/did-core/issues/405


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/406.html" title="Last updated on Sep 20, 2020, 3:50 PM UTC (602e2f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/406/fbff723...602e2f0.html" title="Last updated on Sep 20, 2020, 3:50 PM UTC (602e2f0)">Diff</a>