### PR TITLE
Change DID parameter names to camelCase.

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,7 +878,7 @@ string">ASCII string</a>.
             </tr>
             <tr>
               <td>
-<code>relative-ref</code>
+<code>relativeRef</code>
               </td>
               <td>
 A relative URI reference according to <a
@@ -903,7 +903,7 @@ data-lt="ascii string">ASCII string</a>.
             </tr>
             <tr>
               <td>
-<code>version-time</code>
+<code>versionTime</code>
               </td>
               <td>
 Identifies a certain version timestamp of a <a>DID document</a> to be resolved.
@@ -976,8 +976,8 @@ did:foo:21tDAKCERh95uGgKbJNHYp?service=agent
         </pre>
 
         <pre class="example nohighlight"
-          title="A DID URL with a 'version-time' DID parameter">
-did:foo:21tDAKCERh95uGgKbJNHYp?version-time=2002-10-10T17:00:00Z
+          title="A DID URL with a 'versionTime' DID parameter">
+did:foo:21tDAKCERh95uGgKbJNHYp?versionTime=2002-10-10T17:00:00Z
         </pre>
 
         <pre class="example nohighlight" title="A DID URL with a 'resource' DID parameter">


### PR DESCRIPTION
In https://github.com/w3c/did-core/pull/533, metadata property names were changed from using hyphens to camelCase (e.g. `content-type` -> `contentType`). That same PR also changed both the `version-id` metadata property and the `version-id` DID parameter to `versionId`.

This PR here changes the remaining two concerned DID parameters `relative-ref` and `version-id` to be consistent with the others.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/553.html" title="Last updated on Jan 18, 2021, 10:21 AM UTC (935f753)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/553/af9c06b...935f753.html" title="Last updated on Jan 18, 2021, 10:21 AM UTC (935f753)">Diff</a>