### PR TITLE
Clarify that DID URL dereferencing returns the final resource.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4021,11 +4021,14 @@ represents a full graph merge because the same DID document describes both the
 DID URL Dereferencing
       </h2>
       <p>
-The DID URL dereferencing function dereferences a <a>DID URL</a> into
+The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into
 a resource with contents depending on the <a>DID URL</a>'s components,
 including the <a>DID method</a>, method-specific identifier, path, query,
 and fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
-contained in the <a>DID URL</a>.
+contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
+multiple steps (e.g. when dereferencing the fragment of the DID URL),
+and the function is defined to return the final resource after all
+steps are completed.
 The details of how this process is accomplished are outside the scope of this
 specification, but all conformant implementations implement a function
 which has the following abstract form:

--- a/index.html
+++ b/index.html
@@ -4026,7 +4026,7 @@ a resource with contents depending on the <a>DID URL</a>'s components,
 including the <a>DID method</a>, method-specific identifier, path, query,
 and fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
 contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
-multiple steps (e.g. when dereferencing the fragment of the DID URL),
+multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
 and the function is defined to return the final resource after all
 steps are completed.
 The details of how this process is accomplished are outside the scope of this


### PR DESCRIPTION
This is an attempt to address #399, in order to clarify that DID URL dereferencing returns the final resource (including when the DID URL contains a fragment). How this is implemented is out of scope for DID Core.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/544.html" title="Last updated on Jan 13, 2021, 4:04 PM UTC (68795c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/544/c8bc6b1...68795c4.html" title="Last updated on Jan 13, 2021, 4:04 PM UTC (68795c4)">Diff</a>