### PR TITLE
Complete top-to-bottom review of testability of normative statements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1290,12 +1290,12 @@ method that ensures that two different representations will be able to work
 together.
         </li>
       <li>
-Representations MAY define other extensibility mechanisms, including ones that do
-not require the use of the DID Specification Registries. Such extension mechanisms SHOULD
-support lossless conversion into any other conformant representation. Extension
-mechanisms for a representation SHOULD define a mapping of all properties and
-representation syntax into the <a href="#data-model">data model</a> and its type
-system.
+Representations MAY define other extensibility mechanisms, including ones that
+do not require the use of the DID Specification Registries. Such extension
+mechanisms SHOULD support lossless conversion into any other conformant
+representation. Extension mechanisms for a representation SHOULD define a
+mapping of all properties and representation syntax into the <a
+href="#data-model">data model</a> and its type system.
       </li>
       </ol>
       <p class="note">
@@ -2189,7 +2189,7 @@ A <a>DID document</a> MAY include a <code><a>service</a></code> property.
         <dd>
           <p>
 If a <a>DID document</a> includes a <code>service</code> property, the value
-of the property SHOULD be an <a data-cite="INFRA#ordered-set">ordered set</a>
+of the property MUST be an <a data-cite="INFRA#ordered-set">ordered set</a>
 of <a>service endpoints</a>, where each service endpoint is described by a set
 of properties. Each <a>service endpoint</a> MUST have <code><a>id</a></code>,
 <code>type</code>, and <code><a>serviceEndpoint</a></code> properties, and MAY

--- a/index.html
+++ b/index.html
@@ -4130,7 +4130,7 @@ accept
 The MIME type the caller prefers for <code>content-stream</code>. The <a>DID
 URL Dereferencing</a> implementation SHOULD use this value to determine the
 representation contained in the returned value if such a representation is
-supported and available. This property is OPTIONAL.
+supported and available.
                 </dd>
             </dl>
         </section>
@@ -4151,8 +4151,8 @@ common properties.
 content-type
                 </dt>
                 <dd>
-The MIME type of the returned <code>content-stream</code>.
-This property is OPTIONAL if dereferencing is successful.
+The MIME type of the returned <code>content-stream</code> SHOULD be expressed
+using this property if dereferencing is successful.
                 </dd>
                 <dt>
 error

--- a/index.html
+++ b/index.html
@@ -3264,7 +3264,7 @@ rules are followed:
 
           <ul>
             <li>
-CBOR tags other than the CID tag (42) MUST NOT be utilized.
+CBOR tags other than the CID tag (42) MUST NOT be used.
             </li>
           </ul>
 

--- a/index.html
+++ b/index.html
@@ -943,7 +943,7 @@ If present, the associated value MUST be the
         </table>
 
         <p>
-Implementers as well as <a>DID method</a> specification authors MAY use
+Implementers as well as <a>DID method</a> specification authors might use
 additional DID parameters that are not listed here. For maximum
 interoperability, it is RECOMMENDED that DID parameters use the official W3C
 DID Specification Registries mechanism [[?DID-SPEC-REGISTRIES]], to avoid
@@ -951,7 +951,7 @@ collision with other uses of the same DID parameter with different semantics.
         </p>
 
         <p>
-DID parameters MAY be used if there is a clear use case where the parameter
+DID parameters might be used if there is a clear use case where the parameter
 needs to be part of a URI that can be used as a link, or as a <a>resource</a>
 in RDF / JSON-LD documents.
         </p>
@@ -1600,7 +1600,7 @@ processor MUST produce an error.
 
           <p>
 In the case where a verification method is a public key, the value of the
-<code><a>id</a></code> property MAY be structured as a
+<code><a>id</a></code> property might be structured as a
 <a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. This is
 especially useful for integrating with existing key management systems and key
 formats such as JWK [[RFC7517]]. It is RECOMMENDED that JWK <code>kid</code>
@@ -2983,12 +2983,6 @@ length.</a>
         </ul>
 
       <p>
-The property name `@context` MAY be present in the CBOR representation of a DID
-Document and if present SHOULD be ignored as this property is reserved for
-JSON-LD processing.
-      </p>
-
-      <p>
 All properties of the DID document represented in CBOR MUST be included in the
 root map (major type 5). Properties MAY define additional data sub structures
 represented as nested CBOR maps (major type 5) and is subject to the value
@@ -3406,7 +3400,7 @@ with regards to operations that can be performed on a <a>DID document</a>.
       </p>
       <p>
 Determining the authority of a party to carry out the operations is
-method-specific. For example, a <a>DID method</a> MAY:
+method-specific. For example, a <a>DID method</a> might:
       </p>
       <ul>
         <li>
@@ -3701,7 +3695,7 @@ did-document-stream
 If the resolution is successful, and if the <code>resolveRepresentation</code>
 function was called, this MUST be a byte stream of the resolved <a>DID
 document</a> in one of the conformant
-<a href="#representations">representations</a>. The byte stream MAY then be
+<a href="#representations">representations</a>. The byte stream might then be
 parsed by the caller of the <code>resolveRepresentation</code> function into a
 <a href="#data-model">data model</a>, which can in turn be validated and
 processed. If the resolution is unsuccessful, this value MUST be an empty
@@ -3726,10 +3720,10 @@ href="#did-document-metadata-properties"></a>.
 
         <p>
 Conforming <a>DID resolver</a> implementations do not alter the signature of
-these functions in any way. <a>DID resolver</a> implementations MAY map the
+these functions in any way. <a>DID resolver</a> implementations might map the
 <code>resolve</code> and <code>resolveRepresentation</code> functions to a
 method-specific internal function to perform the actual <a>DID resolution</a>
-process. <a>DID resolver</a> implementations MAY implement  and expose
+process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
 <code>resolve</code> function specified here.
         </p>
@@ -3845,13 +3839,11 @@ This specification defines the following common properties.
           <section>
             <h4>created</h4>
             <p>
-DID document metadata SHOULD include a <code>created</code> property
-to indicate the timestamp of the <a href="#create">Create operation</a>.
-This property MAY not be supported by a given <a>DID method</a>.
-The value of the property MUST be a <a data-cite="INFRA#string">string</a>
-formatted as an
-<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to
-UTC 00:00:00 and without sub-second decimal precision. For example:
+DID document metadata SHOULD include a <code>created</code> property to indicate
+the timestamp of the <a href="#create">Create operation</a>. The value of the
+property MUST be a <a data-cite="INFRA#string">string</a> formatted as an <a
+data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC 00:00:00
+and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
             </p>
           </section>
@@ -3859,11 +3851,10 @@ UTC 00:00:00 and without sub-second decimal precision. For example:
           <section>
             <h4>updated</h4>
             <p>
-DID document metadata SHOULD include an <code>updated</code> property
-to indicate the timestamp of the last <a href="#update">Update operation</a>
-for the document version which was resolved. This property MAY not be
-supported by a given <a>DID method</a>. The value of the property MUST
-follow the same formatting rules as the <code>created</code> property.
+DID document metadata SHOULD include an <code>updated</code> property to
+indicate the timestamp of the last <a href="#update">Update operation</a> for
+the document version which was resolved. The value of the property MUST follow
+the same formatting rules as the <code>created</code> property.
                 </p>
               </section>
 
@@ -3875,7 +3866,6 @@ follow the same formatting rules as the <code>created</code> property.
 DID document metadata SHOULD include a <code>next-update</code> property if
 the resolved document version is not the latest version of the document. It
 indicates the timestamp of the next <a href="#update">Update operation</a>.
-This property MAY not be supported by a given <a>DID method</a>.
 The value of the property MUST follow the same formatting rules as the
 <code>created</code> property.
             </p>
@@ -3886,11 +3876,10 @@ The value of the property MUST follow the same formatting rules as the
                 version-id
               </h4>
               <p>
-DID document metadata SHOULD include a <code>version-id</code> property
-to indicate the version of the last <a href="#update">Update operation</a>
-for the document version which was resolved. This property MAY not be
-supported by a given <a>DID method</a>. The value of the property MUST be
-an <a data-lt="ascii string">ASCII string</a>.
+DID document metadata SHOULD include a <code>version-id</code> property to
+indicate the version of the last <a href="#update">Update operation</a> for the
+document version which was resolved. The value of the property MUST be an <a
+data-lt="ascii string">ASCII string</a>.
               </p>
             </section>
 
@@ -3899,11 +3888,10 @@ an <a data-lt="ascii string">ASCII string</a>.
                 next-version-id
               </h4>
               <p>
-DID document metadata SHOULD include a <code>next-version-id</code> property
-if the resolved document version is not the latest version of the document.
-It indicates the version of the next <a href="#update">Update operation</a>.
-This property MAY not be supported by a given <a>DID method</a>.
-The value of the property MUST be an <a data-lt="ascii string">ASCII string</a>.
+DID document metadata SHOULD include a <code>next-version-id</code> property if
+the resolved document version is not the latest version of the document. It
+indicates the version of the next <a href="#update">Update operation</a>. The
+value of the property MUST be an <a data-lt="ascii string">ASCII string</a>.
               </p>
             </section>
 
@@ -4093,7 +4081,7 @@ content-stream
         <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a resource corresponding to the <a>DID URL</a>.
-The <code>content-stream</code> MAY be a <a>DID document</a> in one of the
+The <code>content-stream</code> SHOULD be a <a>DID document</a> in one of the
 conformant <a href="#representations">representations</a> obtained through
 the resolution process.
 
@@ -4118,9 +4106,9 @@ href="metadata-structure">metadata structure</a>.
     <p>
 Conforming <a>DID URL Dereferencing</a> implementations do not alter the
 signature of these functions in any way. <a>DID URL Dereferencing</a>
-implementations MAY map the <code>dereference</code> function to a
+implementations might map the <code>dereference</code> function to a
 method-specific internal function to perform the actual <a>DID URL
-Dereferencing</a> process. <a>DID URL Dereferencing</a> implementations MAY
+Dereferencing</a> process. <a>DID URL Dereferencing</a> implementations might
 implement and expose additional functions with different signatures in addition
 to the <code>dereference</code> function specified here.
     </p>

--- a/index.html
+++ b/index.html
@@ -1108,7 +1108,7 @@ identifiers.
 
         <p>
 When resolving a relative DID URL reference, the algorithm specified in <a
-data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a>  MUST
+data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a> MUST
 be used. The <strong>base URI</strong> value is the <a>DID</a> that is
 associated with the <a>DID subject</a>, see Section <a href="#did-subject"></a>.
 The <strong>scheme</strong> is <code>did</code>. The <strong>authority</strong>
@@ -1809,7 +1809,7 @@ please see [[?DID-SPEC-REGISTRIES]].
 
 
         <p>
-The <a>DID document</a> MUST NOT express revoked keys using a <a>verification
+The <a>DID document</a> does not express revoked keys using a <a>verification
 relationship</a>.
         </p>
         <p>
@@ -1847,9 +1847,9 @@ appropriate <a>verification relationship</a> property of the
       </p>
       <p>
 The <a>verification relationship</a> between the <a>DID subject</a> and the
-<a>verification method</a> MUST be explicit in the <a>DID document</a>.
+<a>verification method</a> is explicit in the <a>DID document</a>.
 <a>Verification methods</a> that are not associated with a particular
-<a>verification relationship</a> MUST NOT be used for that <a>verification
+<a>verification relationship</a> cannot be used for that <a>verification
 relationship</a>. For example, a <a>verification method</a> in the value of
 the <code><a>authentication</a></code> property cannot be used to engage in
 key agreement protocols with the <a>DID subject</a>&mdash;the value of the
@@ -3226,7 +3226,7 @@ that may be ignored or lost in a round-trip decode/encode.
 To produce a deterministic canonical CBOR representation of a DID document and
 faciliate maximal lossless compatiblity with other core representations via the
 <a href="#data-model">data model</a> the following constraints of a CBOR
-representation of a DID Document MUST be followed:
+representation are as follows:
           </p>
 
           <ul>
@@ -3265,12 +3265,12 @@ href="https://github.com/w3c/did-core/issues/361">issue #361</a>.
 
           <p>
 When producing and consuming DID Documents representing in DagCBOR the following
-rules MUST be followed:
+rules are followed:
           </p>
 
           <ul>
             <li>
-Use no CBOR tags other than the CID tag (42)
+CBOR tags other than the CID tag (42) MUST NOT be utilized.
             </li>
           </ul>
 
@@ -3608,7 +3608,7 @@ considerations for implementors are discussed in [[?DID-RESOLUTION]].
     <p>
 All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a>
 functions for at least one <a>DID method</a> and MUST be able to return a <a>DID
-document</a> in  at least one conformant representation.
+document</a> in at least one conformant representation.
     </p>
 
     <section>
@@ -3620,7 +3620,7 @@ The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>.
 (See <a href="#read-verify"></a>.) The details of how this process is
 accomplished are outside the scope of this specification, but all conformant
-implementations MUST implement two functions which have the following abstract
+implementations implement two functions which have the following abstract
 forms:
         </p>
 
@@ -3725,8 +3725,8 @@ href="#did-document-metadata-properties"></a>.
         </dl>
 
         <p>
-<a>DID resolver</a> implementations MUST NOT alter the signature of these
-functions in any way. <a>DID resolver</a> implementations MAY map the
+Conforming <a>DID resolver</a> implementations do not alter the signature of
+these functions in any way. <a>DID resolver</a> implementations MAY map the
 <code>resolve</code> and <code>resolveRepresentation</code> functions to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations MAY implement  and expose
@@ -3942,7 +3942,7 @@ A conforming <a>DID Method</a> specification MUST guarantee that each
 <code>id</code> property value.
                   </dd>
                   <dd>
-A resolving party MUST retain the values from the <code>id</code> and
+A resolving party is expected to retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties to ensure any subsequent
 interactions with any of the values they contain are correctly handled as
 logically equivalent (e.g. retain all variants in a database so an interaction
@@ -3999,13 +3999,13 @@ A conforming <a>DID Method</a> specification MUST guarantee that the
 <code>id</code> property value.
                   </dd>
                   <dd>
-A resolving party MUST use the <code><a>canonicalId</a></code> value as its
-primary ID value for the DID subject and treat all other equivalent values as
-secondary aliases. (e.g. update corresponding primary references in their
-systems to reflect the new canonical ID directive). <span class="issue">The
-testability of resolving parties is currently under debate and normative
-statements related to resolving parties may be downgraded in the future from a
-MUST to a SHOULD/MAY or similar language.</span>
+A resolving party is expected to use the <code><a>canonicalId</a></code> value
+as its primary ID value for the DID subject and treat all other equivalent
+values as secondary aliases. (e.g. update corresponding primary references in
+their systems to reflect the new canonical ID directive). <span
+class="issue">The testability of resolving parties is currently under debate and
+normative statements related to resolving parties may be downgraded in the
+future from a MUST to a SHOULD/MAY or similar language.</span>
                   </dd>
                 </dl>
 
@@ -4035,7 +4035,7 @@ including the <a>DID method</a>, method-specific identifier, path, query,
 and fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
 contained in the <a>DID URL</a>.
 The details of how this process is accomplished are outside the scope of this
-specification, but all conformant implementations MUST implement a function
+specification, but all conformant implementations implement a function
 which has the following abstract form:
       </p>
 
@@ -4045,7 +4045,7 @@ dereference ( did-url, did-url-dereferencing-input-metadata ) <br>
       </code></p>
 
       <p>
-The input variables of this function MUST be as follows:
+The input variables of this function are as follows:
       </p>
 
       <dl>
@@ -4070,7 +4070,7 @@ REQUIRED, but the structure MAY be empty.
       </dl>
 
       <p>
-The output variables of this function MUST be as follows:
+The output variables of this function are as follows:
       </p>
 
       <dl>
@@ -4116,13 +4116,13 @@ href="metadata-structure">metadata structure</a>.
     </dl>
 
     <p>
-<a>DID URL Dereferencing</a> implementations MUST NOT alter the signature of
-these functions in any way. <a>DID URL Dereferencing</a> implementations MAY
-map the <code>dereference</code> function to a method-specific internal
-function to perform the actual <a>DID URL Dereferencing</a> process. <a>DID
-URL Dereferencing</a> implementations MAY implement and expose additional
-functions with different signatures in addition to the <code>dereference</code>
-function specified here.
+Conforming <a>DID URL Dereferencing</a> implementations do not alter the
+signature of these functions in any way. <a>DID URL Dereferencing</a>
+implementations MAY map the <code>dereference</code> function to a
+method-specific internal function to perform the actual <a>DID URL
+Dereferencing</a> process. <a>DID URL Dereferencing</a> implementations MAY
+implement and expose additional functions with different signatures in addition
+to the <code>dereference</code> function specified here.
     </p>
 
       <section>
@@ -4227,7 +4227,7 @@ definitions use strings for values.
 
         <p>
 All implementations of functions that use metadata structures as either input
-or output MUST be able to fully represent all data types described here in a
+or output are able to fully represent all data types described here in a
 deterministic fashion. As inputs and outputs using metadata structures are
 defined in terms of data types and not their serialization, the method for
 representation is internal to the implementation of the function and is out of


### PR DESCRIPTION
This PR contains a complete top-to-bottom review of the testability of the normative statements in the DID Core specification and should address issue #384. The goal with this PR is to reduce the workload for the entire WG wrt. the test suite and the tests we're going to have to write in the coming month or two. With that goal in mind - this PR removes or refactors normative statements that are tested elsewhere in the specification, aren't our job to test, or are too vague to be tested (by a human or a machine).

I expect there are a few that reviewers might find concerning, so while you're considering the change, ask yourself the following questions to suggest alternatives:

* Is it the job of the DID Core specification (based on our Charter) to test this particular thing?
* Can this statement be empirically tested by a machine or a human?
* Is this statement not tested anywhere else in the specification?

If the answer to all of those questions is "yes", then there may be an argument to not make a subset of the changes made in this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/526.html" title="Last updated on Jan 3, 2021, 9:20 PM UTC (ce0f0e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/526/10744a0...ce0f0e3.html" title="Last updated on Jan 3, 2021, 9:20 PM UTC (ce0f0e3)">Diff</a>