### PR TITLE
normative statements: Security considerations / methods sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -3168,13 +3168,13 @@ replay, message insertion, deletion, modification, and man-in-the-middle.
 Potential denial of service attacks MUST be identified as well.
       </p>
       <p>
-This section MUST discuss, per Section 5 of [[RFC3552]], residual risks (such as
-the risks from compromise in a related protocol, incorrect implementation, or
-cipher) after threat mitigation was deployed.
+This section MUST discuss, per Section 5 of [[RFC3552]], residual risks (such
+as the risks from compromise in a related protocol, incorrect implementation,
+or cipher) after threat mitigation was deployed.
       </p>
       <p>
-This section MUST provide integrity protection and update authentication for all
-operations required by Section <a href="#method-operations"></a>.
+This section MUST provide integrity protection and update authentication for
+all operations required by Section <a href="#method-operations"></a>.
       </p>
       <p>
 If the technology involves authentication, particularly user-host
@@ -3183,12 +3183,12 @@ specified.
       </p>
       <p>
 <a>DID methods</a> MUST discuss the policy mechanism by which <a>DIDs</a> are
-proven to be uniquely assigned. A <a>DID</a> fits the functional definition of a
-URN, as defined in [[RFC8141]]. That is, a <a>DID</a> is a persistent identifier
-that is assigned once to a resource and never reassigned to a different
-resource. This is particularly important in a security context because a
-<a>DID</a> might be used to identify a specific party subject to a specific set
-of authorization rights.
+proven to be uniquely assigned. A <a>DID</a> fits the functional definition of
+a URN, as defined in [[RFC8141]]. That is, a <a>DID</a> is a persistent
+identifier that is assigned once to a resource and never reassigned to a
+different resource. This is particularly important in a security context
+because a <a>DID</a> might be used to identify a specific party subject to a
+specific set of authorization rights.
       </p>
       <p>
 Method-specific endpoint authentication MUST be discussed. Where <a>DID
@@ -3210,6 +3210,10 @@ on.
       <p>
 Data which is to be held secret (keying material, random seeds, and so on)
 SHOULD be clearly labeled.
+      </p>
+      <p>
+<a>DID method</a> specifications SHOULD explain and specify the implementation
+of signatures on <a>DID documents</a>, if applicable.
       </p>
       <p>
 Where <a>DID methods</a> make use of peer-to-peer computing resources, such as
@@ -3827,8 +3831,8 @@ Proving Control of a DID and DID Document
         </h3>
 
         <p>
-Signatures and <a>verifiable timestamps</a> allow <a>DID documents</a> to be cryptographically
-verifiable.
+Signatures and <a>verifiable timestamps</a> allow <a>DID documents</a> to be
+cryptographically verifiable.
         </p>
 
         <p>
@@ -3848,8 +3852,8 @@ the time the timestamp was created.
         </ul>
 
         <p>
-Proving control of a <a>DID</a>, that is, the binding between the <a>DID</a> and
-the <a>DID document</a> that describes it, requires a two step process:
+Proving control of a <a>DID</a>, that is, the binding between the <a>DID</a>
+and the <a>DID document</a> that describes it, requires a two step process:
         </p>
 
         <ol start="1">
@@ -3859,8 +3863,8 @@ Resolving the <a>DID</a> to a <a>DID document</a> according to its
           </li>
 
           <li>
-Verifying that the <code><a>id</a></code> property of the resulting <a>DID document</a>
-matches the <a>DID</a> that was resolved.
+Verifying that the <code><a>id</a></code> property of the resulting <a>DID
+document</a> matches the <a>DID</a> that was resolved.
           </li>
         </ol>
 
@@ -3871,7 +3875,8 @@ It should be noted that this process proves control of a <a>DID</a> and
 
         <p>
 Signatures on <a>DID documents</a> are optional. <a>DID method</a>
-specifications SHOULD explain and specify their implementation if applicable.
+specifications are expected to explain and specify their implementation if
+applicable.
         </p>
       </section>
 


### PR DESCRIPTION
Moves normative language about signatures on DID docs (keeping informative guidance) from Security Consideration to Methods section. #384


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/438.html" title="Last updated on Oct 13, 2020, 1:57 PM UTC (fec222f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/438/c764c67...fec222f.html" title="Last updated on Oct 13, 2020, 1:57 PM UTC (fec222f)">Diff</a>