### PR TITLE
Minor cross reference fixes to the terminology section

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -39,8 +39,7 @@ software library, or a network call such as an HTTPS request.
   <dd>
 A globally unique persistent identifier that does not require a centralized
 registration authority because it is generated and/or registered cryptographically.
-The generic format of a DID is defined in the <a href="#did-syntax"></a> section of
-the <a href="https://w3.org/TR/did-core">DID Core specification</a>.
+The generic format of a DID is defined in <a href="#did-syntax"></a>.
 A specific <a>DID scheme</a> is defined in a <a>DID method</a> specification.
 Many—but not all—DID methods make use of <a>distributed ledger technology</a>
 (DLT) or some other form of decentralized network.
@@ -161,8 +160,7 @@ conforming <a>DID document</a> as output.
 
   <dd>
 The formal syntax of a <a>decentralized identifier</a>. The generic DID scheme
-begins with the prefix <code>did:</code> as defined in the <a href="#did-syntax"></a>
-section of the <a href="https://w3.org/TR/did-core">DID Core specification</a>.
+begins with the prefix <code>did:</code> as defined in <a href="#did-syntax"></a>.
 Each <a>DID method</a> specification must define a specific DID
 scheme that works with that specific <a>DID method</a>. In a specific DID method
 scheme, the DID method name must follow the first colon and terminate with the

--- a/terms.html
+++ b/terms.html
@@ -39,8 +39,8 @@ software library, or a network call such as an HTTPS request.
   <dd>
 A globally unique persistent identifier that does not require a centralized
 registration authority because it is generated and/or registered cryptographically.
-The generic format of a DID is defined in the
-<a href="https://w3.org/TR/did-core">DID Core specification</a>.
+The generic format of a DID is defined in the <a href="#did-syntax"></a> section of
+the <a href="https://w3.org/TR/did-core">DID Core specification</a>.
 A specific <a>DID scheme</a> is defined in a <a>DID method</a> specification.
 Many—but not all—DID methods make use of <a>distributed ledger technology</a>
 (DLT) or some other form of decentralized network.
@@ -161,7 +161,7 @@ conforming <a>DID document</a> as output.
 
   <dd>
 The formal syntax of a <a>decentralized identifier</a>. The generic DID scheme
-begins with the prefix <code>did:</code> as defined in the <a href="did-syntax"></a>
+begins with the prefix <code>did:</code> as defined in the <a href="#did-syntax"></a>
 section of the <a href="https://w3.org/TR/did-core">DID Core specification</a>.
 Each <a>DID method</a> specification must define a specific DID
 scheme that works with that specific <a>DID method</a>. In a specific DID method


### PR DESCRIPTION
As the subject reads.

Added section reference, also added missing '#' in one of the references.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shigeya/did-core/pull/503.html" title="Last updated on Dec 20, 2020, 4:31 PM UTC (44c6caf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/503/2eef04c...shigeya:44c6caf.html" title="Last updated on Dec 20, 2020, 4:31 PM UTC (44c6caf)">Diff</a>