### PR TITLE
Removed the usage of INFRA lists, in favor of ordered sets everywhere.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1201,6 +1201,14 @@ specified in [[INFRA]].
         </tr>
         <tr>
           <td>
+<a data-cite="INFRA#list">list</a>
+          </td>
+          <td>
+A finite ordered sequence of items as specified in [[INFRA]].
+          </td>
+        </tr>
+        <tr>
+          <td>
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
           </td>
           <td>
@@ -2429,6 +2437,16 @@ property value according to its type, as defined in this section
             </tr>
             <tr>
               <td>
+<a data-cite="INFRA#list">list</a>
+              </td>
+              <td>
+<a data-cite="RFC8259#section-5">JSON Array</a>, each element of the list is
+added, in order, as a value of the array according to its type, as defined in
+this section
+              </td>
+            </tr>
+            <tr>
+              <td>
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
@@ -2542,6 +2560,17 @@ is added as a property to the ordered map with the property name being the
 member name and the value converted based on the JSON type and, if available,
 property definition, as defined here; as no order is specified by JSON Objects,
 no insertion order is guaranteed
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC8259#section-5">JSON Array</a> where <a href="#data-model">data
+model</a> property value is a <a data-cite="INFRA#list">list</a> or unknown
+              </td>
+              <td>
+<a data-cite="INFRA#list">list</a>, each value of the JSON Array is added to the
+list in order, converted based on the JSON type of the array value, as defined
+here
               </td>
             </tr>
             <tr>
@@ -2862,6 +2891,16 @@ the property value according to its type, as defined in this section
             </tr>
             <tr>
               <td>
+<a data-cite="INFRA#list">list</a>
+              </td>
+              <td>
+<a data-cite="RFC7049#section-2.1">CBOR array</a> (major type 4), each element
+of the list is added, in order, as a value of the array according to its type,
+as defined in this section
+              </td>
+            </tr>
+            <tr>
+              <td>
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
@@ -3076,6 +3115,18 @@ is added as a property to the ordered map with the property name being the data
 item name and the value converted based on the CBOR type and, if available,
 property definition, as defined here; as no order can be enforced for general
 CBOR maps, no insertion order is guaranteed.
+              </td>
+            </tr>
+            <tr>
+              <td>
+<a data-cite="RFC7049#section-2.1">CBOR array</a> (major type 4), where the <a
+href="#data-model">data model</a> property value is a <a
+data-cite="INFRA#list">list</a> or unknown
+              </td>
+              <td>
+<a data-cite="INFRA#list">list</a>, each value of the
+<a data-cite="RFC7049#section-2.1">CBOR array</a> is added to the list in order,
+converted based on the CBOR type of the array value, as defined in this table
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -4210,8 +4210,8 @@ Input and output metadata is often involved during the <a>DID Resolution</a>,
 used to communicate this metadata MUST be a <a data-cite="INFRA#maps">map</a>
 of properties. Each property name MUST be a <a
 data-cite="INFRA#string">string</a>. Each property value MUST be a <a
-data-cite="INFRA#string">string</a>, <a data-cite="INFRA#maps">map</a>, an <a
-data-cite="INFRA#ordered-set">ordered set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
+data-cite="INFRA#string">string</a>, <a data-cite="INFRA#maps">map</a>, <a
+data-cite="INFRA#list">list</a>, <a data-cite="INFRA#ordered-set">ordered set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
 <a data-cite="INFRA#null">null</a>. The values within any complex data
 structures such as maps and lists MUST be one of these data types as well.
 All metadata property definitions MUST define the value type, including any

--- a/index.html
+++ b/index.html
@@ -1201,18 +1201,10 @@ specified in [[INFRA]].
         </tr>
         <tr>
           <td>
-<a data-cite="INFRA#list">list</a>
-          </td>
-          <td>
-A finite ordered sequence of items as specified in [[INFRA]].
-          </td>
-        </tr>
-        <tr>
-          <td>
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
           </td>
           <td>
-A <a data-cite="INFRA#list">list</a> that does not contain the same item twice
+A finite ordered sequence of items that does not contain the same item twice
 as specified in [[INFRA]].
           </td>
         </tr>
@@ -1368,7 +1360,7 @@ Nested properties include <code>id</code>, <code>type</code> and
     <p class="note" title="Ordering of values">
 As a result of the <a href="#data-model">data model</a> being defined using
 terminology from [[INFRA]], property values which can contain more than one
-item, such as <a data-cite="INFRA#lists">lists</a> and <a
+item, such as <a
 data-cite="INFRA#ordered-set">sets</a>, are explicitly ordered. For the purposes
 of this specification, unless otherwise stated, ordering is not important and
 implementations are not expected to produce or consume deterministically ordered
@@ -1452,8 +1444,8 @@ of <a>URI</a>) identify the same <a>DID subject</a> can be made using the
         <dl>
           <dt><dfn>alsoKnownAs</dfn></dt>
           <dd>
-The value of <code>alsoKnownAs</code> MUST be a
-<a data-cite="INFRA#lists">list</a> where each item in the list is a
+The value of <code>alsoKnownAs</code> MUST be an
+<a data-cite="INFRA#ordered-set">ordered set</a> where each item in the set is a
 <a>URI</a> conforming to [[RFC3986]].
           </dd>
           <dd>
@@ -2437,20 +2429,10 @@ property value according to its type, as defined in this section
             </tr>
             <tr>
               <td>
-<a data-cite="INFRA#list">list</a>
-              </td>
-              <td>
-<a data-cite="RFC8259#section-5">JSON Array</a>, each element of the list is
-added, in order, as a value of the array according to its type, as defined in
-this section
-              </td>
-            </tr>
-            <tr>
-              <td>
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
-<a data-cite="RFC8259#section-5">JSON Array</a>, each element of the list is
+<a data-cite="RFC8259#section-5">JSON Array</a>, each element of the set is
 added, in order, as a value of the array according to its type, as defined in
 this section
               </td>
@@ -2560,17 +2542,6 @@ is added as a property to the ordered map with the property name being the
 member name and the value converted based on the JSON type and, if available,
 property definition, as defined here; as no order is specified by JSON Objects,
 no insertion order is guaranteed
-              </td>
-            </tr>
-            <tr>
-              <td>
-<a data-cite="RFC8259#section-5">JSON Array</a> where <a href="#data-model">data
-model</a> property value is a <a data-cite="INFRA#list">list</a> or unknown
-              </td>
-              <td>
-<a data-cite="INFRA#list">list</a>, each value of the JSON Array is added to the
-list in order, converted based on the JSON type of the array value, as defined
-here
               </td>
             </tr>
             <tr>
@@ -2745,8 +2716,8 @@ The <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a>
 }
                 </pre>
               </li>
-              <li>
-An <a href="https://infra.spec.whatwg.org/#lists">INFRA list</a>,
+              <li>  
+An <a data-cite="INFRA#ordered-set">INFRA ordered set</a>,
 with first item the <a href="https://infra.spec.whatwg.org/#strings">INFRA
 string</a> <code>https://www.w3.org/ns/did/v1</code>, and subsequent items of
 type <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a> or
@@ -2887,16 +2858,6 @@ CBOR Representation Type
 <a data-cite="RFC7049#section-2.1">CBOR map</a> (major type 5), each property
 is represented as a member of the CBOR Map with the property name as the key and
 the property value according to its type, as defined in this section
-              </td>
-            </tr>
-            <tr>
-              <td>
-<a data-cite="INFRA#list">list</a>
-              </td>
-              <td>
-<a data-cite="RFC7049#section-2.1">CBOR array</a> (major type 4), each element
-of the list is added, in order, as a value of the array according to its type,
-as defined in this section
               </td>
             </tr>
             <tr>
@@ -3115,18 +3076,6 @@ is added as a property to the ordered map with the property name being the data
 item name and the value converted based on the CBOR type and, if available,
 property definition, as defined here; as no order can be enforced for general
 CBOR maps, no insertion order is guaranteed.
-              </td>
-            </tr>
-            <tr>
-              <td>
-<a data-cite="RFC7049#section-2.1">CBOR array</a> (major type 4), where the <a
-href="#data-model">data model</a> property value is a <a
-data-cite="INFRA#list">list</a> or unknown
-              </td>
-              <td>
-<a data-cite="INFRA#list">list</a>, each value of the
-<a data-cite="RFC7049#section-2.1">CBOR array</a> is added to the list in order,
-converted based on the CBOR type of the array value, as defined in this table
               </td>
             </tr>
             <tr>
@@ -3916,8 +3865,8 @@ This is the purpose of the <code><a>equivalentId</a></code>  property.
                 <dl>
                   <dt><dfn>equivalentId</dfn></dt>
                   <dd>
-The value of <code>equivalentId</code> MUST be a <a
-data-cite="INFRA#lists">list</a> where each item in the list is a <a
+The value of <code>equivalentId</code> MUST be an <a
+data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is a <a
 data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
 href="#did-syntax"></a>.
                   </dd>
@@ -4210,8 +4159,8 @@ Input and output metadata is often involved during the <a>DID Resolution</a>,
 used to communicate this metadata MUST be a <a data-cite="INFRA#maps">map</a>
 of properties. Each property name MUST be a <a
 data-cite="INFRA#string">string</a>. Each property value MUST be a <a
-data-cite="INFRA#string">string</a>, <a data-cite="INFRA#maps">map</a>, <a
-data-cite="INFRA#lists">list</a>, <a data-cite="INFRA#boolean">boolean</a>, or
+data-cite="INFRA#string">string</a>, <a data-cite="INFRA#maps">map</a>, an <a
+data-cite="INFRA#ordered-set">ordered set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
 <a data-cite="INFRA#null">null</a>. The values within any complex data
 structures such as maps and lists MUST be one of these data types as well.
 All metadata property definitions MUST define the value type, including any


### PR DESCRIPTION
This is a companion PR to issue #518, more exactly its [comment](https://github.com/w3c/did-core/issues/518). Submitting this as a PR may speed up processing in case the group agrees with the conclusions in #518...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/522.html" title="Last updated on Jan 6, 2021, 7:57 AM UTC (fd01d9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/522/9605a1e...fd01d9c.html" title="Last updated on Jan 6, 2021, 7:57 AM UTC (fd01d9c)">Diff</a>