### PR TITLE
terms: add 'immutable' to DLT definition

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -213,11 +213,13 @@ function for a given <a>DID URL</a> or <a>DID document</a>.
   <dt><dfn data-lt="distributed ledger technology|DLT">distributed ledger</dfn> (DLT)</dt>
 
   <dd>
-A <a href="https://en.wikipedia.org/wiki/Distributed_database">distributed database</a>
-in which the various nodes use a
-<a href="https://en.wikipedia.org/wiki/Consensus_(computer_science)">consensus protocol</a>
-to maintain an immutable shared ledger in which each transaction is cryptographically
-signed and chained to the previous transaction.
+A non-centralized system for recording events. These systems establish
+sufficient confidence for participating users to rely upon the data recorded
+by others to make operational decisions. They typically use distributed
+databases where different nodes use a consensus protocol to confirm the
+ordering of cryptographically signed transactions. The linking of digitally
+signed transactions over time often makes the history of the ledger
+effectively immutable.
   </dd>
 
   <dt><dfn data-lt="proofPurpose">proof purpose</dfn></dt>

--- a/terms.html
+++ b/terms.html
@@ -216,7 +216,7 @@ function for a given <a>DID URL</a> or <a>DID document</a>.
 A <a href="https://en.wikipedia.org/wiki/Distributed_database">distributed database</a>
 in which the various nodes use a
 <a href="https://en.wikipedia.org/wiki/Consensus_(computer_science)">consensus protocol</a>
-to maintain a shared ledger in which each transaction is cryptographically
+to maintain an immutable shared ledger in which each transaction is cryptographically
 signed and chained to the previous transaction.
   </dd>
 

--- a/terms.html
+++ b/terms.html
@@ -214,7 +214,7 @@ function for a given <a>DID URL</a> or <a>DID document</a>.
 
   <dd>
 A non-centralized system for recording events. These systems establish
-sufficient confidence for participating users to rely upon the data recorded
+sufficient confidence for participants to rely upon the data recorded
 by others to make operational decisions. They typically use distributed
 databases where different nodes use a consensus protocol to confirm the
 ordering of cryptographically signed transactions. The linking of digitally


### PR DESCRIPTION
Suggested by @iherman in #401. Obviously not an expert, my understanding is a DLT is kinda shoulda supposed to be immutable but under certain situations this might not technically be the case; but for the purposes of this definition stating it as Ivan suggests I think is probably right. Look, now this comment took longer to write than making the change itself. Just close the PR if it's not appropriate to add "immutable" anyway.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/450.html" title="Last updated on Nov 11, 2020, 2:19 PM UTC (dba8371)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/450/b426d48...dba8371.html" title="Last updated on Nov 11, 2020, 2:19 PM UTC (dba8371)">Diff</a>