### PR TITLE
Specify datetime precision for serializations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2430,7 +2430,7 @@ this section
               <td>
 <a data-cite="RFC8259#section-7">JSON String</a> formatted as an
 <a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to
-UTC 00:00 and without sub-second decimal precision. For example:
+UTC 00:00:00 and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -2429,7 +2429,9 @@ this section
               </td>
               <td>
 <a data-cite="RFC8259#section-7">JSON String</a> formatted as an
-<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>
+<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to
+UTC 00:00 and without sub-second decimal precision. For example:
+<code>2020-12-20T19:17:47Z</code>.
               </td>
             </tr>
             <tr>
@@ -2879,7 +2881,9 @@ as defined in this section
               </td>
               <td>
 <a data-cite="RFC7049#section-2.1">CBOR string</a> (major type 5) formatted as
-an <a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a>
+an <a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to
+UTC 00:00 and without sub-second decimal precision. For example:
+<code>2020-12-20T19:17:47Z</code>.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Specify datetime precision for serializations. Fixes #498.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/509.html" title="Last updated on Dec 27, 2020, 6:24 PM UTC (3027601)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/509/5366635...3027601.html" title="Last updated on Dec 27, 2020, 6:24 PM UTC (3027601)">Diff</a>