### PR TITLE
(editorial) minor language refinement

### DIFF
--- a/index.html
+++ b/index.html
@@ -2628,7 +2628,9 @@ data-cite="INFRA#convert-a-json-derived-javascript-value-to-an-infra-value">JSON
 consumption rules</a> in the [[INFRA]] specification.
         </p>
         <p>
-Note that the value of the <code>@context</code> object member will be ignored, if present. That is, this field will not have additional processing applied to its value and will be added verbatim to the abstract data model.
+Note that the <code>@context</code> object member, if present, will not have
+additional processing applied to its value, which will be added verbatim to the
+abstract data model.
         </p>
       </section>
 


### PR DESCRIPTION
Speaking into the void is never pleasant. There was no comment in response to [my suggested language change in #454](https://github.com/w3c/did-core/pull/454#discussion_r529983390), and it would be lost entirely if I were not saying something now.

To reiterate, I suggested that --
```
Note that no additional processing will be applied to the value of the 
<code>@context</code> object member, if present. The original value will 
be added verbatim to the abstract data model.
```
-- would be clearer than (line breaks added) --
```
Note that the value of the <code>@context</code> object member will be
ignored, if present. That is, this field will not have additional 
processing applied to its value and will be added verbatim to the 
abstract data model.
```

The major reason for this change is that "ignored" simply isn't correct here, as — even with the subsequent clarifying statement — "ignored" implies dropping the value on the floor, not carrying it forward to the abstract data model.

Upon re-re-re-re-reading both of the above, I believe this would be better still, and this is what I've put in this PR --
```
Note that the <code>@context</code> object member, if present, will not have
additional processing applied to its value, which will be added verbatim to the
abstract data model.
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/did-core/pull/472.html" title="Last updated on Dec 1, 2020, 8:13 PM UTC (57e2c45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/472/11622f3...TallTed:57e2c45.html" title="Last updated on Dec 1, 2020, 8:13 PM UTC (57e2c45)">Diff</a>