### PR TITLE
Marks did+ld+json media type at risk

### DIFF
--- a/index.html
+++ b/index.html
@@ -2409,6 +2409,13 @@ documents</a> that are in JSON-LD (as indicated by a <code>content-type</code>
 of <code>application/did+ld+json</code> in the resolver metadata).
       </p>
 
+      <p class="issue atrisk" data-number="208">
+Use of the media type <code>application/did+ld+json</code> is pending
+clarification over registration of media types with multiple suffixes. The
+alternative will be to use <code>application/did+jsonld</code> if multiple
+suffixes cannot be registered by the time the rest of DID Core is ready for PR.
+      </p>
+
       <ul>
         <li>
 The <code>@id</code> and <code>@type</code> keywords are aliased to
@@ -4655,6 +4662,14 @@ according to the rules defined in <a href="#fragment"></a>.
 
     <section>
       <h2>application/did+ld+json</h2>
+
+      <p class="issue atrisk" data-number="208">
+Use of the media type <code>application/did+ld+json</code> is pending
+clarification over registration of media types with multiple suffixes. The
+alternative will be to use <code>application/did+jsonld</code> if multiple
+suffixes cannot be registered by the time the rest of DID Core is ready for PR.
+      </p>
+
       <dl>
         <dt>Type name:</dt>
         <dd>application</dd>


### PR DESCRIPTION
Adds notes to mark `application/did+ld+json` at risk pending IANA feedback on multiple suffixes issue. See #208


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/458.html" title="Last updated on Nov 16, 2020, 1:14 PM UTC (2845e0c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/458/b426d48...2845e0c.html" title="Last updated on Nov 16, 2020, 1:14 PM UTC (2845e0c)">Diff</a>