### PR TITLE
editorial: Clarify that id is only for DID subject when at top level

### DIFF
--- a/index.html
+++ b/index.html
@@ -1257,14 +1257,15 @@ Sub-properties include <code>id</code>, <code>type</code> and
       <h2>DID Subject</h2>
 
       <p>
-The <a>DID subject</a> is denoted with the <code><a>id</a></code> property. The
-<a>DID subject</a> is the entity that the <a>DID document</a> is about. That is,
-it is the entity identified by the <a>DID</a> and described by the
-<a>DID document</a>.
+The <a>DID subject</a> is denoted with the <code><a>id</a></code> property at
+the top level of a <a>DID document</a>. The <a>DID subject</a> is the entity
+that the <a>DID document</a> is about. That is, it is the entity identified by
+the <a>DID</a> and described by the <a>DID document</a>.
       </p>
 
       <p>
-<a>DID documents</a> MUST include the <code><a>id</a></code> property.
+<a>DID documents</a> MUST include the <code><a>id</a></code> property at the
+top level.
       </p>
 
       <dl>
@@ -1292,6 +1293,15 @@ resolved <a>DID document</a> MUST match the <a>DID</a> that was
 resolved, or be populated with the equivalent canonical <a>DID</a>
 specified by the <a>DID method</a>, which SHOULD be used by the resolving
 party going forward.
+      </p>
+
+      <p class="note" title="Nested objects with the id property">
+A <a>DID document</a> can contain objects which have their own unique
+identifier; see, for example, <a href="#verification-methods"></a>. Such other
+objects also use the <code>id</code> property to denote the identifier of
+the object in question. The <code>id</code> property only denotes the
+<a>DID</a> of the <a>DID subject</a> when it is present at the <em>top
+level</em> of a <a>DID document</a>.
       </p>
 
     <section>


### PR DESCRIPTION
Adds explicitly "at the top level" to statements about the `id` property denoting the DID subject, and a note that clarifies further that `id` may be used on nested objects and does not denote the DID subject in that case. Raised in #401.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/449.html" title="Last updated on Oct 27, 2020, 7:51 PM UTC (b7daf99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/449/5dd10b5...b7daf99.html" title="Last updated on Oct 27, 2020, 7:51 PM UTC (b7daf99)">Diff</a>