### PR TITLE
Added Comma after "EC" in P-256 section of Example 37

### DIFF
--- a/index.html
+++ b/index.html
@@ -4997,7 +4997,7 @@ practice to avoid using the same verification method for multiple purposes.
       "type": "JsonWebKey2020",
       "controller": "did:example:123",
       "publicKeyJwk": {
-        "kty": "EC"
+        "kty": "EC",
         "crv": "P-256",
         "x": "38M1FDts7Oea7urmseiugGW7tWc3mLpJh6rKe7xINZ8",
         "y": "nDQW6XZ7b_u2Sy9slofYLlG03sOEoug3I0aAPQ0exs4"


### PR DESCRIPTION
This is for https://github.com/w3c/did-core/issues/520 . 
"Example 37: DID Document with many different verification methods".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bshambaugh/did-core/pull/521.html" title="Last updated on Jan 2, 2021, 3:54 AM UTC (9b83fe1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/521/9605a1e...bshambaugh:9b83fe1.html" title="Last updated on Jan 2, 2021, 3:54 AM UTC (9b83fe1)">Diff</a>