### PR TITLE
Update at risk text for issue #208.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5332,7 +5332,9 @@ media types with multiple suffixes</a>. The alternative will be to use
 <code>application/ld+json</code> with an expected profile parameter of
 <code>https://www.w3.org/ns/did/json-ld-profile</code> if multiple suffixes
 cannot be registered by the time the rest of DID Core is ready for W3C
-Proposed Recommendation.
+Proposed Recommendation. Discussion is happening in the
+<a href="https://mailarchive.ietf.org/arch/msg/media-types/Sv8oT38p1nWHPYZQmnL_9GPjeic/">
+IETF media-types mailing list</a>.
       </p>
 
       <dl>

--- a/index.html
+++ b/index.html
@@ -2674,9 +2674,13 @@ set to <code>application/did+ld+json</code>.
 
       <p class="issue atrisk" data-number="208">
 Use of the media type <code>application/did+ld+json</code> is pending
-clarification over registration of media types with multiple suffixes. The
-alternative will be to use <code>application/did+jsonld</code> if multiple
-suffixes cannot be registered by the time the rest of DID Core is ready for PR.
+clarification over the registration of
+<a href="https://datatracker.ietf.org/doc/html/draft-w3cdidwg-media-types-with-multiple-suffixes">
+media types with multiple suffixes</a>. The alternative will be to use
+<code>application/ld+json</code> with an expected profile parameter of
+<code>https://www.w3.org/ns/did/json-ld-profile</code> if multiple suffixes
+cannot be registered by the time the rest of DID Core is ready for W3C
+Proposed Recommendation.
       </p>
 
       <p>
@@ -5322,9 +5326,13 @@ according to the rules defined in <a href="#fragment"></a>.
 
       <p class="issue atrisk" data-number="208">
 Use of the media type <code>application/did+ld+json</code> is pending
-clarification over registration of media types with multiple suffixes. The
-alternative will be to use <code>application/did+jsonld</code> if multiple
-suffixes cannot be registered by the time the rest of DID Core is ready for PR.
+clarification over the registration of
+<a href="https://datatracker.ietf.org/doc/html/draft-w3cdidwg-media-types-with-multiple-suffixes">
+media types with multiple suffixes</a>. The alternative will be to use
+<code>application/ld+json</code> with an expected profile parameter of
+<code>https://www.w3.org/ns/did/json-ld-profile</code> if multiple suffixes
+cannot be registered by the time the rest of DID Core is ready for W3C
+Proposed Recommendation.
       </p>
 
       <dl>
@@ -5509,8 +5517,6 @@ Fragment identifiers used with
 according to the rules defined in <a href="#fragment"></a>.
       </p>
     </section>
-
-
 
   </section>
 


### PR DESCRIPTION
Updates the at risk text for the `application/did+ld+json` media type.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/524.html" title="Last updated on Jan 10, 2021, 7:24 PM UTC (d48f2c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/524/c2841ed...d48f2c8.html" title="Last updated on Jan 10, 2021, 7:24 PM UTC (d48f2c8)">Diff</a>