### PR TITLE
Change MUST to SHOULD for lossless conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -1262,7 +1262,9 @@ that ensures that two different representations will be able to work together.
       <li>
 Representations MAY define other extensibility mechanisms including methods for
 decentralized extensions. Such extension mechanisms SHOULD support lossless
-conversion into any other conformant representation.
+conversion into any other conformant representation. Extension mechanisms for a 
+representation SHOULD define a mapping of all properties and representation syntax 
+into the abstract data model and its type system.
       </li>
       </ol>
       <p class="note">

--- a/index.html
+++ b/index.html
@@ -1261,7 +1261,7 @@ that ensures that two different representations will be able to work together.
         </li>
       <li>
 Representations MAY define other extensibility mechanisms including methods for
-decentralized extensions. Such extension mechanisms MUST support lossless
+decentralized extensions. Such extension mechanisms SHOULD support lossless
 conversion into any other conformant representation.
       </li>
       </ol>


### PR DESCRIPTION
I think this is simply a mistake.. During the Amsterdam F2F we said that representations may support extension mechanisms that only work in a specific representation, and that can't be losslessly converted to others.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/465.html" title="Last updated on Dec 13, 2020, 8:25 PM UTC (c8fba4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/465/26ad2eb...c8fba4b.html" title="Last updated on Dec 13, 2020, 8:25 PM UTC (c8fba4b)">Diff</a>