### PR TITLE
methods: remove untestable normative statement

### DIFF
--- a/index.html
+++ b/index.html
@@ -3015,9 +3015,9 @@ A <a>DID method</a> specification MUST define exactly one method-specific
       </p>
 
       <p>
-The authors of a new <a>DID method</a> specification SHOULD use a method name
-that is unique among all <a>DID method</a> names known to them at the time of
-publication.
+The authors of a new <a>DID method</a> specification are expected to use a
+method name that is unique among all <a>DID method</a> names known to them at
+the time of publication.
       </p>
 
       <div class="note" title="Unique DID method names">


### PR DESCRIPTION
Rewords normative statement about method names from:

> The authors of a new DID method specification SHOULD use a method name that
> is unique among all DID method names known to them at the time of publication.

to 

> The authors of a new <a>DID method</a> specification are expected to use a
> method name that is unique among all <a>DID method</a> names known to them at
> the time of publication.

because the way it's worded ("known to them") is untestable even by humans.

#384


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/470.html" title="Last updated on Nov 24, 2020, 9:23 PM UTC (142ccad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/470/002b9f0...142ccad.html" title="Last updated on Nov 24, 2020, 9:23 PM UTC (142ccad)">Diff</a>