### PR TITLE
Remove mention of DID document as input in DID URL dereferencing term definition

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -188,12 +188,12 @@ path</a> (with its leading <code>/</code> character), optional <a>DID query</a>
   <dt><dfn>DID URL dereferencing</dfn></dt>
 
   <dd>
-The function that takes as its input a <a>DID URL</a>, a <a>DID document</a>,
-plus a set of dereferencing options, and returns a <a>resource</a>. This
+The function that takes as its input a <a>DID URL</a>
+and a set of input metadata, and returns a <a>resource</a>. This
 resource might be a <a>DID document</a> plus additional metadata, or it might be a
 secondary resource contained within the <a>DID document</a>, or it might be a
-resource entirely external to the <a>DID document</a>. If the function begins
-with a <a>DID URL</a>, it uses the <a>DID resolution</a> function to fetch a
+resource entirely external to the <a>DID document</a>. The function
+uses the <a>DID resolution</a> function to fetch a
 <a>DID document</a> indicated by the <a>DID</a> contained within the
 <a>DID URL</a>. The dereferencing function then can perform additional
 processing on the <a>DID document</a> to return the dereferenced resource


### PR DESCRIPTION
Addresses #545.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/546.html" title="Last updated on Jan 13, 2021, 1:32 AM UTC (1279415)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/546/c8bc6b1...1279415.html" title="Last updated on Jan 13, 2021, 1:32 AM UTC (1279415)">Diff</a>