### PR TITLE
Add at risk marker to Resolution section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3723,12 +3723,13 @@ Resolution
     <p class="issue atrisk" data-number="549">
 The Working Group is unsure if there will be enough implementation experience
 for the DID Resolution section. We are seeking feedback from the implementation
-community as to whether they prefer to do this work now, or if they would
-prefer that this section is published as a NOTE and taken up in a future
-W3C DID Resolution Working Group. If there is support for publishing the
-DID Resolution section as a NOTE during the W3C Candidate Recommendation
-process, this section will be migrated to a new document and published as a
-NOTE before the DID Core specification proceeds to the W3C Proposed
+community as to whether they prefer to do all of this work now, or if they would
+prefer that this section is, or parts of the section are, rewritten to be non-normative, 
+or published as a NOTE and taken up in a future W3C DID Resolution Working 
+Group. If there is support for rewriting a subset of the DID Resolution section,
+or publishing any part of it as a NOTE during the W3C Candidate Recommendation 
+process, this section will be modified and/or published as a NOTE appropriately 
+before the DID Core specification proceeds to the W3C Proposed 
 Recommendation stage.
     </p>
 

--- a/index.html
+++ b/index.html
@@ -3720,6 +3720,18 @@ identification, secondary use, disclosure, exclusion.
 Resolution
     </h1>
 
+    <p class="issue atrisk" data-number="549">
+The Working Group is unsure if there will be enough implementation experience
+for the DID Resolution section. We are seeking feedback from the implementation
+community as to whether they prefer to do this work now, or if they would
+prefer that this section is published as a NOTE and taken up in a future
+W3C DID Resolution Working Group. If there is support for publishing the
+DID Resolution section as a NOTE during the W3C Candidate Recommendation
+process, this section will be migrated to a new document and published as a
+NOTE before the DID Core specification proceeds to the W3C Proposed
+Recommendation stage.
+    </p>
+
     <p>
 This section defines the inputs and outputs of <a>DID resolution</a> and <a>DID
 URL dereferencing</a>. These functions are defined in an abstract way. Their


### PR DESCRIPTION
This is related to issue #549 and presumes that the group wants to mark the section at risk before going into CR. Looking to see if folks in the group would object to this language. Note that at risk doesn't mean we're going to remove it -- it means, we have implementation concerns.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/550.html" title="Last updated on Jan 24, 2021, 4:56 PM UTC (6981692)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/550/af9c06b...6981692.html" title="Last updated on Jan 24, 2021, 4:56 PM UTC (6981692)">Diff</a>