### PR TITLE
changes usage of localized rules to previously used language

### DIFF
--- a/index.html
+++ b/index.html
@@ -2349,7 +2349,7 @@ behavior for any such properties defined by the representation.
 The production and consumption rules in this section apply to all
 implementations seeking to be fully compatible with independent implementations
 of the specification. Deployments of this specification MAY use a custom
-agreed-upon representation, iincluding rules agreed to by a pair of producers
+agreed-upon representation, including rules agreed to by a pair of producers
 and consumers for handling properties not listed in the registry. See section <a
   href="#extensibility"></a> for more information.
     </p>

--- a/index.html
+++ b/index.html
@@ -2349,9 +2349,9 @@ behavior for any such properties defined by the representation.
 The production and consumption rules in this section apply to all
 implementations seeking to be fully compatible with independent implementations
 of the specification. Deployments of this specification MAY use a custom
-agreed-upon representation, including localized rules for handling properties
-not listed in the registry. See section <a href="#extensibility"></a>
-for more information.
+agreed-upon representation, iincluding rules agreed to by a pair of producers
+and consumers for handling properties not listed in the registry. See section <a
+  href="#extensibility"></a> for more information.
     </p>
 
     <section>


### PR DESCRIPTION
Attempts to solve an editorial issue so we can close #494 

Digging through the commits it looks like this language came about from @jricher with @msporny handling much of the review in this area during PR #197 in [this commit](https://github.com/w3c/did-core/pull/197/commits/a4df7caedd15dc1d61ce1cf77fceff683b762143#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R1916)

From the looks of it we may be alright going to this language based on [this commit](https://github.com/w3c/did-core/commit/c1c28469d728830f27b46d73551cb8fff1b2ffe0#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R2342)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/507.html" title="Last updated on Dec 20, 2020, 4:32 PM UTC (4db1b10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/507/97336d3...4db1b10.html" title="Last updated on Dec 20, 2020, 4:32 PM UTC (4db1b10)">Diff</a>