### PR TITLE
Rework Data Model section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,7 +588,7 @@ DID documents
 typically express verification methods (such as public keys) and <a>services</a>
 relevant to interactions with the DID subject. A DID document is represents an
 abstract data model, and can be serialized according to a particular syntax
-(see <a href="#core-representations"></a>).  The generic properties supported
+(see <a href="#representations"></a>).  The generic properties supported
 in a DID document are specified in <a href="#core-properties"></a>.
 The <a>DID</a> itself is the value of the `id` property. The properties
 present in a DID document may be updated according to the applicable
@@ -684,7 +684,7 @@ model described in this specification which complies with the relevant
 normative statements in Sections <a href="#data-model"></a> and  <a
 href="#core-properties"></a>. A serialization format for the conforming
 document is deterministic, bi-directional, and lossless as described in
-Section <a href="#core-representations"></a>.
+Section <a href="#representations"></a>.
       </p>
 
       <p>
@@ -1037,7 +1037,7 @@ that are more restrictive than the generic rules in this section.
         <p>
 In order to maximize interoperability, implementers are urged to ensure that
 <a>DID fragments</a> are interpreted in the same way across representations (as
-described in <a href="#core-representations"></a>). For example, while
+described in <a href="#representations"></a>). For example, while
 JSON Pointer [[?RFC6901]] can be used in a <a>DID fragment</a>, it will not
 be interpreted in the same way across representations.
         </p>
@@ -1127,47 +1127,127 @@ absolute DID URL value of <code>did:example:123456789abcdefghi#key-1</code>.
   <section>
     <h1>Data Model</h1>
     <p>
-This specification defines an abstract data model for <a>DID documents</a>,
-independent of any specific representation. This section provides a
-high-level description of the data model, a set of requirements for
-representations, and a set of requirements for extensibility.
+This specification defines an abstract data model for <a>DID documents</a> that
+is capable of being serialized into multiple concrete representations. This
+section provides a high-level description of the data model, how different types
+of properties are expressed in the data model, and instructions for extending
+the data model.
     </p>
-    <section>
-      <h2>Definition</h2>
-      <p>
+    <p>
 A <a>DID document</a> consists of a <a data-cite="INFRA#maps">map</a> of <a
-data-cite="INFRA#map-entry">properties</a>, which are name-value pairs (ie. a
-property name, and a property value). The definitions of each of these
-properties are specified in section <a href="#core-properties"></a>. Specific
-representations are defined in section <a href="#core-representations"></a>.
-      </p>
-    </section>
-    <section>
-      <h2>Representations</h2>
-      <p>
-Following are the requirements for representations.
-      </p>
-      <ol>
-        <li>
-A representation MUST define an unambiguous encoding and decoding of all
-property names and their associated values as defined in this specification.
-This means anything you can represent in the <a>DID document</a> data model
-can be represented in any compliant representation.
-        </li>
-        <li>
-The representation MUST be associated with an IANA-registered MIME type.
-        </li>
-        <li>
-The representation MUST define fragment processing rules for its MIME type that
-are conformant with the fragment processing rules defined in section
-<a href="#fragment"></a> of this specification.
-        </li>
-      </ol>
-        <p>
-The core representations are specified in section
-<a href="#core-representations"></a>.
-        </p>
-    </section>
+data-cite="INFRA#map-entry">properties</a>, where each property consists of
+a property name/property value pair. The data model contains at least two
+different classes of properties. The first class of properties are called
+core properties, and are specified in section <a href="#core-properties"></a>.
+The second class of properties are called representation properties, and
+are specified in section <a href="#representations"></a>.
+    </p>
+    <p>
+All property names in the data model are <a
+data-cite="INFRA#strings">strings</a>. All property values are expressed
+using one of the data types in the table below.
+    </p>
+
+    <table class="simple" id="public-key-support">
+      <thead>
+        <tr>
+          <th>
+Data&nbsp;Type
+          </th>
+          <th>
+Considerations
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+          </td>
+          <td>
+A finite ordered sequence of key/value pairs, with no key appearing twice as
+specified in [[INFRA]].
+          </td>
+        </tr>
+        <tr>
+          <td>
+<a data-cite="INFRA#list">list</a>
+          </td>
+          <td>
+A finite ordered sequence of items as specified in [[INFRA]].
+          </td>
+        </tr>
+        <tr>
+          <td>
+<a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
+          </td>
+          <td>
+A <a data-cite="INFRA#list">list</a> that does not contain the same item twice
+as specified in [[INFRA]].
+          </td>
+        </tr>
+        <tr>
+          <td>
+<dfn>datetime</dfn>
+          </td>
+          <td>
+A date and time value that is capable of losslessly expressing all values
+expressible by a `dateTime` as specified in
+[<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>].
+          </td>
+        </tr>
+        <tr>
+          <td>
+<a data-cite="INFRA#string">string</a>
+          </td>
+          <td>
+A sequence of code units often used to represent human readable language
+as specified in [[INFRA]].
+          </td>
+        </tr>
+        <tr>
+          <td>
+<dfn>decimal</dfn>
+          </td>
+          <td>
+A value that represents a subset of the real numbers, which can be
+represented by decimal numerals as specified in
+[<a data-cite="XMLSCHEMA11-2#decimal">XMLSCHEMA11-2</a>]. To maximize
+interoperability, implementers are urged to only express values capable of
+being represented by 53 bits in binary notation.
+          </td>
+        </tr>
+        <tr>
+          <td>
+<dfn>double</dfn>
+          </td>
+          <td>
+A value that is often used to approximate arbitrary real numbers as specified
+in [<a data-cite="XMLSCHEMA11-2#double">XMLSCHEMA11-2</a>]. To maximize
+interoperability, implementers are urged to only express values capable of
+being represented by 64 bits in binary notation.
+          </td>
+        </tr>
+        <tr>
+          <td>
+<a data-cite="INFRA#boolean">boolean</a>
+          </td>
+          <td>
+A value that is either true or false as defined in [[INFRA]].
+          </td>
+        </tr>
+        <tr>
+          <td>
+<a data-cite="INFRA#null">null</a>
+          </td>
+          <td>
+A value that is used to indicate the lack of a value as defined in [[INFRA]].
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
     <section>
       <h2>Extensibility</h2>
       <p>
@@ -2212,7 +2292,7 @@ and <a href="#authentication"></a>.
   </section>
 
   <section class="normative">
-    <h1>Core Representations</h1>
+    <h1>Representations</h1>
 
     <p>
 All concrete representations of a <a>DID document</a> are serialized using a
@@ -2249,6 +2329,36 @@ agreed-upon representation, including localized rules for handling properties
 not listed in the registry. See section <a href="#extensibility"></a>
 for more information.
     </p>
+
+    <section>
+      <h2>Creating Representations</h2>
+      <p>
+The <a href="#data-model">data model</a> provided in this specification
+supports being serialized into a variety of existing representations. Some
+applications might require the creation of a new representation. All new
+representations require the following:
+      </p>
+      <ol>
+        <li>
+A representation MUST define an unambiguous encoding and decoding of all
+property names and their associated values as defined in this specification.
+This means anything you can represent in the <a>DID document</a> data model
+can be represented in any compliant representation.
+        </li>
+        <li>
+The representation MUST be associated with an IANA-registered MIME type.
+        </li>
+        <li>
+The representation MUST define fragment processing rules for its MIME type that
+are conformant with the fragment processing rules defined in section
+<a href="#fragment"></a> of this specification.
+        </li>
+      </ol>
+      <p>
+In order to maximize interoperability, representation specification authors
+SHOULD register their representation in the [[?DID-SPEC-REGISTRIES]].
+      </p>
+    </section>
 
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -2334,15 +2334,15 @@ for more information.
       <p>
 The <a href="#data-model">data model</a> provided in this specification
 supports being serialized into a variety of existing representations. Some
-applications might require the creation of a new representation. All new
+applications might require the creation of a new representation. All
 representations require the following:
       </p>
       <ol>
         <li>
-A representation MUST define an unambiguous encoding and decoding of all
+A representation MUST define an unambiguous encoding and decoding for all
 property names and their associated values as defined in this specification.
-This means anything you can represent in the <a>DID document</a> data model
-can be represented in any compliant representation.
+This enables anything that can be represented in the <a>DID document</a> data
+model to also be represented in a compliant representation.
         </li>
         <li>
 The representation MUST be associated with an IANA-registered MIME type.

--- a/index.html
+++ b/index.html
@@ -1213,8 +1213,8 @@ as specified in [[INFRA]].
           <td>
 A real number without a fractional component as specified in
 [<a data-cite="XMLSCHEMA11-2#decimal">XMLSCHEMA11-2</a>]. To maximize
-interoperability, implementers are urged to only express values capable of
-being represented by 53 bits in binary notation.
+interoperability, implementers are urged to heed the advice regarding
+integers in <a data-cite="rfc7159#section-6">RFC7159, Section 6: Numbers</a>.
           </td>
         </tr>
         <tr>
@@ -1224,8 +1224,8 @@ being represented by 53 bits in binary notation.
           <td>
 A value that is often used to approximate arbitrary real numbers as specified
 in [<a data-cite="XMLSCHEMA11-2#double">XMLSCHEMA11-2</a>]. To maximize
-interoperability, implementers are urged to only express doubles capable of
-being represented as IEEE double-precision 64-bit floating point values.
+interoperability, implementers are urged to heed the advice regarding
+doubles in <a data-cite="rfc7159#section-6">RFC7159, Section 6: Numbers</a>.
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -2340,7 +2340,8 @@ representations require the following:
       <ol>
         <li>
 A representation MUST define an unambiguous encoding and decoding for all
-property names and their associated values as defined in this specification.
+property names and all data model <a href="#data-model">data types</a> 
+as defined in this specification.
 This enables anything that can be represented in the <a>DID document</a> data
 model to also be represented in a compliant representation.
         </li>

--- a/index.html
+++ b/index.html
@@ -2345,7 +2345,7 @@ This enables anything that can be represented in the <a>DID document</a> data
 model to also be represented in a compliant representation.
         </li>
         <li>
-The representation MUST be associated with an IANA-registered MIME type.
+The representation MUST be uniquely associated with an IANA-registered MIME type.
         </li>
         <li>
 The representation MUST define fragment processing rules for its MIME type that

--- a/index.html
+++ b/index.html
@@ -2330,7 +2330,7 @@ for more information.
     </p>
 
     <section>
-      <h2>Creating Representations</h2>
+      <h2>Representation Requirements</h2>
       <p>
 The <a href="#data-model">data model</a> provided in this specification
 supports being serialized into a variety of existing representations. Some

--- a/index.html
+++ b/index.html
@@ -1208,11 +1208,10 @@ as specified in [[INFRA]].
         </tr>
         <tr>
           <td>
-<dfn>decimal</dfn>
+<dfn>integer</dfn>
           </td>
           <td>
-A value that represents a subset of the real numbers, which can be
-represented by decimal numerals as specified in
+A real number without a fractional component as specified in
 [<a data-cite="XMLSCHEMA11-2#decimal">XMLSCHEMA11-2</a>]. To maximize
 interoperability, implementers are urged to only express values capable of
 being represented by 53 bits in binary notation.
@@ -1225,8 +1224,9 @@ being represented by 53 bits in binary notation.
           <td>
 A value that is often used to approximate arbitrary real numbers as specified
 in [<a data-cite="XMLSCHEMA11-2#double">XMLSCHEMA11-2</a>]. To maximize
-interoperability, implementers are urged to only express values capable of
-being represented by 64 bits in binary notation.
+interoperability, implementers are urged to only express doubles capable of
+being represented as IEEE double-precision 64-bit floating point values
+[[IEEE 754-2008]].
           </td>
         </tr>
         <tr>

--- a/index.html
+++ b/index.html
@@ -1225,8 +1225,7 @@ being represented by 53 bits in binary notation.
 A value that is often used to approximate arbitrary real numbers as specified
 in [<a data-cite="XMLSCHEMA11-2#double">XMLSCHEMA11-2</a>]. To maximize
 interoperability, implementers are urged to only express doubles capable of
-being represented as IEEE double-precision 64-bit floating point values
-[[IEEE 754-2008]].
+being represented as IEEE double-precision 64-bit floating point values.
           </td>
         </tr>
         <tr>

--- a/terms.html
+++ b/terms.html
@@ -100,7 +100,7 @@ association with the <a>DID</a>. A DID document may also contain other
 <a href="https://en.wikipedia.org/wiki/Attribute_(computing)">attributes</a> or
 <a href="https://en.wikipedia.org/wiki/Claims-based_identity">claims</a>
 describing the <a>DID subject</a>. A DID document may have one or more different
-<a>representations</a> as defined in <a href="#core-representations"></a> or in
+<a>representations</a> as defined in <a href="#representations"></a> or in
 the W3C DID Specification Registries [[DID-SPEC-REGISTRIES]].
   </dd>
 
@@ -252,7 +252,7 @@ past, current, or desired state of a given resource, in a format that can be
 readily communicated via the protocol, and that consists of a set of
 representation metadata and a potentially unbounded stream of representation
 data." A <a>DID document</a> is a representation of information
-describing a <a>DID subject</a>. The <a href="#core-representations"></a>
+describing a <a>DID subject</a>. The <a href="#representations"></a>
 section of the <a href="https://w3.org/TR/did-core">DID Core specification</a>
 defines several representation formats for a <a>DID document</a>.
   </dd>


### PR DESCRIPTION
This PR implements a number of resolutions made during the last DID WG virtual face-to-face meeting. Namely, it adds different classes of properties, defines all datatypes, and moves representation authoring rules to later in document.

Reviewers should look at the rewritten Data Model section here:

https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/455.html#data-model

and the representation authoring guidelines that was moved here:

https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/455.html#creating-representations


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/455.html" title="Last updated on Nov 17, 2020, 4:49 PM UTC (ecda543)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/455/b426d48...ecda543.html" title="Last updated on Nov 17, 2020, 4:49 PM UTC (ecda543)">Diff</a>