### PR TITLE
At Risk statement for ABNF not allowing an empty method-id-string

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,6 +766,9 @@ string. Some DID methods have expressed an interest in providing
 resolution of an DID with an empty <code>method-specific-id</code> string,
 for example to enable discovery of a DID document describing a
 <a>verifiable data registry</a> by resolving the DID method name alone.
+The Working Group is requesting feedback during the Candidate Recommendation
+stage on whether or not an empty <code>method-specific-id</code> string is
+of interest to implementers. This feature may change as a result of that feedback.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -760,6 +760,15 @@ method-specific-id = *( *idchar ":" ) 1*idchar
 idchar             = ALPHA / DIGIT / "." / "-" / "_"
       </pre>
 
+      <p class="issue atrisk" data-number="34">
+      This ABNF does not currently permit an empty <code>method-specific-id</code>
+      string. Some DID methods have expressed an interest in providing
+      resolution of an DID with an empty <code>method-specific-id</code> string,
+      for example to enable discovery of a DID document describing a
+      <a>verifiable data registry</a> by resolving the DID method name alone.
+      </p>
+
+
       <p>
 For requirements on <a>DID methods</a> relating to the <a>DID</a> syntax, see
 Section <a href="#method-schemes"></a>.

--- a/index.html
+++ b/index.html
@@ -761,13 +761,12 @@ idchar             = ALPHA / DIGIT / "." / "-" / "_"
       </pre>
 
       <p class="issue atrisk" data-number="34">
-      This ABNF does not currently permit an empty <code>method-specific-id</code>
-      string. Some DID methods have expressed an interest in providing
-      resolution of an DID with an empty <code>method-specific-id</code> string,
-      for example to enable discovery of a DID document describing a
-      <a>verifiable data registry</a> by resolving the DID method name alone.
+This ABNF does not currently permit an empty <code>method-specific-id</code>
+string. Some DID methods have expressed an interest in providing
+resolution of an DID with an empty <code>method-specific-id</code> string,
+for example to enable discovery of a DID document describing a
+<a>verifiable data registry</a> by resolving the DID method name alone.
       </p>
-
 
       <p>
 For requirements on <a>DID methods</a> relating to the <a>DID</a> syntax, see


### PR DESCRIPTION
This PR replaces #477 (because it had extraneous commits).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/talltree/did-core/pull/484.html" title="Last updated on Dec 19, 2020, 4:44 AM UTC (f67b606)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/484/16ba782...talltree:f67b606.html" title="Last updated on Dec 19, 2020, 4:44 AM UTC (f67b606)">Diff</a>