### PR TITLE
Add concrete serialization rules for JSON based on new data types section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2426,7 +2426,7 @@ JSON Representation Type
               </td>
               <td>
 <a data-cite="RFC8259#section-7">JSON String</a> formatted as an
-<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>]
+<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>
               </td>
             </tr>
             <tr>
@@ -2529,7 +2529,8 @@ Data&nbsp;Type
             </tr>
             <tr>
               <td>
-<a data-cite="RFC8259#section-5">JSON Array</a>
+<a data-cite="RFC8259#section-5">JSON Array</a> where data model property value
+is a <a data-cite="INFRA#list">list</a>
               </td>
               <td>
 <a data-cite="INFRA#list">list</a>
@@ -2537,7 +2538,8 @@ Data&nbsp;Type
             </tr>
             <tr>
               <td>
-<a data-cite="RFC8259#section-5">JSON Array</a>
+<a data-cite="RFC8259#section-5">JSON Array</a> where data model property value
+is an <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
@@ -2545,8 +2547,8 @@ Data&nbsp;Type
             </tr>
             <tr>
               <td>
-<a data-cite="RFC8259#section-7">JSON String</a> formatted as an
-<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>]
+<a data-cite="RFC8259#section-7">JSON String</a> where data model
+property value is an <a>datetime</a>
               </td>
               <td>
 <a>datetime</a>

--- a/index.html
+++ b/index.html
@@ -2390,7 +2390,7 @@ in JSON [[RFC8259]] by mapping property values to JSON types as follows:
 Data&nbsp;Type
               </th>
               <th>
-Representation Type
+JSON Representation Type
               </th>
             </tr>
           </thead>
@@ -2506,35 +2506,95 @@ the <a>DID document</a>, and all members of this object are properties of the
 member value is interpreted as follows:
         </p>
 
-        <ul>
-          <li>
-<a data-cite="RFC8259#section-6">Number types</a> MUST interpreted as numeric
-values representable as IEEE754.
-          </li>
-          <li>
-<a data-cite="RFC8259#section-3">Boolean literals</a> MUST be interpreted as a
-Boolean value.
-          </li>
-          <li>
-An <a data-cite="RFC8259#section-5">Array type</a> MUST be interpreted as a
-Sequence or Unordered set, depending on the definition of the property for this
-value.
-          </li>
-          <li>
-An <a data-cite="RFC8259#section-4">Object type</a> MUST be interpreted as a
-sets of properties.
-          </li>
-          <li>
-A <a data-cite="RFC8259#section-3">null literal</a> MUST be interpreted as an
-Empty value.
-          </li>
-          <li>
-<a data-cite="RFC8259#section-7">String types</a> MUST be interpreted as
-Strings, which may be further parsed depending on the definition of the property
-for this value into more specific data types such as URIs, date stamps, or other
-values.
-          </li>
-        </ul>
+        <table class="simple" id="json-representation-production">
+          <thead>
+            <tr>
+              <th>
+JSON Representation Type
+              </th>
+              <th>
+Data&nbsp;Type
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-4">JSON Object</a>
+              </td>
+              <td>
+<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-5">JSON Array</a>
+              </td>
+              <td>
+<a data-cite="INFRA#list">list</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-5">JSON Array</a>
+              </td>
+              <td>
+<a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-7">JSON String</a> formatted as an
+<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>]
+              </td>
+              <td>
+<a>datetime</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-7">JSON String</a>
+              </td>
+              <td>
+<a data-cite="INFRA#string">string</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-6">JSON Number</a> without a decimal or
+fractional component
+              </td>
+              <td>
+<a>integer</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-6">JSON Number</a> with a fractional component
+              </td>
+              <td>
+<a>double</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-3">JSON Boolean</a>
+              </td>
+              <td>
+<a data-cite="INFRA#boolean">boolean</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-3">JSON null literal</a>
+              </td>
+              <td>
+<a data-cite="INFRA#null">null</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
         <p>
 Implementers consuming JSON are advised to ensure that their algorithms are

--- a/index.html
+++ b/index.html
@@ -1148,7 +1148,7 @@ data-cite="INFRA#strings">strings</a>. All property values are expressed
 using one of the data types in the table below.
     </p>
 
-    <table class="simple" id="public-key-support">
+    <table class="simple" id="data-types">
       <thead>
         <tr>
           <th>
@@ -2340,7 +2340,7 @@ representations require the following:
       <ol>
         <li>
 A representation MUST define an unambiguous encoding and decoding for all
-property names and all data model <a href="#data-model">data types</a> 
+property names and all data model <a href="#data-model">data types</a>
 as defined in this specification.
 This enables anything that can be represented in the <a>DID document</a> data
 model to also be represented in a compliant representation.
@@ -2383,36 +2383,95 @@ in Section <a href="#data-model"></a>, including all extensions, are encoded
 in JSON [[RFC8259]] by mapping property values to JSON types as follows:
         </p>
 
-        <ul>
-          <li>
-Numeric values representable as IEEE754 MUST be represented as a
-<a data-cite="RFC8259#section-6">Number type</a>.
-          </li>
-          <li>
-Boolean values MUST be represented as a <a data-cite="RFC8259#section-3">Boolean
-literal</a>.
-          </li>
-          <li>
-Sequence value MUST be represented as an <a data-cite="RFC8259#section-5">Array
-type</a>.
-          </li>
-          <li>
-Unordered sets of values MUST be represented as an <a
-data-cite="RFC8259#section-5">Array type</a>.
-          </li>
-          <li>
-Sets of properties MUST be represented as an <a
-data-cite="RFC8259#section-4">Object type</a>.
-          </li>
-          <li>
-Empty values MUST be represented as a <a data-cite="RFC8259#section-3">null
-literal</a>.
-          </li>
-          <li>
-Other values MUST be represented as a <a data-cite="RFC8259#section-7">String
-type</a>.
-          </li>
-        </ul>
+        <table class="simple" id="json-representation-production">
+          <thead>
+            <tr>
+              <th>
+Data&nbsp;Type
+              </th>
+              <th>
+Representation Type
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>
+<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-4">JSON Object</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="INFRA#list">list</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-5">JSON Array</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-5">JSON Array</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a>datetime</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-7">JSON String</a> formatted as an
+<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>]
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="INFRA#string">string</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-7">JSON String</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a>integer</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-6">JSON Number</a> without a decimal or
+fractional component
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a>double</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-6">JSON Number</a> with a fractional component
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="INFRA#boolean">boolean</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-3">JSON Boolean</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="INFRA#null">null</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-3">JSON null literal</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
         <p>
 Implementers producing JSON are advised to ensure that their algorithms are

--- a/index.html
+++ b/index.html
@@ -2401,7 +2401,7 @@ JSON Representation Type
 <a data-cite="INFRA#maps">ordered&nbsp;map</a>
               </td>
               <td>
-<a data-cite="RFC8259#section-4">JSON Object</a>
+<a data-cite="RFC8259#section-4">JSON Object</a>, each property is represented as a member of the JSON Object with the property name as the member name and the property value according to its type, as defined in this section
               </td>
             </tr>
             <tr>
@@ -2409,7 +2409,7 @@ JSON Representation Type
 <a data-cite="INFRA#list">list</a>
               </td>
               <td>
-<a data-cite="RFC8259#section-5">JSON Array</a>
+<a data-cite="RFC8259#section-5">JSON Array</a>, each element of the list is added, in order, as a value of the array according to its type, as defined in this section
               </td>
             </tr>
             <tr>
@@ -2417,7 +2417,7 @@ JSON Representation Type
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
-<a data-cite="RFC8259#section-5">JSON Array</a>
+<a data-cite="RFC8259#section-5">JSON Array</a>, each element of the list is added, in order, as a value of the array according to its type, as defined in this section
               </td>
             </tr>
             <tr>
@@ -2524,16 +2524,16 @@ Data&nbsp;Type
 <a data-cite="RFC8259#section-4">JSON Object</a>
               </td>
               <td>
-<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+<a data-cite="INFRA#maps">ordered&nbsp;map</a>, each member of the JSON Object is added as a property to the ordered map with the property name being the member name and the value converted based on the JSON type and, if available, property definition, as defined here; as no order is specified by JSON Objects, no insertion order is guaranteed
               </td>
             </tr>
             <tr>
               <td>
 <a data-cite="RFC8259#section-5">JSON Array</a> where data model property value
-is a <a data-cite="INFRA#list">list</a>
+is a <a data-cite="INFRA#list">list</a> or unknown
               </td>
               <td>
-<a data-cite="INFRA#list">list</a>
+<a data-cite="INFRA#list">list</a>, each value of the JSON Array is added to the list in order, converted based on the JSON type of the array value, as defined here
               </td>
             </tr>
             <tr>
@@ -2542,7 +2542,7 @@ is a <a data-cite="INFRA#list">list</a>
 is an <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
-<a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
+<a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>, each value of the JSON Array is added to the ordered set in order, converted based on the JSON type of the array value, as defined here
               </td>
             </tr>
             <tr>
@@ -2556,7 +2556,7 @@ property value is an <a>datetime</a>
             </tr>
             <tr>
               <td>
-<a data-cite="RFC8259#section-7">JSON String</a>
+<a data-cite="RFC8259#section-7">JSON String</a>, where data model property value type is <a>string</a> or unknown
               </td>
               <td>
 <a data-cite="INFRA#string">string</a>
@@ -2573,7 +2573,7 @@ fractional component
             </tr>
             <tr>
               <td>
-<a data-cite="RFC8259#section-6">JSON Number</a> with a fractional component
+<a data-cite="RFC8259#section-6">JSON Number</a> with a fractional component, or when property value is a <a>double</a> regardless of inclusion of fractional component
               </td>
               <td>
 <a>double</a>


### PR DESCRIPTION
This PR builds on top of #455 by adding concrete JSON serialization/deserialization rules for production and consumption. If this PR is acceptable the the group, similar PRs will be raised for the JSON-LD and CBOR sections.

You can preview the changes, which are effectively the addition of conversion tables, here:

JSON Production
https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/469.html#production

JSON Consumption
https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/469.html#consumption


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/469.html" title="Last updated on Nov 24, 2020, 9:59 PM UTC (f8c4ba8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/469/002b9f0...f8c4ba8.html" title="Last updated on Nov 24, 2020, 9:59 PM UTC (f8c4ba8)">Diff</a>