### PR TITLE
Add advisement on computing the cryptographic hash of a context

### DIFF
--- a/index.html
+++ b/index.html
@@ -2755,6 +2755,13 @@ machine-readable information about the context. These URIs SHOULD be
 associated with a cryptographic hash of the content of the JSON-LD Context as
 part of registration in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
             </p>
+            <p class="advisement">
+              If included, the cryptographic hash of the content of the JSON-LD Context, MUST be computed in a manner equivalent to:
+              <pre class="example">
+                curl -s https://www.w3.org/ns/did/v1#910cd6648f6f7b72a7896a8da83e63460eb8355a0af4b56b699c9281452ac8bb  | openssl sha256
+              </pre>
+              The integrity check is considered valid if and only if the hex digest of the resource matches the fragment.
+            </p>
           </dd>
         </dl>
         <p>

--- a/index.html
+++ b/index.html
@@ -2760,7 +2760,7 @@ If included, the cryptographic hash of the content of the JSON-LD Context MUST b
 computed in a manner equivalent to the following:
             </p>
             <pre class="example">
-curl -s https://www.w3.org/ns/did/v1  | openssl sha256
+curl -s https://www.w3.org/ns/did/v1 | openssl sha256
             </pre>
             <p>
 The command above will result in the following hash, expressed in hexadecimal notation:

--- a/index.html
+++ b/index.html
@@ -2756,7 +2756,8 @@ associated with a cryptographic hash of the content of the JSON-LD Context as
 part of registration in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
             </p>
             <p class="advisement">
-              If included, the cryptographic hash of the content of the JSON-LD Context MUST be computed in a manner equivalent to the following:
+If included, the cryptographic hash of the content of the JSON-LD Context MUST be
+computed in a manner equivalent to the following:
             </p>
             <pre class="example">
 curl -s https://www.w3.org/ns/did/v1  | openssl sha256

--- a/index.html
+++ b/index.html
@@ -2756,11 +2756,17 @@ associated with a cryptographic hash of the content of the JSON-LD Context as
 part of registration in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
             </p>
             <p class="advisement">
-              If included, the cryptographic hash of the content of the JSON-LD Context, MUST be computed in a manner equivalent to:
-              <pre class="example">
-                curl -s https://www.w3.org/ns/did/v1#910cd6648f6f7b72a7896a8da83e63460eb8355a0af4b56b699c9281452ac8bb  | openssl sha256
-              </pre>
-              The integrity check is considered valid if and only if the hex digest of the resource matches the fragment.
+              If included, the cryptographic hash of the content of the JSON-LD Context MUST be computed in a manner equivalent to the following:
+            </p>
+            <pre class="example">
+curl -s https://www.w3.org/ns/did/v1  | openssl sha256
+            </pre>
+            <p>
+The command above will result in the following hash, expressed in hexadecimal notation:
+            </p>             
+            <pre class="example">
+910cd6648f6f7b72a7896a8da83e63460eb8355a0af4b56b699c9281452ac8bb              
+            </pre>
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
Addresses https://github.com/w3c/did-core/issues/464


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/485.html" title="Last updated on Dec 17, 2020, 2:24 PM UTC (1bb6dfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/485/16ba782...1bb6dfa.html" title="Last updated on Dec 17, 2020, 2:24 PM UTC (1bb6dfa)">Diff</a>