### PR TITLE
Changing DID method name description to match the ABNF definition to allow digits

### DIFF
--- a/index.html
+++ b/index.html
@@ -742,8 +742,9 @@ The <a>DID scheme</a> name MUST be an
 <a data-lt="ascii lowercase">ASCII lowercase string</a>.
       </p>
       <p>
-The <a>DID method</a> name MUST be an
-<a data-lt="ascii lowercase">ASCII lowercase string</a>.
+The <a>DID method</a> name MUST be a string cosists of
+<a data-lt="ascii lower alpha">ASCII lower alpha</a> and
+<a data-lt="ascii digit">ASCII digit</a>.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -742,9 +742,9 @@ The <a>DID scheme</a> name MUST be an
 <a data-lt="ascii lowercase">ASCII lowercase string</a>.
       </p>
       <p>
-The <a>DID method</a> name MUST be a string cosists of
-<a data-lt="ascii lower alpha">ASCII lower alpha</a> and
-<a data-lt="ascii digit">ASCII digit</a>.
+The <a>DID method</a> name MUST be a string which consists of
+<a data-lt="ascii lower alpha">ASCII lowercase characters</a> and
+<a data-lt="ascii digit">ASCII digits</a>.
       </p>
 
       <p>


### PR DESCRIPTION
For Issue #491


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shigeya/did-core/pull/492.html" title="Last updated on Dec 20, 2020, 4:25 PM UTC (42183ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/492/2eef04c...shigeya:42183ea.html" title="Last updated on Dec 20, 2020, 4:25 PM UTC (42183ea)">Diff</a>