### PR TITLE
Swap service and relative-ref parameters in table.

### DIFF
--- a/index.html
+++ b/index.html
@@ -868,6 +868,16 @@ Description
           <tbody>
             <tr>
               <td>
+<code><a>service</a></code>
+              </td>
+              <td>
+Identifies a service from the <a>DID document</a> by service ID. Support for
+this parameter is REQUIRED. The associated value MUST be an <a data-lt="ascii
+string">ASCII string</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>
 <code>relative-ref</code>
               </td>
               <td>
@@ -878,16 +888,6 @@ a <a>DID document</a> by using the <code>service</code> parameter. Support for
 this parameter is REQUIRED. The associated value MUST be an <a data-lt="ascii
 string">ASCII string</a> and MUST use percent-encoding for certain characters
 as specified in <a data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>.
-              </td>
-            </tr>
-            <tr>
-              <td>
-<code><a>service</a></code>
-              </td>
-              <td>
-Identifies a service from the <a>DID document</a> by service ID. Support for
-this parameter is REQUIRED. The associated value MUST be an <a data-lt="ascii
-string">ASCII string</a>.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This is an editorial PR that simply changes the order of the [DID parameter table](https://w3c.github.io/did-core/#did-parameters) to list `service` before `relative-ref`.

I agree with the re-ordering done by @rhiaro in https://github.com/w3c/did-core/pull/427/commits/74586e8f3f1c7245e9d725c25850d749aa028cb6, which nicely lists required parameters before optional ones, but I think the table becomes more readable if `service` comes before `relative-ref`. After all, the latter mentions the former, and all the examples I've seen also use them in this order.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/531.html" title="Last updated on Jan 5, 2021, 9:50 PM UTC (fbe4639)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/531/10744a0...fbe4639.html" title="Last updated on Jan 5, 2021, 9:50 PM UTC (fbe4639)">Diff</a>