### PR TITLE
DIDs as Enhanced URNs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4310,33 +4310,29 @@ addresses using DNS lookups is available at [[?DNS-DID]].
 
     <section>
         <h2>
-Persistence of DIDs
+DIDs as URNs
         </h2>
 
         <p>
-Although a <a>DID</a> is able to function as a Uniform Resource Name (URN)—a
-"persistent, location-independent resource identifier"as defined by [[RFC8141]]—
-this is not a requirement of all DIDs. Rather the persistence of a <a>DID</a>,
-is determined by the <a>DID controller</a>.
-
-If a <a>DID controller</a> intends for a <a>DID</a> to function as a URN, there
-are two important security considerations:
+If desired by a <a>DID controller</a>, a <a>DID</a> is capable of fulfilling
+the functions of a Uniform Resource Name (URN) as defined by [[RFC8141]], i.e.,
+"a persistent, location-independent resource identifier". A <a>DID controller</a>
+who intends to use a <a>DID</a> for this purpose is advised to follow the
+security considerations in [[RFC8141]]. In particular:
         </p>
         <ol start="1">
           <li>
-The <a>DID controller</a> should choose a <a>DID method</a> that supports their
-requirements for persistence. <a>DID controllers</a> are advised to refer to the
-Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide which
-<a>DID method</a> best meets their persistence requirements.
+The <a>DID controller</a> should choose a <a>DID method</a> that supports the
+<a>DID controller</a>'s requirements for persistence. It is recommended to
+consult the Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide which
+<a>DID method</a> is best suited.
           </li>
           <li>
 The <a>DID controller</a> should publish its operational policies so relying
 parties can determine the degree to which they can rely on the persistence of a
 <a>DID</a> controlled by that <a>DID controller</a>. In the absence of such
 policies, relying parties should not make any assumption about whether a
-<a>DID</a> is a persistent identifier for the same <a>DID subject</a>. This is
-particularly important from a security standpoint if the <a>DID</a> is used for
-authentication or authorization purposes.
+<a>DID</a> is a persistent identifier for the same <a>DID subject</a>.
           </li>
         </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -767,24 +767,34 @@ Section <a href="#method-schemes"></a>.
 
       <div class="note" title="Persistence">
         <p>
-  A <a>DID</a> is expected to be persistent and immutable. That is, a <a>DID</a>
-  is bound exclusively and permanently to its one and only subject. Even after a
-  <a>DID</a> is deactivated, it is intended that it never be repurposed.
+The persistence of a <a>DID</a>, i.e., the ability for it to continue to
+identify the same <a>DID subject</a> over time, is a function of: a) the DID
+controller, and b) the <a>DID method</a>. While <a>DID</a> architecture is
+designed to support the ability for a <a>DID</a> to be permanently bound to one
+<a>DID subject</a> for all time, there are two important caveats:
+        </p>
+        <ol start="1">
+          <li>
+The <a>DID controller</a> may wish to terminate this binding—or possibly even
+bind the <a>DID</a> to a different <a>DID subject</a> at some point in time.
+          </li>
+          <li>
+Even if a permanent binding is desired, maintaining this binding is dependent
+on the infrastructure required by the <a>DID method</a>.
+          </li>
+        </ol>
+        <p>
+With regard to the first caveat, requesting parties are advised not to make
+assumptions about the permanence of the binding of a <a>DID</a> to a
+<a>DID subject</a> in the absence of <a>DID</a> assignment policies specified
+by the <a>DID controller</a> and consistent with the <a>DID method</a>. This is
+particularly important from a security standpoint if the requesting party is
+relying on the binding for authentication or authorization purposes.
         </p>
         <p>
-Ideally, a <a>DID</a> would be a completely abstract decentralized identifier
-(like a <a>UUID</a>) that could be bound to multiple underlying <a>verifiable
-data registries</a> over time, thus maintaining its persistence independent of
-any particular system. However, registering the same identifier on multiple
-<a>verifiable data registries</a> makes it extremely difficult to identify the
-authoritative version of a <a>DID document</a> if the contents diverge
-between the different <a>verifiable data registries</a>. It also greatly
-increases implementation complexity for developers.
-        </p>
-        <p>
-To avoid these issues, developers should refer to the Decentralized
+With regard to the second caveat, developers should refer to the Decentralized
 Characteristics Rubric [[?DID-RUBRIC]] to decide which <a>DID method</a> best
-addresses the needs of the use case.
+addresses their needs for persistence of a <a>DID</a>.
         </p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -4310,38 +4310,39 @@ addresses using DNS lookups is available at [[?DNS-DID]].
 
     <section>
         <h2>
-DIDs as URNs
+DIDs as Enhanced URNs
         </h2>
 
         <p>
 If desired by a <a>DID controller</a>, a <a>DID</a> is capable of acting
 as an enhanced Uniform Resource Name (URN) as defined by [[RFC8141]], i.e.,
-"a persistent, location-independent resource identifier". DIDs used in this way
-provide a cryptographically secure, location-independent identifier for a digital
-resource, while also providing the metadata that allows retrieval. Because of the
-indirection between the DID Document and the DID itself, the DID Controller can
-adjust the actual location of the resource &mdash; or even provide the resource
-directly &mdash; without adjusting the DID. DIDs of this type can definitively
-verify that the resource retrieved is, in fact, the resource identified.
+"a persistent, location-independent resource identifier". <a>DIDs</a> used in
+this way provide a cryptographically secure, location-independent identifier for
+a digital resource, while also providing metadata that enables retrieval.
+Because of the indirection between the <a>DID document</a> and the <a>DID</a>
+itself, the <a>DID controller</a> can adjust the actual location of the resource
+&mdash; or even provide the resource directly &mdash; without adjusting the
+<a>DID</a>. <a>DIDs</a> of this type can definitively verify that the resource
+retrieved is, in fact, the resource identified.
         </p>
         <p>
-A <a>DID controller</a>
-who intends to use a <a>DID</a> for this purpose is advised to follow the
-security considerations in [[RFC8141]]. In particular:
+A <a>DID controller</a> who intends to use a <a>DID</a> for this purpose is
+advised to follow the security considerations in [[RFC8141]]. In particular:
         </p>
         <ol start="1">
           <li>
-The <a>DID controller</a> is expected to choose a <a>DID method</a> that supports the
-<a>DID controller's</a> requirements for persistence. It is expected that implementers will
-consult the Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide upon
-the most suitable <a>DID method</a>.
+The <a>DID controller</a> is expected to choose a <a>DID method</a> that
+supports the controller's requirements for persistence. The Decentralized
+Characteristics Rubric [[?DID-RUBRIC]] is one tool available to help
+implementers decide upon the most suitable <a>DID method</a>.
           </li>
           <li>
-The <a>DID controller</a> is expected to publish its operational policies so relying
-parties can determine the degree to which they can rely on the persistence of a
-<a>DID</a> controlled by that <a>DID controller</a>. In the absence of such
-policies, relying parties are not expected to make any assumption about whether a
-<a>DID</a> is a persistent identifier for the same <a>DID subject</a>.
+The <a>DID controller</a> is expected to publish its operational policies so
+relying parties can determine the degree to which they can rely on the
+persistence of a <a>DID</a> controlled by that <a>DID controller</a>. In the
+absence of such policies, relying parties are not expected to make any
+assumption about whether a <a>DID</a> is a persistent identifier for the same
+<a>DID subject</a>.
           </li>
         </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -765,40 +765,6 @@ For requirements on <a>DID methods</a> relating to the <a>DID</a> syntax, see
 Section <a href="#method-schemes"></a>.
       </p>
 
-      <div class="note" title="Persistence">
-        <p>
-The persistence of a <a>DID</a>, i.e., its ability to continue to identify the
-same <a>DID subject</a> over time, is a function of: a) the <a>DID
-controller</a>'s policies for control of the <a>DID</a>, and b) the <a>DID method</a>.
-While <a>DID</a> architecture is designed to support the ability for a <a>DID</a>
-to be permanently bound to one <a>DID subject</a> as long as that binding is
-required, there are two important caveats:
-        </p>
-        <ol start="1">
-          <li>
-The <a>DID controller</a> may wish to terminate this binding—or possibly even
-bind the <a>DID</a> to a different <a>DID subject</a> at any point in time.
-          </li>
-          <li>
-If a permanent binding is desired, maintaining this binding is dependent
-on the infrastructure required by the <a>DID method</a>.
-          </li>
-        </ol>
-        <p>
-With regard to the first caveat, requesting parties are advised not to make
-assumptions about the permanence of the binding of a <a>DID</a> to a
-<a>DID subject</a> in the absence of knowledge of (and assurance of) the
-binding policies followed by the <a>DID controller</a>. This is particularly
-important from a security standpoint if the requesting party is relying on the
-binding for authentication or authorization purposes.
-        </p>
-        <p>
-With regard to the second caveat, developers should refer to the Decentralized
-Characteristics Rubric [[?DID-RUBRIC]] to decide which <a>DID method</a> best
-addresses their requirements for persistence of a <a>DID</a>.
-        </p>
-      </div>
-
     </section>
 
     <section class="normative">
@@ -4344,7 +4310,40 @@ addresses using DNS lookups is available at [[?DNS-DID]].
 
     <section>
         <h2>
-Immutability
+Persistence of DIDs
+        </h2>
+
+        <p>
+Although a <a>DID</a> is able to function as a Uniform Resource Name (URN)—a
+"persistent, location-independent resource identifier"as defined by [[RFC8141]]—
+this is not a requirement of all DIDs. Rather the persistence of a <a>DID</a>,
+is determined by the <a>DID controller</a>.
+
+If a <a>DID controller</a> intends for a <a>DID</a> to function as a URN, there
+are two important security considerations:
+        </p>
+        <ol start="1">
+          <li>
+The <a>DID controller</a> should choose a <a>DID method</a> that supports their
+requirements for persistence. <a>DID controllers</a> are advised to refer to the
+Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide which
+<a>DID method</a> best meets their persistence requirements.
+          </li>
+          <li>
+The <a>DID controller</a> should publish its operational policies so relying
+parties can determine the degree to which they can rely on the persistence of a
+<a>DID</a> controlled by that <a>DID controller</a>. In the absence of such
+policies, relying parties should not make any assumption about whether a
+<a>DID</a> is a persistent identifier for the same <a>DID subject</a>. This is
+particularly important from a security standpoint if the <a>DID</a> is used for
+authentication or authorization purposes.
+          </li>
+        </ol>
+    </section>
+
+    <section>
+        <h2>
+Immutability of DID Documents
         </h2>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -767,11 +767,12 @@ Section <a href="#method-schemes"></a>.
 
       <div class="note" title="Persistence">
         <p>
-The persistence of a <a>DID</a>, i.e., the ability for it to continue to
-identify the same <a>DID subject</a> over time, is a function of: a) the DID
-controller, and b) the <a>DID method</a>. While <a>DID</a> architecture is
-designed to support the ability for a <a>DID</a> to be permanently bound to one
-<a>DID subject</a> for all time, there are two important caveats:
+The persistence of a <a>DID</a>, i.e., its ability to continue to identify the
+same <a>DID subject</a> over time, is a function of: a) the <a>DID
+controller</a>'s policies for control of the <a>DID</a>, and b) the <a>DID method</a>.
+While <a>DID</a> architecture is designed to support the ability for a <a>DID</a>
+to be permanently bound to one <a>DID subject</a> as long as that binding is
+required, there are two important caveats:
         </p>
         <ol start="1">
           <li>
@@ -786,15 +787,15 @@ on the infrastructure required by the <a>DID method</a>.
         <p>
 With regard to the first caveat, requesting parties are advised not to make
 assumptions about the permanence of the binding of a <a>DID</a> to a
-<a>DID subject</a> in the absence of <a>DID</a> assignment policies specified
-by the <a>DID controller</a> and consistent with the <a>DID method</a>. This is
-particularly important from a security standpoint if the requesting party is
-relying on the binding for authentication or authorization purposes.
+<a>DID subject</a> in the absence of knowledge of (and assurance of) the
+binding policies followed by the <a>DID controller</a>. This is particularly
+important from a security standpoint if the requesting party is relying on the
+binding for authentication or authorization purposes.
         </p>
         <p>
 With regard to the second caveat, developers should refer to the Decentralized
 Characteristics Rubric [[?DID-RUBRIC]] to decide which <a>DID method</a> best
-addresses their needs for persistence of a <a>DID</a>.
+addresses their requirements for persistence of a <a>DID</a>.
         </p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -4314,9 +4314,12 @@ DIDs as URNs
         </h2>
 
         <p>
-If desired by a <a>DID controller</a>, a <a>DID</a> is capable of fulfilling
-the functions of a Uniform Resource Name (URN) as defined by [[RFC8141]], i.e.,
-"a persistent, location-independent resource identifier". A <a>DID controller</a>
+If desired by a <a>DID controller</a>, a <a>DID</a> is capable of acting
+as an enhanced Uniform Resource Name (URN) as defined by [[RFC8141]], i.e.,
+"a persistent, location-independent resource identifier". DIDs used in this way provide a cryptographically secure, location-independent identifier for a digital resource, while also providing the metadata that allows retrieval. Because of the indirection between the DID Document and the DID itself, the DID Controller can adjust the actual location of the resource--or even provide the resource directly--without adjusting the DID. DIDs of this type can definitively verify that the resource retrieved is, in fact, the resource identified.
+        </p>
+        <p>
+A <a>DID controller</a>
 who intends to use a <a>DID</a> for this purpose is advised to follow the
 security considerations in [[RFC8141]]. In particular:
         </p>

--- a/index.html
+++ b/index.html
@@ -4329,7 +4329,7 @@ retrieved is, in fact, the resource identified.
 A <a>DID controller</a> who intends to use a <a>DID</a> for this purpose is
 advised to follow the security considerations in [[RFC8141]]. In particular:
         </p>
-        <ol start="1">
+        <ul>
           <li>
 The <a>DID controller</a> is expected to choose a <a>DID method</a> that
 supports the controller's requirements for persistence. The Decentralized
@@ -4344,7 +4344,7 @@ absence of such policies, relying parties are not expected to make any
 assumption about whether a <a>DID</a> is a persistent identifier for the same
 <a>DID subject</a>.
           </li>
-        </ol>
+        </ul>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -4326,7 +4326,7 @@ security considerations in [[RFC8141]]. In particular:
         <ol start="1">
           <li>
 The <a>DID controller</a> should choose a <a>DID method</a> that supports the
-<a>DID controller</a>'s requirements for persistence. It is recommended to
+<a>DID controller's</a> requirements for persistence. It is recommended to
 consult the Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide which
 <a>DID method</a> is best suited.
           </li>

--- a/index.html
+++ b/index.html
@@ -4316,7 +4316,13 @@ DIDs as URNs
         <p>
 If desired by a <a>DID controller</a>, a <a>DID</a> is capable of acting
 as an enhanced Uniform Resource Name (URN) as defined by [[RFC8141]], i.e.,
-"a persistent, location-independent resource identifier". DIDs used in this way provide a cryptographically secure, location-independent identifier for a digital resource, while also providing the metadata that allows retrieval. Because of the indirection between the DID Document and the DID itself, the DID Controller can adjust the actual location of the resource--or even provide the resource directly--without adjusting the DID. DIDs of this type can definitively verify that the resource retrieved is, in fact, the resource identified.
+"a persistent, location-independent resource identifier". DIDs used in this way
+provide a cryptographically secure, location-independent identifier for a digital
+resource, while also providing the metadata that allows retrieval. Because of the
+indirection between the DID Document and the DID itself, the DID Controller can
+adjust the actual location of the resource &mdash; or even provide the resource
+directly &mdash; without adjusting the DID. DIDs of this type can definitively
+verify that the resource retrieved is, in fact, the resource identified.
         </p>
         <p>
 A <a>DID controller</a>

--- a/index.html
+++ b/index.html
@@ -4325,16 +4325,16 @@ security considerations in [[RFC8141]]. In particular:
         </p>
         <ol start="1">
           <li>
-The <a>DID controller</a> should choose a <a>DID method</a> that supports the
-<a>DID controller's</a> requirements for persistence. It is recommended to
+The <a>DID controller</a> is expected to choose a <a>DID method</a> that supports the
+<a>DID controller's</a> requirements for persistence. It is expected that implementers will
 consult the Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide upon
 the most suitable <a>DID method</a>.
           </li>
           <li>
-The <a>DID controller</a> should publish its operational policies so relying
+The <a>DID controller</a> is expected to publish its operational policies so relying
 parties can determine the degree to which they can rely on the persistence of a
 <a>DID</a> controlled by that <a>DID controller</a>. In the absence of such
-policies, relying parties should not make any assumption about whether a
+policies, relying parties are not expected to make any assumption about whether a
 <a>DID</a> is a persistent identifier for the same <a>DID subject</a>.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -777,7 +777,7 @@ required, there are two important caveats:
         <ol start="1">
           <li>
 The <a>DID controller</a> may wish to terminate this binding—or possibly even
-bind the <a>DID</a> to a different <a>DID subject</a> at some point in time.
+bind the <a>DID</a> to a different <a>DID subject</a> at any point in time.
           </li>
           <li>
 Even if a permanent binding is desired, maintaining this binding is dependent

--- a/index.html
+++ b/index.html
@@ -4327,8 +4327,8 @@ security considerations in [[RFC8141]]. In particular:
           <li>
 The <a>DID controller</a> should choose a <a>DID method</a> that supports the
 <a>DID controller's</a> requirements for persistence. It is recommended to
-consult the Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide which
-<a>DID method</a> is best suited.
+consult the Decentralized Characteristics Rubric [[?DID-RUBRIC]] to decide upon
+the most suitable <a>DID method</a>.
           </li>
           <li>
 The <a>DID controller</a> should publish its operational policies so relying

--- a/index.html
+++ b/index.html
@@ -780,7 +780,7 @@ The <a>DID controller</a> may wish to terminate this binding—or possibly even
 bind the <a>DID</a> to a different <a>DID subject</a> at any point in time.
           </li>
           <li>
-Even if a permanent binding is desired, maintaining this binding is dependent
+If a permanent binding is desired, maintaining this binding is dependent
 on the infrastructure required by the <a>DID method</a>.
           </li>
         </ol>


### PR DESCRIPTION
The note on persistence of DIDs was revised per the text discussed on [slide 34 of the presentation deck](https://docs.google.com/presentation/d/1RoE8E4y8S1j65EJaXZ8oihkduNbjTXXvdwtkzw961Xw/edit?pli=1#slide=id.ga6aa7427ae_1_61) for the DID WG TPAC virtual F2F session.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/talltree/did-core/pull/457.html" title="Last updated on Jan 31, 2021, 9:41 PM UTC (d0c16e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/457/c92b13c...talltree:d0c16e2.html" title="Last updated on Jan 31, 2021, 9:41 PM UTC (d0c16e2)">Diff</a>