### PR TITLE
Improve content integrity protection parts (mostly about json-ld contexts)

### DIFF
--- a/common.js
+++ b/common.js
@@ -166,11 +166,6 @@ var ccg = {
       ],
       date: "2011",
       publisher: "Information and Privacy Commissioner"
-    },
-    "IPFS": {
-      title: "InterPlanetary File System (IPFS)",
-      href: "https://docs.ipfs.io/",
-      publisher: "Protocol Labs"
     }
   }
 };

--- a/common.js
+++ b/common.js
@@ -166,6 +166,11 @@ var ccg = {
       ],
       date: "2011",
       publisher: "Information and Privacy Commissioner"
+    },
+    "IPFS": {
+      title: "InterPlanetary File System (IPFS)",
+      href: "https://docs.ipfs.io/",
+      publisher: "Protocol Labs"
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -2774,25 +2774,10 @@ interoperable across representations.
 
             <p>
 It is RECOMMENDED that dereferencing each <a>URI</a> value of the
-<code>@context</code> property results in a document containing machine-readable
-information about the context. These URIs SHOULD be associated with a
-cryptographic hash of the content of the JSON-LD Context as part of registration
-in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
-            </p>
-            <p class="advisement">
-If included, the cryptographic hash of the content of the JSON-LD Context MUST
-be computed in a manner equivalent to the following:
-            </p>
-            <pre class="example">
-curl -s https://www.w3.org/ns/did/v1 | openssl sha256
-            </pre>
-            <p>
-The command above will result in the following hash, expressed in hexadecimal
-notation:
-            </p>
-            <pre class="example">
-910cd6648f6f7b72a7896a8da83e63460eb8355a0af4b56b699c9281452ac8bb
-            </pre>
+<code>@context</code> property results in a document containing
+machine-readable information about the context. Note that further expectations
+of additional JSON-LD contexts are described as part of the DID specification
+registries registration process.
             </p>
           </dd>
         </dl>
@@ -4731,6 +4716,28 @@ an attack vector that will circumvent verification unless the DID document is
 re-verified.
       </p>
 
+    </section>
+
+    <section>
+      <h2>
+Content Integrity Protection
+      </h2>
+      <p>
+DID documents which include external JSON-LD contexts (see
+<a href="#json-ld"></a>) or any other links to external machine-readable
+content are vulnerable to tampering.
+      </p>
+      <p>
+DID document consumers can cache local static copies of JSON-LD contexts
+and/or verify the integrity of external contexts against the cryptographic
+hash for the context as registered in the DID specification registries
+(see the registration process for more detail) [[?DID-SPEC-REGISTRIES]].
+      </p>
+      <p>
+Implementers can also consider other means to protect links to external
+content as best suited to their application. Examples of URL schemes which
+enforce content integrity are [[HASHLINK]] and [[IPFS]].
+      </p>
     </section>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -4733,11 +4733,6 @@ and/or verify the integrity of external contexts against the cryptographic
 hash for the context as registered in the DID specification registries
 (see the registration process for more detail) [[?DID-SPEC-REGISTRIES]].
       </p>
-      <p>
-Implementers can also consider other means to protect links to external
-content as best suited to their application. Examples of URL schemes which
-enforce content integrity are [[HASHLINK]] and [[IPFS]].
-      </p>
     </section>
   </section>
 


### PR DESCRIPTION
I think there was a general feeling that the very specific parts about hashing the JSON-LD context don't belong in the Core spec (https://github.com/w3c/did-core/pull/485#issuecomment-744068170). https://github.com/w3c/did-spec-registries/pull/146 on the registries adds the specifics there instead. I also added a bit about this more generally in security considerations.

This _removes_ a normative statement in favour of deferring to the registries and additional informative security guidence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/534.html" title="Last updated on Jan 17, 2021, 6:53 PM UTC (f6555eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/534/10744a0...f6555eb.html" title="Last updated on Jan 17, 2021, 6:53 PM UTC (f6555eb)">Diff</a>