### PR TITLE
respec: fix restrictReferences

### DIFF
--- a/common.js
+++ b/common.js
@@ -3,7 +3,6 @@
 /*  ... stolen from Gregg Kellogg of the JSON-LD 1.1 Working Group */
 /*  ... who stole it from Manu Sporny of the JSON-LD 1.0 Working Group */
 /*  ... who stole it from Shane McCarron, that beautiful, beautiful man. */
-/* exported restrictReferences */
 var ccg = {
   // Add as the respecConfig localBiblio variable
   // Extend or override global respec references
@@ -12,7 +11,7 @@ var ccg = {
       title: "DID Specification Registries",
       href: "https://w3c.github.io/did-spec-registries/",
       authors: [
-      	"Orie Steele",
+        "Orie Steele",
         "Manu Sporny"
       ],
       status: "ED",
@@ -31,7 +30,7 @@ var ccg = {
       title: "Verifiable Claims Use Cases",
       href: "https://www.w3.org/TR/verifiable-claims-use-cases/",
       authors: [
-      	"Shane McCarron",
+        "Shane McCarron",
         "Daniel Burnett",
         "Gregg Kellogg",
         "Brian Sletten",
@@ -44,7 +43,7 @@ var ccg = {
       title: "Decentralized Identifier Use Cases",
       href: "https://www.w3.org/TR/did-use-cases/",
       authors: [
-      	"Joe Andrieu",
+        "Joe Andrieu",
         "Kim Hamilton Duffy",
         "Ryan Grant",
         "Adrian Gropper"
@@ -171,21 +170,6 @@ var ccg = {
   }
 };
 
-// We should be able to remove terms that are not actually
-// referenced from the common definitions
-//
-// Add class "preserve" to a definition to ensure it is not removed.
-//
-// the termlist is in a block of class "termlist".
-const termNames = [] ;
-const termsReferencedByTerms = [] ;
-
-function restrictReferences(utils, content, filename) {
-  const base = document.createElement("div");
-  base.innerHTML = content;
-
-  return (base.innerHTML);
-}
 
 require(["core/pubsubhub"], (respecEvents) => {
   "use strict";
@@ -206,113 +190,66 @@ require(["core/pubsubhub"], (respecEvents) => {
       anchor.href= anchor.dataset.cite.replace(/^.*#/,"#");
       delete anchor.dataset.cite;
     }
+
   });
 
-  // add a handler to come in after all the definitions are resolved
-  //
-  // New logic: If the reference is within a 'dl' element of
-  // class 'termlist', and if the target of that reference is
-  // also within a 'dl' element of class 'termlist', then
-  // consider it an internal reference and ignore it.
-  respecEvents.sub('end-all', (message) => {
-    console.log("message", message);
-    if (message === 'core/link-to-dfn') {
-      // 1. build a list of all term-internal references
-      // 2. When ready to process, for each reference INTO the terms,
-      // remove any terms they reference from the termNames array too.
-      const noPreserve =
-        document.querySelectorAll("#terminology dfn:not(.preserve)");
+});
 
-      for (const item of noPreserve) {
-        const $t = $(item);
-        const titles = getDfnTitles(item);
-        console.log('titles', titles);
-        /*
-        const $t = $(item);
-        const titles = $t.getDfnTitles();
-        const n = $t.makeID("dfn", titles[0]);
-        if (n) {
-          termNames[n] = $t.parent();
-        }
-        */
+// Removes dfns that aren't referenced anywhere in the spec.
+// To ensure a definition appears in the Terminology section, use
+//  and link to it!
+// This is triggered by postProcess in the respec config.
+function restrictRefs(config, document){
+
+  // Get set of ids internal dfns referenced in the spec body
+  const internalDfnLinks = document.querySelectorAll("a.internalDFN");
+  let internalDfnIds = new Set();
+  for (const dfnLink of internalDfnLinks) {
+    const dfnHref = dfnLink.href.split("#")[1];
+    internalDfnIds.add(dfnHref);
+  }
+
+  // Remove unused dfns from the termlist
+  const termlist = document.querySelector(".termlist");
+  const linkIdsInDfns = [];
+  for (const child of termlist.querySelectorAll("dfn")){
+    if (!internalDfnIds.has(child.id)){
+      let dt = child.closest("dt");
+      let dd = dt.nextElementSibling;
+
+      // Get internal links from dfns we're going to remove
+      //  because these show up in the dfn-panels later and then
+      //  trigger the local-refs-exist linter (see below)
+      const linksInDfn = dd.querySelectorAll("a.internalDFN");
+      for (link of linksInDfn) {
+        linkIdsInDfns.push(link.id);
       }
 
-      //const $container = $(".termlist", base) ;
-      //const containerID = $container.makeID("", "terms") ;
+      termlist.removeChild(dt);
+      termlist.removeChild(dd);
+    }
+  }
 
-      // all definitions are linked; find any internal references
-      const internalTerms = document.querySelectorAll(".termlist a.internalDFN");
-      for (const item of internalTerms) {
-        const idref = item.getAttribute('href').replace(/^#/,"") ;
-        if (termNames[idref]) {
-          // this is a reference to another term
-          // what is the idref of THIS term?
-          const def = item.closest('dd');
-          if (def) {
-            const tid = def.previousElementSibling
-              .querySelector('dfn')
-              .getAttribute('id');
-            if (tid) {
-              if (termsReferencedByTerms[tid] === undefined) termsReferencedByTerms[tid] = [];
-              termsReferencedByTerms[tid].push(idref);
-            }
-          }
-        }
-      }
+  // Remove unused dfns from the dfn-panels
+  //  (these are hidden, but still trigger the local-refs-exist linter)
+  //  (this seems like a hack, there's probably a better way to hook into respec
+  //   before it gets to this point)
+  const dfnPanels = document.querySelectorAll(".dfn-panel");
+  for (const panel of dfnPanels) {
+    if (!internalDfnIds.has(panel.querySelector(".self-link").href.split("#")[1])){
+      panel.parentNode.removeChild(panel);
+    }
 
-      // clearRefs is recursive.  Walk down the tree of
-      // references to ensure that all references are resolved.
-      const clearRefs = (theTerm) => {
-        if (termsReferencedByTerms[theTerm] ) {
-          for (const item of termsReferencedByTerms[theTerm]) {
-            if (termNames[item]) {
-                delete termNames[item];
-                clearRefs(item);
-            }
-          }
-        };
-        // make sure this term doesn't get removed
-        if (termNames[theTerm]) {
-          delete termNames[theTerm];
-        }
-      };
-
-      // now termsReferencedByTerms has ALL terms that
-      // reference other terms, and a list of the
-      // terms that they reference
-      const internalRefs = document.querySelectorAll("a[data-link-type='dfn']");
-      for (const item of internalRefs) {
-        const idref = item.getAttribute('href').replace(/^.*#/,"") ;
-        // if the item is outside the term list
-        if (!item.closest('dl.termlist')) {
-          clearRefs(idref);
-        }
-      }
-
-      // delete any terms that were not referenced.
-      for (const term in termNames) {
-        //console.log("DELETE TERM?", term);
-        const $p = $("#"+term);
-        // Remove term definitions inside a dt, where data-cite does not start with shortname
-        if ($p === undefined) { continue; }
-        if (!$p.parent().is("dt")) { continue; }
-        if (($p.data("cite") || "").toLowerCase().startsWith(respecConfig.shortName)) { continue; }
-
-        const $dt = $p.parent();
-        const $dd = $dt.next();
-
-        // If the associated dd contains a dfn which is _not_ in termNames, warn
-        if ($dd.children("dfn").length > 0) {
-          console.log(term + " definition contains definitions " + $dd.children("dfn").attr("id"))
-        }
-        console.log("drop term " + term);
-        const tList = $p.getDfnTitles();
-        $dd.remove(); // remove dd
-        $dt.remove(); // remove dt
+    // Remove references to dfns we removed which link to other dfns
+    const panelLinks = panel.querySelectorAll("li a");
+    for (const link of panelLinks) {
+      if (linkIdsInDfns.includes(link.href.split("#")[1])) {
+        link.parentNode.removeChild(link);
       }
     }
-  });
-});
+  }
+
+}
 
 function _esc(s) {
   return s.replace(/&/g,'&amp;')

--- a/index.html
+++ b/index.html
@@ -64,9 +64,10 @@
     // preProcess: [
     //   prepare_reqlist
     // ],
-    // postProcess: [
-    //   add_reqlist_button
-    // ],
+    postProcess: [
+    //   add_reqlist_button,
+      restrictRefs
+    ],
 
     // list of specification editors
     editors: [{
@@ -715,7 +716,7 @@ produce errors when consuming non-conforming <a>DIDs</a> or <a>DID documents</a>
 Terminology
     </h2>
 
-    <div data-include="terms.html" data-oninclude="restrictReferences">
+    <div data-include="terms.html">
     </div>
 
     <p>


### PR DESCRIPTION
Less of a 'fix' and more of a complete rewrite.

`restrictRefs` is now triggered by `postProcess` in the respec config. It removes any definitions from the terminology section that are not actually used in the spec.

It is not smart enough to detect circular definition cycles within the terminology section itself, but I've eyeballed it and don't think there are any.

There *are* definitions that are *only* referred to from other definitions (and not in the main body of the spec) - but we can't drop these without removing their reference or we get respec errors. Will do another editorial pass over terminology at some point to reduce this.

There's a really hacky bit to stop the invisible 'definition panels' triggering the local-refs-exist linter, because I didn't figure out how to remove the dfns before the DOM is built. But for the time being it works..


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/467.html" title="Last updated on Nov 21, 2020, 1:45 AM UTC (dcd30fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/467/26ad2eb...dcd30fd.html" title="Last updated on Nov 21, 2020, 1:45 AM UTC (dcd30fd)">Diff</a>