### PR TITLE
Add JSON-LD Producer / Consumer details

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
     src='https://www.w3.org/Tools/respec/respec-w3c-common'>
   </script><!--script src='./respec-w3c-common.js' class='remove'></script-->
 
+  <script src="https://unpkg.com/reqlist/lib/reqlist.js" class="remove"></script>
+  <link href="https://unpkg.com/reqlist/lib/reqlist.css" class="removeOnSave" rel="stylesheet" type="text/css" />
+
   <script class='remove' src="./common.js">
   </script>
   <script class="remove" type="text/javascript">
@@ -55,6 +58,15 @@
             branch: "master"
     },
     includePermalinks: false,
+
+    // Uncomment these to use the respec extension that generates a list of
+    //   normative statements:
+    // preProcess: [
+    //   prepare_reqlist
+    // ],
+    // postProcess: [
+    //   add_reqlist_button
+    // ],
 
 
     // editors, add as many as you like

--- a/index.html
+++ b/index.html
@@ -2526,7 +2526,7 @@ The value of the <code>@context</code> property MUST be exactly one of the follo
   </li>
   <li>An array of one or more elements,
     where the value of the first element is
-    <code>https://www.w3.org/ns/did/v1</code>.
+    a string with the value of <code>https://www.w3.org/ns/did/v1</code>.
 
     <pre class="example">
       {

--- a/index.html
+++ b/index.html
@@ -2379,6 +2379,11 @@ the root object. Properties MAY define additional data sub structures subject
 to the value representation rules in the list above.
         </p>
 
+        <p>
+The member name <code>@context</code> MUST NOT be used as this property is
+reserved for JSON-LD producers.
+        </p>
+
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2525,7 +2525,7 @@ The value of the <code>@context</code> property MUST be exactly one of the follo
     </pre>
   </li>
   <li>An array of one or more elements,
-    where the value of the first <a>URI</a> is
+    where the value of the first element is
     <code>https://www.w3.org/ns/did/v1</code>.
 
     <pre class="example">

--- a/index.html
+++ b/index.html
@@ -2626,7 +2626,7 @@ that decision.
 
         <p>
           Consumers SHOULD drop all properties from a DID Documents that 
-          are not defined by the <code>@context</code>. 
+          are not defined via the <code>@context</code>. 
         </p>
  
       </section>

--- a/index.html
+++ b/index.html
@@ -2572,7 +2572,7 @@ registries, then the DID Document will not be interoperable across
 representations.
 
 <p>
-  Producers SHOULD not produce DID Documents that 
+  Producers SHOULD NOT produce DID Documents that 
   contain properties not defined by the <code>@context</code>. 
   Such properties MAY be dropped by Consumers.
 </p>

--- a/index.html
+++ b/index.html
@@ -2557,6 +2557,7 @@ The value of <code>@context</code> MUST be exactly one of these values.
         ...
       }
     </pre>
+    <p class="issue"  data-number="432">The working group is still discussing restrictions on <code>@base</code>, beyond what JSON-LD allows.</p>
   </li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -2549,10 +2549,7 @@ The value of <code>@context</code> MUST be exactly one of these values.
       {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://example.com/blockchain-identity/v1",
-          {
-            "@base": "did:example:123"
-          }
+          "https://example.com/blockchain-identity/v1"
         ],
         ...
       }

--- a/index.html
+++ b/index.html
@@ -2510,43 +2510,41 @@ Production
         </h3>
 
         <p>
-The <a>DID document</a> is serialized following the rules in the JSON processor,
-with one addition: <a>DID documents</a> MUST include the <code>@context</code>
-property.
+The <a>DID document</a> MUST be serialized as a JSON document,
+with one additional requirement: <br/> 
+The <a>DID document</a> MUST include the <code>@context</code> property.
         </p>
 
         <dl>
           <dt>@context</dt>
           <dd>
-The value of the <code>@context</code> property MUST be exactly one of the following:
+
+<p>
+The <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD specification </a> 
+defines values that are valid for this property.
+</p>
+
+<p>
+The value of <code>@context</code> MUST be exactly one of these values.
+</p>
 
 <ul>
-  <li>The string <code>https://www.w3.org/ns/did/v1</code>. 
+  <li>
+    The <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a>
+    <code>https://www.w3.org/ns/did/v1</code>.
     <pre class="example">
       {
         "@context": "https://www.w3.org/ns/did/v1",
-        "id": "did:example:123"
-      }      
+        ...
+      }
     </pre>
   </li>
-  <li>An array of one or more elements,
-    where the value types of the members of the array
-    MUST be either a string or an object and the first element is
-    the string <code>https://www.w3.org/ns/did/v1</code>.
-
-    <pre class="example">
-      {
-        "@context": [
-          "https://www.w3.org/ns/did/v1",
-          "https://example.com/blockchain-identity/v1"
-        ],
-        "id": "did:example:123"
-      }      
-    </pre>
-  </li>
-  <li>An array where the first value is
-    <code>https://www.w3.org/ns/did/v1</code>, and the final value is an object.
-
+  <li>
+    An <a href="https://infra.spec.whatwg.org/#lists">INFRA list</a>, 
+    with first item the <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a>
+    <code>https://www.w3.org/ns/did/v1</code>, and subsequent items of type 
+    <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a> or 
+    <a href="https://infra.spec.whatwg.org/#maps">INFRA map</a>.
     <pre class="example">
       {
         "@context": [
@@ -2556,11 +2554,12 @@ The value of the <code>@context</code> property MUST be exactly one of the follo
             "@base": "did:example:123"
           }
         ],
-        "id": "did:example:123"
-      }      
+        ...
+      }
     </pre>
   </li>
 </ul>
+
 
 All members of the
 <code>@context</code> property SHOULD exist in the DID specification
@@ -2568,12 +2567,12 @@ registries in order to achieve interoperability across different
 representations. 
 
 If a member does not exist in the DID specification
-registries, then the DID Document will not be interoperable across
+registries, then the DID Document might not be interoperable across
 representations.
 
 <p>
   Producers SHOULD NOT produce DID Documents that 
-  contain properties not defined by the <code>@context</code>. 
+  contain properties not defined via the <code>@context</code>. 
   Properties that are not defined via the <code>@context</code> MAY be dropped by Consumers.
 </p>
 

--- a/index.html
+++ b/index.html
@@ -2379,10 +2379,6 @@ the root object. Properties MAY define additional data sub structures subject
 to the value representation rules in the list above.
         </p>
 
-        <p>
-The member name <code>@context</code> MUST NOT be used as this property is
-reserved for JSON-LD producers.
-        </p>
 
       </section>
 
@@ -2517,25 +2513,66 @@ property.
         <dl>
           <dt>@context</dt>
           <dd>
-The value of the <code>@context</code> property MUST be one or more <a>URIs</a>,
-where the value of the first <a>URI</a> is
-<code>https://www.w3.org/ns/did/v1</code>. All members of the
+The value of the <code>@context</code> property MUST be exactly one of the following:
+
+<ul>
+  <li>The string <code>https://www.w3.org/ns/did/v1</code>. 
+    <pre class="example">
+      {
+        "@context": "https://www.w3.org/ns/did/v1",
+        "id": "did:example:123"
+      }      
+    </pre>
+  </li>
+  <li>An array of one or more <a>URIs</a>,
+    where the value of the first <a>URI</a> is
+    <code>https://www.w3.org/ns/did/v1</code>.
+
+    <pre class="example">
+      {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://example.com/blockchain-identity/v1"
+        ],
+        "id": "did:example:123"
+      }      
+    </pre>
+  </li>
+  <li>An array where the first value is
+    <code>https://www.w3.org/ns/did/v1</code>, and the final value is an object.
+
+    <pre class="example">
+      {
+        "@context": [
+          "https://www.w3.org/ns/did/v1",
+          "https://example.com/blockchain-identity/v1",
+          {
+            "@base": "did:example:123"
+          }
+        ],
+        "id": "did:example:123"
+      }      
+    </pre>
+  </li>
+</ul>
+
+All members of the
 <code>@context</code> property SHOULD exist in the DID specification
 registries in order to achieve interoperability across different
-representations. If a member does not exist in the DID specification
+representations. 
+
+If a member does not exist in the DID specification
 registries, then the DID Document will not be interoperable across
 representations.
+
+<p>
+  Producers SHOULD not produce DID Documents that 
+  contain properties not defined by the <code>@context</code>. 
+  Such properties MAY be dropped by Consumers.
+</p>
+
           </dd>
         </dl>
-
-        <p class="issue" data-number="202">
-This specification defines globally interoperable documents, and the requirement
-that the context value be in the verifiable data registry means that different JSON-LD
-processors can consume the document without having to dereference anything in
-the context field. However, a pair of producers and consumers can have local
-extension agreements. This needs to be clarified in a section on extensibility
-and linked here when available.
-        </p>
 
       </section>
 
@@ -2554,9 +2591,10 @@ interpreted using JSON-LD processing under the rules of the defined
         <dl>
           <dt>@context</dt>
           <dd>
-The value of the <code>@context</code> property MUST be one or more <a>URIs</a>,
-where the value of the first <a>URI</a> is
-<code>https://www.w3.org/ns/did/v1</code>. If more than one <a>URI</a> is
+The value of the <code>@context</code> property MUST conform 
+to the <a href="#production-0">JSON-LD Production Rules</a>. 
+
+If more than one <a>URI</a> is
 provided, the <a>URIs</a> MUST be interpreted as an ordered set. It is
 RECOMMENDED that dereferencing each <a>URI</a> results in a document containing
 machine-readable information about the context. To enable interoperability
@@ -2580,6 +2618,11 @@ unknown data members on consumption, and this section needs to be updated with
 that decision.
         </p>
 
+        <p>
+          Consumers SHOULD drop all properties from a DID Documents that 
+          are not defined by the <code>@context</code>. 
+        </p>
+ 
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -2574,7 +2574,7 @@ representations.
 <p>
   Producers SHOULD NOT produce DID Documents that 
   contain properties not defined by the <code>@context</code>. 
-  Such properties MAY be dropped by Consumers.
+  Properties that are not defined via the <code>@context</code> MAY be dropped by Consumers.
 </p>
 
           </dd>

--- a/index.html
+++ b/index.html
@@ -2524,7 +2524,7 @@ The value of the <code>@context</code> property MUST be exactly one of the follo
       }      
     </pre>
   </li>
-  <li>An array of one or more <a>URIs</a>,
+  <li>An array of one or more elements,
     where the value of the first <a>URI</a> is
     <code>https://www.w3.org/ns/did/v1</code>.
 


### PR DESCRIPTION
- [x] JSON-LD Producers MAY use `string` or `array of string or object` values for `@context`

- [x] JSON-LD Producers SHOULD NOT produce DID Documents with terms not defined in `@context`.
- [x] JSON-LD Consumers SHOULD drop properties from DID Documents not defined in `@context`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/408.html" title="Last updated on Oct 12, 2020, 1:56 PM UTC (de525cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/408/1547e0a...de525cd.html" title="Last updated on Oct 12, 2020, 1:56 PM UTC (de525cd)">Diff</a>