### PR TITLE
normative statements: Conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,19 +676,18 @@ implementations of a given DID method must be interoperable for that method).
       </p>
 
      <p>
-A <dfn>conforming DID</dfn> is any concrete expression of the rules specified in
-Section <a href="#identifier"></a> and MUST comply with relevant normative
+A <dfn>conforming DID</dfn> is any concrete expression of the rules specified
+in Section <a href="#identifier"></a> and complies with relevant normative
 statements in that section.
      </p>
 
       <p>
 A <dfn>conforming DID document</dfn> is any concrete expression of the data
-model described in this specification and MUST comply with the relevant
+model described in this specification and complies with with the relevant
 normative statements in Sections <a href="#data-model"></a> and  <a
-href="#core-properties"></a>. A serialization format for the conforming document
-MUST be deterministic, bi-directional, and lossless as described in Section <a
-href="#core-representations"></a>. The <a>conforming DID document</a> MAY be
-transmitted or stored in any such serialization format.
+href="#core-properties"></a>. A serialization format for the conforming
+document is deterministic, bi-directional, and lossless as described in
+Section <a href="#core-representations"></a>.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -677,13 +677,13 @@ implementations of a given DID method must be interoperable for that method).
 
      <p>
 A <dfn>conforming DID</dfn> is any concrete expression of the rules specified
-in Section <a href="#identifier"></a> and complies with relevant normative
+in Section <a href="#identifier"></a> which complies with relevant normative
 statements in that section.
      </p>
 
       <p>
 A <dfn>conforming DID document</dfn> is any concrete expression of the data
-model described in this specification and complies with with the relevant
+model described in this specification which complies with the relevant
 normative statements in Sections <a href="#data-model"></a> and  <a
 href="#core-properties"></a>. A serialization format for the conforming
 document is deterministic, bi-directional, and lossless as described in


### PR DESCRIPTION
Removes untestable normative language from Conformance section, towards #384


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/426.html" title="Last updated on Oct 18, 2020, 4:00 PM UTC (d3d5772)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/426/c764c67...d3d5772.html" title="Last updated on Oct 18, 2020, 4:00 PM UTC (d3d5772)">Diff</a>