### PR TITLE
Add feature at risk for DagCBOR.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3308,6 +3308,7 @@ preserved by default and represented as major type 3 (UTF-8 String)
 
       <section>
         <h3>CBOR Extensibility</h3>
+
         <p>
 In CBOR, one point of extensibility is with the use of CBOR tags. [[RFC7049]]
 defines a basic set of data types, as well as a tagging mechanism that enables
@@ -3336,6 +3337,18 @@ empty byte string is the empty text string of other representations.
 
         <section>
           <h4>DagCBOR</h4>
+
+          <p class="issue atrisk" data-number="551">
+The Working Group is seeking feedback concerning the implementability of
+the DagCBOR canonicalization algorithm in this section and the DagCBOR
+representation in general. If implementers are unable to provide an adequate
+test suite for the canonicalization algorithm and at least two interoperable
+implementations of the canonicalization algorithm and the DagCBOR
+representation, it is likely that this section of the specification will be
+moved into a separate document and registered as a representation extension
+in the DID Specification Registries [[DID-SPEC-REGISTRIES]].
+          </p>
+
           <p>
 DagCBOR is a further restricted subset of CBOR for representing the DID Document
 as a Directed Acyclic Graph model using canonical CBOR encoding


### PR DESCRIPTION
This PR attempts to address issue #551 by adding a feature at risk marker for DagCBOR. /cc @jonnycrunch


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/552.html" title="Last updated on Jan 17, 2021, 9:57 PM UTC (115cd8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/552/af9c06b...115cd8b.html" title="Last updated on Jan 17, 2021, 9:57 PM UTC (115cd8b)">Diff</a>