### PR TITLE
Change deactivate from an error to a boolean flag in metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3787,6 +3787,16 @@ when determining how to parse and process the <code>did-document-stream</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>
                 <dt>
+deactivated
+                </dt>
+                <dd>
+A <a data-cite="INFRA#boolean">boolean</a> value that, when set to true, indicates the <a>DID</a> supplied to the 
+<a>DID resolution</a> function has been deactivated and SHALL be recognized as 
+being in a deactivated state. This property is REQUIRED if the <a>DID</a> supplied 
+is determined by the DID Method to be in a deactivated state. 
+(See <a href="#deactivate"></a>.)
+                </dd>
+                <dt>
 error
                 </dt>
                 <dd>
@@ -3818,13 +3828,6 @@ This error code is returned if the representation requested via the
 <code>accept</code> input metadata property is not supported by the DID method
 and/or DID resolver implementation.
 </dd>
-                        <dt>
-deactivated
-                        </dt>
-                        <dd>
-The <a>DID</a> supplied to the <a>DID resolution</a> function has been
-deactivated. (See <a href="#deactivate"></a>.)
-                        </dd>
                     </dl>
                 </dd>
             </dl>
@@ -3954,7 +3957,7 @@ graph merge because the same DID document describes both the
 <code><a>equivalentId</a></code> DID and the <code>id</code> property DID.
                   </p>
                 </div>
-                
+
                 <div class="issue" title="Observance of equivalentId recommendations">
                   <p>
 If a resolving party does not retain the values from the <code>id</code> and
@@ -4179,6 +4182,15 @@ content-type
 The MIME type of the returned <code>content-stream</code> SHOULD be expressed
 using this property if dereferencing is successful.
                 </dd>
+
+                <dt>
+deactivated
+                </dt>
+                <dd>
+This property is REQUIRED be populated with a <a data-cite="INFRA#boolean">boolean</a> 
+`true` value if the <a>DID</a> supplied is determined by the DID Method to be in a 
+deactivated state. (See <a href="#deactivate"></a>.)
+                </dd>
                 <dt>
 error
                 </dt>
@@ -4203,13 +4215,6 @@ not-found
 The <a>DID URL dereferencer</a> was unable to find the
 <code>content-stream</code> resulting from this dereferencing request.
                         </dd>
-                        <dt>
-deactivated
-                        </dt>
-                        <dd>
-The <a>DID</a> in the <a>DID URL</a> supplied to the <a>DID URL
-dereferencing</a> function has been deactivated. (See
-<a href="#deactivate"></a>.)
                     </dl>
                 </dd>
             </dl>

--- a/index.html
+++ b/index.html
@@ -3954,6 +3954,17 @@ graph merge because the same DID document describes both the
 <code><a>equivalentId</a></code> DID and the <code>id</code> property DID.
                   </p>
                 </div>
+                
+                <div class="issue" title="Observance of equivalentId recommendations">
+                  <p>
+If a resolving party does not retain the values from the <code>id</code> and
+<code><a>equivalentId</a></code> properties and ensure any subsequent
+interactions with any of the values they contain are correctly handled as
+logically equivalent, there may be negative or unexpected issues that 
+arise related to user experience. You are strongly advised to observe the 
+directives related to this metadata property.
+                  </p>
+                </div>
 
               </section>
 
@@ -4009,6 +4020,16 @@ is defined to be canonical for the DID subject in the scope of the DID document.
 Like <code><a>equivalentId</a></code>, <code><a>canonicalId</a></code>
 represents a full graph merge because the same DID document describes both the
 <code><a>canonicalId</a></code> DID and the <code>id</code> property DID.
+                  </p>
+                </div>
+
+                <div class="issue" title="Observance of canonicalId recommendations">
+                  <p>
+If a resolving party does not use the <code><a>canonicalId</a></code> value
+as its primary ID value for the DID subject and treat all other equivalent
+values as secondary aliases, there may be negative or unexpected issues that 
+arise related to user experience. You are strongly advised to observe the 
+directives related to this metadata property.
                   </p>
                 </div>
 


### PR DESCRIPTION
Resolves https://github.com/w3c/did-core/issues/468


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csuwildcat/did-core/pull/543.html" title="Last updated on Jan 12, 2021, 5:16 PM UTC (50ba61f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/543/c8bc6b1...csuwildcat:50ba61f.html" title="Last updated on Jan 12, 2021, 5:16 PM UTC (50ba61f)">Diff</a>