### PR TITLE
normative statements: Representations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2281,12 +2281,12 @@ All concrete representations of a <a>DID document</a> are serialized using a
 deterministic mapping that is able to be unambiguously parsed into the data
 model defined in this specification. All serialization methods MUST define rules
 for the bidirectional translation of a <a>DID document</a> both into and out of
-the representation in question. As a consequence, translation between any two
-representations MUST be done by parsing the source format into a <a>DID
-document</a> model (described in Sections <a href="#data-model"></a> and <a
-href="#core-properties"></a>) and then serializing the <a>DID document</a> model
-into the target representation. An implementation MUST NOT convert between
-representations without first parsing to a <a>DID document</a> model.
+the representation in question. An implementation MUST NOT convert between
+representations without first parsing to a <a>DID document</a> model
+(described in Sections <a href="#data-model"></a> and <a
+href="#core-properties"></a>); translation between any two representations is
+done by parsing the source format into a <a>DID document</a> model and then
+serializing the <a>DID document</a> model into the target representation.
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -2277,7 +2277,7 @@ and <a href="#authentication"></a>.
     <h1>Core Representations</h1>
 
     <p>
-All concrete representations of a <a>DID document</a> MUST be serialized using a
+All concrete representations of a <a>DID document</a> are serialized using a
 deterministic mapping that is able to be unambiguously parsed into the data
 model defined in this specification. All serialization methods MUST define rules
 for the bidirectional translation of a <a>DID document</a> both into and out of

--- a/index.html
+++ b/index.html
@@ -2297,10 +2297,10 @@ capable of expressing the data model, such as XML or YAML.
 
     <p>
 Producers MUST indicate which representation of a document has been used via a
-media type in the document's metadata. Consumers MUST determine which
-representation a document is in via the <code>content-type</code> DID resolver
-metadata field. (See <a href="#did-resolution"></a>). Consumers MUST NOT
-determine the representation of a document through its content alone.
+media type in the document's metadata. Consumers MUST determine the
+representation of a <a>DID document</a> via the <code>content-type</code> DID
+resolver metadata field (see <a href="#did-resolution"></a>), <em>not</em>
+through the content of the <a>DID document</a> alone.
     </p>
 
     <p class="issue" data-number="203">


### PR DESCRIPTION
Some of the normative statements in the Representations section appear to be saying the same thing twice, in the inverse. I've tried to resolve these to make the more succinct in terms of normative requirements, but maintain most of the original language for clarity. Please let me know if I accidentally removed a distinct normative req though. See: #384


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/434.html" title="Last updated on Oct 18, 2020, 6:18 PM UTC (a680816)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/434/c764c67...a680816.html" title="Last updated on Oct 18, 2020, 6:18 PM UTC (a680816)">Diff</a>