### PR TITLE
Cleanup key representations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,7 +1658,7 @@ encoded as the raw 32-byte public key value in Base58 Bitcoin format
 secp256k1
               </td>
               <td>
-Secp256k1 Koblitz public key values MUST either be encoded as a JWK [[RFC7517]] 
+Secp256k1 public key values MUST either be encoded as a JWK [[RFC7517]] 
 using the <code>publicKeyJwk</code> or be
 encoded as the raw 33-byte public key value in Base58
 Bitcoin format [[BASE58]] using the <code>publicKeyBase58</code> property.

--- a/index.html
+++ b/index.html
@@ -1619,7 +1619,7 @@ expressed and encoded.
         <table class="simple" id="public-key-support">
           <caption>
 This table defines the support for public key expression in a DID document.
-For each public key type, a maximum of two encoding formats are supported.
+For each public key type, a maximum of two encoding formats is supported.
           </caption>
           <thead>
             <tr>
@@ -1638,9 +1638,8 @@ Support
 RSA<br/>(<code>RsaVerificationKey2018</code>)
               </td>
               <td>
-RSA public key values MUST either be encoded as a JWK [[RFC7517]] or be
-encoded in Privacy Enhanced Mail (PEM) format using the
-<code>publicKeyPem</code> property.
+RSA public key values MUST be encoded as a JWK [[RFC7517]] using the
+<code>publicKeyJwk</code> property.
               </td>
             </tr>
             <tr>
@@ -1648,29 +1647,21 @@ encoded in Privacy Enhanced Mail (PEM) format using the
 ed25519<br/>(<code>Ed25519VerificationKey2018</code>)
               </td>
               <td>
-Ed25519 public key values MUST either be encoded as a JWK [[RFC7517]] or be
+Ed25519 public key values MUST either be encoded as a JWK [[RFC7517]] 
+using the <code>publicKeyJwk</code> or be
 encoded as the raw 32-byte public key value in Base58 Bitcoin format
 [[BASE58]] using the <code>publicKeyBase58</code> property.
               </td>
             </tr>
             <tr>
               <td>
-secp256k1-koblitz<br/>(pending)
+secp256k1
               </td>
               <td>
-Secp256k1 Koblitz public key values MUST either be encoded as a JWK
-[[RFC7517]] or be encoded as the raw 33-byte public key value in Base58
+Secp256k1 Koblitz public key values MUST either be encoded as a JWK [[RFC7517]] 
+using the <code>publicKeyJwk</code> or be
+encoded as the raw 33-byte public key value in Base58
 Bitcoin format [[BASE58]] using the <code>publicKeyBase58</code> property.
-              </td>
-            </tr>
-            <tr>
-              <td>
-secp256r1<br/>(<code>SchnorrSecp256k1VerificationKey2019</code>)
-              </td>
-              <td>
-Secp256r1 public key values MUST either be encoded as a JWK [[RFC7517]] or be
-encoded as the raw 32-byte public key value encoded in Base58 Bitcoin format
-[[BASE58]] using the <code>publicKeyBase58</code> property.
               </td>
             </tr>
             <tr>
@@ -1678,8 +1669,9 @@ encoded as the raw 32-byte public key value encoded in Base58 Bitcoin format
 Curve25519<br/>(<code>X25519KeyAgreementKey2019</code>)
               </td>
               <td>
-Curve25519 (also known as X25519) public key values MUST either be encoded as
-a JWK [[RFC7517]] or be encoded as the raw 32-byte public key value in Base58
+Curve25519 (also known as X25519) public key values MUST either be encoded 
+as a JWK [[RFC7517]] using the <code>publicKeyJwk</code> or be 
+encoded as the raw 32-byte public key value in Base58
 Bitcoin format [[BASE58]] using the <code>publicKeyBase58</code> property.
               </td>
             </tr>
@@ -1697,7 +1689,7 @@ Example:
   <span class="comment">...</span>
   "verificationMethod": [{
     "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
-    "type": "JwsVerificationKey2020",
+    "type": "JsonWebKey2020",
     "controller": "did:example:123",
     "publicKeyJwk": {
       "crv": "Ed25519",
@@ -1710,11 +1702,6 @@ Example:
     "type": "Ed25519VerificationKey2018",
     "controller": "did:example:pqrstuvwxyz0987654321",
     "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
-  }, {
-    "id": "did:example:123456789abcdefghi#keys-2",
-    "type": "Secp256k1VerificationKey2018",
-    "controller": "did:example:123456789abcdefghi",
-    "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"
   }],
   <span class="comment">...</span>
 }

--- a/index.html
+++ b/index.html
@@ -1616,6 +1616,13 @@ will be elaborated upon in this specification and if so, how they will be
 expressed and encoded.
         </p>
 
+<p class="issue" data-number="423">
+The Working Group is still debating how best to communicate support for 
+specific verification method types.
+</p>
+
+        https://github.com/w3c/did-core/issues/
+
         <table class="simple" id="public-key-support">
           <caption>
 This table defines the support for public key expression in a DID document.


### PR DESCRIPTION
addresses https://github.com/w3c/did-core/issues/405

- [x] Remove undocumented and unused Schnorr hand waving
- [x] Remove publicKeyPem from RSA (JWK only)
- [x] Fix Json Web Key name
- [x] clarify how `publicKeyJwk` is used instead of `publicKeyBase58`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/407.html" title="Last updated on Oct 9, 2020, 5:19 PM UTC (5a68b39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/407/fbff723...5a68b39.html" title="Last updated on Oct 9, 2020, 5:19 PM UTC (5a68b39)">Diff</a>