### PR TITLE
editorial: remove biometrics examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,8 +270,7 @@ The Decentralized Identifiers (DIDs) defined in this specification are a new
 type of globally unique identifier designed to enable individuals and
 organizations to generate our own identifiers using systems we trust, and to
 prove control of those identifiers (authenticate) using cryptographic proofs
-(for example, digital signatures, privacy-preserving biometric protocols, and so
-on).
+(for example, digital signatures).
     </p>
     <p>
 Because we control the generation and assertion of these identifiers, each of us
@@ -1438,8 +1437,8 @@ usage, it verifies that the signer possessed the associated private key.
 Verification methods might take many parameters. An example of this is a set
 of five cryptographic keys from which any three are required to contribute to
 a threshold signature. Methods need not be cryptographic. An example of this
-might be the contact information for a biometric service provider that compares
-a purported <a>DID controller</a> against a candidate biometric vector.
+might be the contact information for a verifiable credential verifier that
+verifies a credential presented by a purported <a>DID controller</a>.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1436,10 +1436,7 @@ usage, it verifies that the signer possessed the associated private key.
       <p>
 Verification methods might take many parameters. An example of this is a set
 of five cryptographic keys from which any three are required to contribute to
-a threshold signature. Methods need not be cryptographic. An example of this
-might be the use of a service endpoint that returns a verifiable credential
-for the purported <a>DID Controller</a> which the <a>DID Controller</a> can
-provide as proof of control.
+a threshold signature. Methods need not be cryptographic.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1437,8 +1437,9 @@ usage, it verifies that the signer possessed the associated private key.
 Verification methods might take many parameters. An example of this is a set
 of five cryptographic keys from which any three are required to contribute to
 a threshold signature. Methods need not be cryptographic. An example of this
-might be the contact information for a verifiable credential verifier that
-verifies a credential presented by a purported <a>DID controller</a>.
+might be the use of a service endpoint that returns a verifiable credential
+for the purported <a>DID Controller</a> which the <a>DID Controller</a> can
+provide as proof of control.
       </p>
 
       <p>


### PR DESCRIPTION
Personal preference to remove biometrics examples from the spec. This is too dystopian, and I don't think we should be encouraging it even if it's technically possible. It's also dancing close to the PII and bound-forever problems (even though the example refers to an endpoint, rather than biometric data in the DID doc). I've replaced the example with something less specific about credentials, but also happy to see a better more specific example suggested instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/459.html" title="Last updated on Nov 30, 2020, 11:41 AM UTC (9631fd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/459/b426d48...9631fd3.html" title="Last updated on Nov 30, 2020, 11:41 AM UTC (9631fd3)">Diff</a>