### PR TITLE
Added tables to replace the introductory part on core properties - bis for github

### DIFF
--- a/index.html
+++ b/index.html
@@ -1328,7 +1328,7 @@ property.
       <li>properties defined for a <a>Verification Method</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#verification-methods"></a>; </li>
       <li>properties defined for a <a>Service Endpoint</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#service-endpoints"></a>.</li>
     </ol>
-    
+
     <p class="note" title="Repeated properties">Some of the properties (e.g., <code>id</code> or <code>type</code>) are present in different classes but with possible differences in the associated constraints. Hence their repeated presence in the tables in Section <a href="#property-summary"></a>.</p>
 
     <p class="note" title="Ordering of values">
@@ -1361,7 +1361,7 @@ property.
               <td><code><a>alsoKnownAs</a</code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>.
               </td>
             </tr>
             <tr>
@@ -1369,54 +1369,54 @@ property.
               <td>OPTIONAL</td>
               <td>
                 A <a data-cite="INFRA#string">string</a> or an <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules in Section <a href="#did-syntax"></a>.
-              </td> 
+              </td>
             </tr>
             <tr>
               <td><code><a>verificationMethod</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> (see <a href="#core-properties-for-a-verification-method"></a>) or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
               <td><code><a>authentication</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> (see <a href="#core-properties-for-a-verification-method"></a>) or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
               <td><code><a>assertionMethod</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> (see <a href="#core-properties-for-a-verification-method"></a>) or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
               <td><code><a>keyAgreement</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> (see <a href="#core-properties-for-a-verification-method"></a>) or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
               <td><code><a>capabilityInvocation</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> ins<a data-cite="INFRA#ordered-map">maps</a>ances or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> (see <a href="#core-properties-for-a-verification-method"></a>) or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
               <td><code><a>capabilityDelegation</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> (see <a href="#core-properties-for-a-verification-method"></a>) or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
               <td><code><a>service</a></code></td>
               <td>OPTIONAL</td>
-              <td>An <a data-cite="INFRA#ordered-set">ordered set</a> of <a>Service Endpoint</a> <a data-cite="INFRA#ordered-map">maps</a>.</td>
+              <td>An <a data-cite="INFRA#ordered-set">ordered set</a> of <a>Service Endpoint</a> <a data-cite="INFRA#ordered-map">maps</a>  (see <a href="#core-properties-for-a-service-endpoint"></a>).</td>
             </tr>
           </tbody>
         </table>
@@ -1438,7 +1438,7 @@ property.
               <td><code>id</code></td>
               <td>REQUIRED</td>
               <td>
-                A <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URI</a>-s and which SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+                A <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URIs</a> and which SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
               </td>
             </tr>
             <tr>
@@ -1446,7 +1446,7 @@ property.
               <td>REQUIRED</td>
               <td>
                 A <a data-cite="INFRA#string">string</a> or an <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules in Section <a href="#did-syntax"></a>.
-              </td> 
+              </td>
             </tr>
             <tr>
               <td><code>type</code></td>
@@ -1458,7 +1458,7 @@ property.
             <tr>
               <td><code><a>publicKeyJwk</a></code></td>
               <td>OPTIONAL</td>
-              <td>A <a data-cite="INFRA#maps">map</a> representing a JSON Web Key that conforms to [[RFC7517]].</td>
+              <td>A <a data-cite="INFRA#maps">map</a> representing a JSON Web Key that conforms to [[RFC7517]]. This value MUST NOT contain "d", or any other members of the private information class as described in <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration Template</a>.</td>
             </tr>
             <tr>
               <td><code><a>publicKeyBase58</a></code></td>
@@ -1489,7 +1489,7 @@ property.
               <td><code>id</code></td>
               <td>REQUIRED</td>
               <td>
-                when used on a <a>Service Endpoint</a>: a <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URI</a>-s.
+                when used on a <a>Service Endpoint</a>: a <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URIs</a>.
               </td>
             </tr>
             <tr>
@@ -1503,7 +1503,7 @@ property.
               <td><code><a>serviceEndpoint</a></code></td>
               <td>OPTIONAL</td>
               <td>
-                A <a data-cite="INFRA#string">string</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s, a <a data-cite="INFRA#string">map</a>, or an <a data-cite="INFRA#ordered-set">ordered set</a> composed of a one or more <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s and/or <a data-cite="INFRA#string">maps</a>.
+                A <a data-cite="INFRA#string">string</a> that conform to the rules of [[RFC3986]] for <a>URIs</a>, a <a data-cite="INFRA#string">map</a>, or an <a data-cite="INFRA#ordered-set">ordered set</a> composed of a one or more <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s and/or <a data-cite="INFRA#string">maps</a>.
               </td>
             </tr>
           </tbody>
@@ -2414,7 +2414,7 @@ and <a href="#authentication"></a>.
     </section>
 
   </section>
-  
+
   </section>
 
   <section class="normative">
@@ -2889,7 +2889,7 @@ The <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a>
 }
                 </pre>
               </li>
-              <li>  
+              <li>
 An <a data-cite="INFRA#ordered-set">INFRA ordered set</a>,
 with first item the <a href="https://infra.spec.whatwg.org/#strings">INFRA
 string</a> <code>https://www.w3.org/ns/did/v1</code>, and subsequent items of
@@ -5023,12 +5023,12 @@ endpoint in the DID document adds privacy risk either due to correlation
 protected by an authorization mechanism, or both.
       </p>
       <p>
-The degree of additional privacy risk caused by using multiple service 
-endpoints in one DID document can be difficult to estimate. Privacy 
-harms are typically unintended consequences. DIDs can identify documents, 
-services, schemas, and other things that may be associated 
-with individual people, households, clubs, and employers &mdash; and 
-correlation of their service endpoints could become a powerful 
+The degree of additional privacy risk caused by using multiple service
+endpoints in one DID document can be difficult to estimate. Privacy
+harms are typically unintended consequences. DIDs can identify documents,
+services, schemas, and other things that may be associated
+with individual people, households, clubs, and employers &mdash; and
+correlation of their service endpoints could become a powerful
 surveillance and inference tool.
       </p>
       <p>
@@ -5054,21 +5054,21 @@ DIDs about things and documents that are associated with natural persons
           </li>
       </ol>
       <p>
-For the first category, consider non-DID publication mechanisms with only 
+For the first category, consider non-DID publication mechanisms with only
 a single service endpoint. In some cases, the publication mechanism might
 reference a DID Document with no service endpoints at all. For the second
-category, prefer using only one service that points to an authorization server, 
-mediator, or proxy that can provide herd immunity. For the third category, 
+category, prefer using only one service that points to an authorization server,
+mediator, or proxy that can provide herd immunity. For the third category,
 avoid the use of multiple service endpoints for a DID because some
 of these (e.g., an authorization server) are likely to be reused with other,
-related DIDs. Place correlatable service endpoints behind a 
-privacy-preserving  mechanism, if possible, or introduce a mediator or proxy 
-as a sole service endpoint in order to obscure related devices and documents 
+related DIDs. Place correlatable service endpoints behind a
+privacy-preserving  mechanism, if possible, or introduce a mediator or proxy
+as a sole service endpoint in order to obscure related devices and documents
 through herd immunity.
       </p>
     </section>
   </section>
-  
+
   <section class="informative">
     <h1>
       Examples

--- a/index.html
+++ b/index.html
@@ -1320,63 +1320,200 @@ describe relationships between the <a>DID subject</a> and the value of the
 property.
     </p>
 
-    <p>
-For reference, the core properties found in the <a>DID document</a> (the
-topmost <a data-cite="INFRA#ordered-map">map</a> in the  <a
-href="#data-model">data model</a>) are as follows. Properties belonging to other
-<a data-cite="INFRA#ordered-map">maps</a> referenced in the <a>DID document</a>
-are also listed, with their respective property.
-    </p>
-    <ul id="core-properties-summary">
-      <li>
-<code><a>id</a></code>: defined in <a href="#identifier-0"></a>
-      </li>
-      <li>
-<code><a>alsoKnownAs</a></code>: defined in <a href="#also-known-as"></a>
-      </li>
-      <li>
-<code><a>controller</a></code>: defined in <a href="#did-controller"></a>
-      </li>
-      <li>
-<code><a>verificationMethod</a></code>: defined in
-<a href="#verification-methods"></a>. Nested properties include <code>id</code>,
-<code>type</code>, <code>controller</code>.
-      </li>
-      <li>
-<code><a>authentication</a></code>: defined in <a href="#authentication"></a>.
-      </li>
-      <li>
-<code><a>assertionMethod</a></code>: defined in <a href="#assertion"></a>.
-      </li>
-      <li>
-<code><a>keyAgreement</a></code>: defined in <a href="#key-agreement"></a>.
-      </li>
-      <li>
-<code><a>capabilityInvocation</a></code>: defined in
-<a href="#capability-invocation"></a>.
-      </li>
-      <li>
-<code><a>capabilityDelegation</a></code>: defined in
-<a href="#capability-delegation"></a>.
-      </li>
-      <li>
-<code><a>service</a></code>: defined in <a href="#service-endpoints"></a>.
-Nested properties include <code>id</code>, <code>type</code> and
-<code><a>serviceEndpoint</a></code>.
-      </li>
-    </ul>
+
+    <p>This document defines three classes of core properties:</p>
+
+    <ol>
+      <li>properties defined for a <a>DID Document</a>, serializing the topmost <a data-cite="INFRA#ordered-map">map</a> in the  <a href="#data-model">data model</a>;</li>
+      <li>properties defined for a <a>Verification Method</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#verification-methods"></a>; </li>
+      <li>properties defined for a <a>Service Endpoint</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#service-endpoints"></a>.</li>
+    </ol>
+    
+    <p class="note" title="Repeated properties">Some of the properties (e.g., <code>id</code> or <code>type</code>) are present in different classes but with possible differences in the associated constraints. Hence their repeated presence in the tables in Section <a href="#property-summary"></a>.</p>
 
     <p class="note" title="Ordering of values">
-As a result of the <a href="#data-model">data model</a> being defined using
-terminology from [[INFRA]], property values which can contain more than one
-item, such as <a
-data-cite="INFRA#ordered-set">sets</a>, are explicitly ordered. For the purposes
-of this specification, unless otherwise stated, ordering is not important and
-implementations are not expected to produce or consume deterministically ordered
-values.
+      As a result of the <a href="#data-model">data model</a> being defined using terminology from [[INFRA]], property values which can contain more than one item, such as <a data-cite="INFRA#ordered-map">maps</a> and <a data-cite="INFRA#ordered-set">sets</a>, are explicitly ordered. For the purposes of this specification, unless otherwise stated, ordering is not important and implementations are not expected to produce or consume deterministically ordered values.
     </p>
 
     <section>
+      <h2>Property Summary</h2>
+
+      <section>
+        <h2>Core Properties for a <a>DID Document</a></h2>
+
+        <table class=simple>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Usage constraints</th>
+              <th>Value constraints</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>id</code></td>
+              <td>REQUIRED</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> that conforms to the rules in Section <a href="#did-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>alsoKnownAs</a</code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>controller</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> or an <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules in Section <a href="#did-syntax"></a>.
+              </td> 
+            </tr>
+            <tr>
+              <td><code><a>verificationMethod</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>authentication</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>assertionMethod</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>keyAgreement</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>capabilityInvocation</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> ins<a data-cite="INFRA#ordered-map">maps</a>ances or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>capabilityDelegation</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                An <a data-cite="INFRA#ordered-set">ordered set</a> of either <a>Verification Method</a> <a data-cite="INFRA#ordered-map">maps</a> or <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s. <br/>The <a>URI</a> values SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>service</a></code></td>
+              <td>OPTIONAL</td>
+              <td>An <a data-cite="INFRA#ordered-set">ordered set</a> of <a>Service Endpoint</a> <a data-cite="INFRA#ordered-map">maps</a>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Core Properties for a <a>Verification Method</a></h2>
+
+        <table class=simple>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Usage constraints</th>
+              <th>Value constraints</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>id</code></td>
+              <td>REQUIRED</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URI</a>-s and which SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>controller</a></code></td>
+              <td>REQUIRED</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> or an <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a> that conform to the rules in Section <a href="#did-syntax"></a>.
+              </td> 
+            </tr>
+            <tr>
+              <td><code>type</code></td>
+              <td>REQUIRED</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> or an <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>publicKeyJwk</a></code></td>
+              <td>OPTIONAL</td>
+              <td>A <a data-cite="INFRA#maps">map</a> representing a JSON Web Key that conforms to [[RFC7517]].</td>
+            </tr>
+            <tr>
+              <td><code><a>publicKeyBase58</a></code></td>
+              <td>OPTIONAL</td>
+              <td>A <a
+                data-cite="INFRA#string">string</a> that conforms to a base58btc encoded public key.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>As an extra constraint on the <code><a>publicKeyJwk</a></code> and <code><a>publicKeyBase58</a></code> properties, while both of these properties are OPTIONAL, a particular <a>Verification Method</a> MUST contain <em>exactly one</em> of the two.</p>
+      </section>
+
+
+      <section>
+        <h2>Core Properties for a <a>Service Endpoint</a></h2>
+
+      <table class=simple>
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Usage constraints</th>
+              <th>Value constraints</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>id</code></td>
+              <td>REQUIRED</td>
+              <td>
+                when used on a <a>Service Endpoint</a>: a <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URI</a>-s.
+              </td>
+            </tr>
+            <tr>
+              <td><code>type</code></td>
+              <td>REQUIRED</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> or an <a data-cite="INFRA#ordered-set">ordered set</a> of <a data-cite="INFRA#string">strings</a>.
+              </td>
+            </tr>
+            <tr>
+              <td><code><a>serviceEndpoint</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s, a <a data-cite="INFRA#string">map</a>, or an <a data-cite="INFRA#ordered-set">ordered set</a> composed of a one or more <a data-cite="INFRA#string">strings</a> that conform to the rules of [[RFC3986]] for <a>URI</a>-s and/or <a data-cite="INFRA#string">maps</a>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+
+    <section>
+      <h2>Detailed Specifications of Core Properties</h2>
+      <section>
       <h2>DID Subject</h2>
 
       <p>
@@ -2276,6 +2413,8 @@ and <a href="#authentication"></a>.
       </p>
     </section>
 
+  </section>
+  
   </section>
 
   <section class="normative">


### PR DESCRIPTION
resolving merge conflicts in #528 would have been terrible; git's rebase went completely crazy. However, my changes in #528 were fully concentrated to the initial part of §5, so I decided to make a fresh branch and manually transfer my changes instead.

@rhiaro, would you mind checking that the changes here are indeed the same as the changes proposed in #528 (except that they are on the fresh branch)? If so, @msporny, I believe the comments in #528 stand for this one, and this PR could be merged (and #528 simply closed).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/536.html" title="Last updated on Jan 11, 2021, 1:35 PM UTC (41af738)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/536/c8bc6b1...41af738.html" title="Last updated on Jan 11, 2021, 1:35 PM UTC (41af738)">Diff</a>