### PR TITLE
Link "DID resolution" term directly to corresponding section.

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -145,7 +145,7 @@ The function that takes as its input a <a>DID</a> and a set of input
 metadata and returns a <a>DID document</a> in a conforming <a>representation</a>
 plus additional metadata. This function relies on the "Read" operation of the
 applicable <a>DID method</a>. The inputs and outputs of this function are
-defined in <a href="#resolution"></a>.
+defined in <a href="#did-resolution"></a>.
   </dd>
 
   <dt><dfn data-lt="DID resolvers">DID resolver</dfn></dt>


### PR DESCRIPTION
Very small change to improve a reference, purely editorial.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/547.html" title="Last updated on Jan 13, 2021, 1:38 AM UTC (77a476c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/547/c8bc6b1...77a476c.html" title="Last updated on Jan 13, 2021, 1:38 AM UTC (77a476c)">Diff</a>