### PR TITLE
Add DID parameter for dereferencing an information resource identified by a DID

### DIFF
--- a/index.html
+++ b/index.html
@@ -949,8 +949,7 @@ Additional considerations for processing these parameters are discussed in
         </p>
 
         <p>
-Two example <a>DID URLs</a> using the <code><a>service</a></code> and
-<code>version-time</code> DID parameters are shown below.
+Some example <a>DID URLs</a> using DID parameters are shown below.
         </p>
 
         <pre class="example nohighlight" title="A DID URL with a 'service' DID parameter">
@@ -960,6 +959,11 @@ did:foo:21tDAKCERh95uGgKbJNHYp?service=agent
         <pre class="example nohighlight" title="A DID URL with a 'version-time' DID parameter">
 did:foo:21tDAKCERh95uGgKbJNHYp?version-time=2002-10-10T17:00:00Z
         </pre>
+
+        <pre class="example nohighlight" title="A DID URL with a 'resource' DID parameter">
+did:foo:21tDAKCERh95uGgKbJNHYp?resource=true
+        </pre>
+;';/'
 
         <p class="note" title="DID parameters and DID resolution">
 The <a>DID resolution</a> and the <a>DID URL dereferencing</a> functions can

--- a/index.html
+++ b/index.html
@@ -914,7 +914,7 @@ parameter is OPTIONAL. If present, the associated value MUST be an
 <code>subject</code>
               </td>
               <td>
-Indicates that the resource to be resolved is the <a>DID Subject</a>, rather
+Indicates that the resource to be dereferenced is the <a>DID Subject</a>, rather
 than the <a>DID Document</a>. This parameter is used to retrieve an information
 resource identified by a <a>DID</a>. Support for this parameter is OPTIONAL.
 If present, the associated value MUST be the

--- a/index.html
+++ b/index.html
@@ -911,7 +911,7 @@ parameter is OPTIONAL. If present, the associated value MUST be an
             </tr>
             <tr>
               <td>
-<code>subject</code>
+<code>resource</code>
               </td>
               <td>
 Indicates that the resource to be dereferenced is the <a>DID Subject</a>, rather

--- a/index.html
+++ b/index.html
@@ -963,7 +963,6 @@ did:foo:21tDAKCERh95uGgKbJNHYp?version-time=2002-10-10T17:00:00Z
         <pre class="example nohighlight" title="A DID URL with a 'resource' DID parameter">
 did:foo:21tDAKCERh95uGgKbJNHYp?resource=true
         </pre>
-;';/'
 
         <p class="note" title="DID parameters and DID resolution">
 The <a>DID resolution</a> and the <a>DID URL dereferencing</a> functions can

--- a/index.html
+++ b/index.html
@@ -909,6 +909,18 @@ parameter is OPTIONAL. If present, the associated value MUST be an
 <a data-lt="ascii string">ASCII string</a>.
               </td>
             </tr>
+            <tr>
+              <td>
+<code>subject</code>
+              </td>
+              <td>
+Indicates that the resource to be resolved is the <a>DID Subject</a>, rather
+than the <a>DID Document</a>. This parameter is used to retrieve an information
+resource identified by a <a>DID</a>. Support for this parameter is OPTIONAL.
+If present, the associated value MUST be the
+<a data-lt="ascii string">ASCII string</a> <code>true</code>.
+              </td>
+            </tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
fixes Issue #199 

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/did-spec/pull/480.html" title="Last updated on Dec 22, 2020, 5:17 PM UTC (e8ac856)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/480/16ba782...brentzundel:e8ac856.html" title="Last updated on Dec 22, 2020, 5:17 PM UTC (e8ac856)">Diff</a>