### PR TITLE
Add LinkedDomain example

### DIFF
--- a/index.html
+++ b/index.html
@@ -2236,6 +2236,10 @@ standard specification.
       <pre class="example nohighlight" title="Various service endpoints">
 {
   "service": [{
+    "id":"did:example:123#linked-domain",
+    "type": "LinkedDomains",
+    "serviceEndpoint": "https://bar.example.com"
+  }, {
     "id": "did:example:123456789abcdefghi#openid",
     "type": "OpenIdConnectVersion1.0Service",
     "serviceEndpoint": "https://openid.example.com/"


### PR DESCRIPTION
Related https://github.com/w3c/did-spec-registries/pull/168


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/489.html" title="Last updated on Dec 12, 2020, 7:08 PM UTC (8388af7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/489/16ba782...8388af7.html" title="Last updated on Dec 12, 2020, 7:08 PM UTC (8388af7)">Diff</a>