### PR TITLE
Allow serviceEndpoint to be an array. Address #506.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2182,10 +2182,15 @@ produce an error.
           </p>
           <p>
 The value of the <code><dfn>serviceEndpoint</dfn></code> property MUST be a
-valid <a>URI</a> conforming to [[RFC3986]] and normalized according to the
-rules in section 6 of [[RFC3986]] and to any normalization rules in its
-applicable <a>URI</a> scheme specification, <em>OR</em> a set of properties
-which describe the <a>service endpoint</a> further.
+<a data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#string">map</a>,
+or a <a data-cite="INFRA#">list</a> composed of a one or more
+<a data-cite="INFRA#string">strings</a> and/or
+<a data-cite="INFRA#string">maps</a>. All <a data-cite="INFRA#string">string</a>
+values MUST be valid <a>URI</a>s conforming to [[RFC3986]] and normalized
+according to the rules in section 6 of [[RFC3986]] and to any normalization
+rules in its applicable <a>URI</a> scheme specification. Extension
+specifications for services MAY further restrict the properties associated
+with the extension.
           </p>
         </dd>
       </dl>
@@ -2217,11 +2222,7 @@ standard specification.
     "id": "did:example:123456789abcdefghi#hub",
     "type": "IdentityHub",
     "verificationMethod": "did:example:123456789abcdefghi#key-1",
-    "serviceEndpoint": {
-      "@context": "https://schema.identity.foundation/hub",
-      "type": "UserHubEndpoint",
-      "instances": ["did:example:456", "did:example:789"]
-    }
+    "serviceEndpoint": ["did:example:456", "did:example:789"]
   }, {
     "id": "did:example:123456789abcdefghi#messages",
     "type": "MessagingService",

--- a/index.html
+++ b/index.html
@@ -2183,7 +2183,7 @@ produce an error.
           <p>
 The value of the <code><dfn>serviceEndpoint</dfn></code> property MUST be a
 <a data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#string">map</a>,
-or a <a data-cite="INFRA#">list</a> composed of a one or more
+or an <a data-cite="INFRA#ordered-set">ordered set</a> composed of a one or more
 <a data-cite="INFRA#string">strings</a> and/or
 <a data-cite="INFRA#string">maps</a>. All <a data-cite="INFRA#string">string</a>
 values MUST be valid <a>URI</a>s conforming to [[RFC3986]] and normalized


### PR DESCRIPTION
This PR fixes an oversight in the definition of serviceEndpoint to be an array. This should address #506.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/510.html" title="Last updated on Dec 20, 2020, 9:57 PM UTC (668ca83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/510/6434f17...668ca83.html" title="Last updated on Dec 20, 2020, 9:57 PM UTC (668ca83)">Diff</a>