### PR TITLE
Add section on service privacy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4818,12 +4818,13 @@ endpoint in the DID document adds privacy risk either due to correlation
 protected by an authorization mechanism, or both.
       </p>
       <p>
-The degree of additional privacy risk caused by using multiple service endpoints in one
-DID document can be difficult to estimate. Privacy harms are typically
-unintended consequences. DIDs can identify documents, services, schemas, and
-other things that may be associated with individual people,
-households, clubs, and employers &mdash; and correlation of their service
-endpoints could become a powerful surveillance and inference tool.
+The degree of additional privacy risk caused by using multiple service 
+endpoints in one DID document can be difficult to estimate. Privacy 
+harms are typically unintended consequences. DIDs can identify documents, 
+services, schemas, and other things that may be associated 
+with individual people, households, clubs, and employers &mdash; and 
+correlation of their service endpoints could become a powerful 
+surveillance and inference tool.
       </p>
       <p>
 DID documents are often public and will be stored and indexed efficiently by

--- a/index.html
+++ b/index.html
@@ -4830,7 +4830,7 @@ DID documents are often public and will be stored and indexed efficiently by
 their very standards-based nature. This risk is worse if DID documents are
 published to immutable Verifiable Data Registries. Access to a history of the
 DID documents referenced by a DID represents a form of traffic analysis made
-more efficient through our standards process.
+more efficient through the use of standards.
       </p>
       <p>
 Examples of service endpoints in DID documents come in three broad categories:
@@ -4853,7 +4853,7 @@ reference a DID Document with no service endpoints at all. For the second
 category, prefer using only one service that points to an authorization server, 
 mediator, or proxy that can provide herd immunity. For the third category, 
 avoid the use of multiple service endpoints for a DID because some
-of these (e.g. an authorization server) are likely to be reused with other,
+of these (e.g., an authorization server) are likely to be reused with other,
 related DIDs. Place correlatable service endpoints behind a 
 privacy-preserving  mechanism, if possible, or introduce a mediator or proxy 
 as a sole service endpoint in order to obscure related devices and documents 

--- a/index.html
+++ b/index.html
@@ -4812,14 +4812,14 @@ layers, and pad messages to standard lengths.
       </h2>
       <p>
 The ability for a controller to optionally state at least one service endpoint
-in the DID document increases their control and agency. Stating more than one
-endpoint in the DID document always adds privacy risk either due to correlation
-across the endpoint descriptions or because the services are not protected by
-an authorization mechanism, or both.
+in the DID document increases their control and agency. Each additional
+endpoint in the DID document adds privacy risk either due to correlation
+(e.g., across endpoint descriptions) or because the services are not
+protected by an authorization mechanism, or both.
       </p>
       <p>
-The degree of added privacy risk for using multiple service endpoints in one
-DID document can be difficult to estimate. Privacy harms are typically due to
+The degree of additional privacy risk caused by using multiple service endpoints in one
+DID document can be difficult to estimate. Privacy harms are typically
 unintended consequences. DIDs can identify documents, things, and schemas as
 well as services. As such, they will be associated with individual people,
 households, clubs, and employers &mdash; and correlation of their service
@@ -4827,7 +4827,7 @@ endpoints could become a powerful surveillance and inference tool.
       </p>
       <p>
 DID documents are often public and will be stored and indexed efficiently by
-their very nature as standards-based. This risk is worse if DID documents are
+their very standards-based nature. This risk is worse if DID documents are
 published to immutable Verifiable Data Registries. Access to a history of the
 DID documents referenced by a DID represents a form of traffic analysis made
 more efficient through our standards process.

--- a/index.html
+++ b/index.html
@@ -4805,8 +4805,62 @@ keep negotiated options to a minimum on wire protocols, use encrypted transport
 layers, and pad messages to standard lengths.
       </p>
     </section>
-  </section>
 
+    <section>
+      <h2>
+          Service Privacy
+      </h2>
+      <p>
+The ability for a controller to optionally state at least one service endpoint
+in the DID document increases their control and agency. Stating more than one
+endpoint in the DID document always adds privacy risk either due to correlation
+across the endpoint descriptions or because the services are not protected by
+an authorization mechanism, or both.
+      </p>
+      <p>
+The degree of added privacy risk for using multiple service endpoints in one
+DID document can be difficult to estimate. Privacy harms are typically due to
+unintended consequences. DIDs can identify documents, things, and schemas as
+well as services. As such, they will be associated with individual people,
+households, clubs, and employers &mdash; and correlation of their service
+endpoints could become a powerful surveillance and inference tool.
+      </p>
+      <p>
+DID documents are often public and will be stored and indexed efficiently by
+their very nature as standards-based. This risk is worse if DID documents are
+published to immutable Verifiable Data Registries. Access to a history of the
+DID documents referenced by a DID represents a form of traffic analysis made
+more efficient through our standards process.
+      </p>
+      <p>
+Examples of service endpoints in DID documents come in three broad categories:
+      </p>
+      <ol>
+          <li>Intentional public disclosures</li>
+          <li>
+              DIDs about natural persons (as might be covered by GDPR and
+              similar privacy regulations)
+          </li>
+          <li>
+              DIDs about things and documents that are associated with natural
+              persons.
+          </li>
+      </ol>
+      <p>
+For category 1, consider non-DID publication mechanisms with only a single
+service endpoint as the root. In some cases, the publication mechanism might
+reference a DID Document with no service endpoints at all. For category 2,
+prefer using only one service that points to an authorization server or to a
+mediator / proxy that can provide a kind of herd immunity, or both. For
+category 3, avoid the use of multiple service endpoints for a DID because some
+of these (e.g. an authorization server) are likely to be reused with other,
+related DIDs. Place correlatable service endpoints behind a “firewall”, if
+possible, or introduce a mediator / proxy as a sole service endpoint in
+order to obscure related devices and documents through herd immunity.
+      </p>
+    </section>
+  </section>
+  
   <section class="informative">
     <h1>
       Examples

--- a/index.html
+++ b/index.html
@@ -4820,8 +4820,8 @@ protected by an authorization mechanism, or both.
       <p>
 The degree of additional privacy risk caused by using multiple service endpoints in one
 DID document can be difficult to estimate. Privacy harms are typically
-unintended consequences. DIDs can identify documents, things, and schemas as
-well as services. As such, they will be associated with individual people,
+unintended consequences. DIDs can identify documents, services, schemas, and
+other things that may be associated with individual people,
 households, clubs, and employers &mdash; and correlation of their service
 endpoints could become a powerful surveillance and inference tool.
       </p>

--- a/index.html
+++ b/index.html
@@ -4847,16 +4847,17 @@ Examples of service endpoints in DID documents come in three broad categories:
           </li>
       </ol>
       <p>
-For category 1, consider non-DID publication mechanisms with only a single
-service endpoint as the root. In some cases, the publication mechanism might
-reference a DID Document with no service endpoints at all. For category 2,
-prefer using only one service that points to an authorization server or to a
-mediator / proxy that can provide a kind of herd immunity, or both. For
-category 3, avoid the use of multiple service endpoints for a DID because some
+For the first category, consider non-DID publication mechanisms with only 
+a single service endpoint. In some cases, the publication mechanism might
+reference a DID Document with no service endpoints at all. For the second
+category, prefer using only one service that points to an authorization server, 
+mediator, or proxy that can provide herd immunity. For the third category, 
+avoid the use of multiple service endpoints for a DID because some
 of these (e.g. an authorization server) are likely to be reused with other,
-related DIDs. Place correlatable service endpoints behind a “firewall”, if
-possible, or introduce a mediator / proxy as a sole service endpoint in
-order to obscure related devices and documents through herd immunity.
+related DIDs. Place correlatable service endpoints behind a 
+privacy-preserving  mechanism, if possible, or introduce a mediator or proxy 
+as a sole service endpoint in order to obscure related devices and documents 
+through herd immunity.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -4836,14 +4836,15 @@ more efficient through the use of standards.
 Examples of service endpoints in DID documents come in three broad categories:
       </p>
       <ol>
-          <li>Intentional public disclosures</li>
           <li>
-              DIDs about natural persons (as might be covered by GDPR and
-              similar privacy regulations)
+Intentional public disclosures
           </li>
           <li>
-              DIDs about things and documents that are associated with natural
-              persons.
+DIDs about natural persons (as might be covered by GDPR and similar
+privacy regulations)
+          </li>
+          <li>
+DIDs about things and documents that are associated with natural persons
           </li>
       </ol>
       <p>


### PR DESCRIPTION
This is an alternative embodiment of the "Service Privacy" guidance as proposed by Adrian Gropper in [this comment](https://github.com/w3c/did-core/pull/511#issuecomment-749163897). If accepted, it would supersede #511 and address issue #382.

Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/did-core/pull/515.html" title="Last updated on Jan 10, 2021, 7:09 PM UTC (572e072)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/515/6434f17...dhh1128:572e072.html" title="Last updated on Jan 10, 2021, 7:09 PM UTC (572e072)">Diff</a>