### PR TITLE
Adding the `verificationMethod` as an optional property for service endpoints' table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1500,6 +1500,13 @@ property.
               </td>
             </tr>
             <tr>
+              <td><code><a>verificationMethod</a></code></td>
+              <td>OPTIONAL</td>
+              <td>
+                A <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URIs</a>. The <a>URI</a> value SHOULD also conform to the rules in Section <a href="#did-url-syntax"></a>.
+              </td>
+            </tr>
+            <tr>
               <td><code><a>serviceEndpoint</a></code></td>
               <td>OPTIONAL</td>
               <td>


### PR DESCRIPTION
[Example 22](https://w3c.github.io/did-core/#example-22-various-service-endpoints) suggests that it is possible to use the `verificationMethod` as part of a service endpoint, although that is not explicitly listed in [§5.2.5](https://w3c.github.io/did-core/#service-endpoints). That being said, it looks like an omission; using a verification method defined elsewhere in the DID document makes perfect sense.

This PR adds the entry to the table in [§5.1.3](https://w3c.github.io/did-core/#core-properties-for-a-service-endpoint). Note that, in contrast to the behaviour of the property when used for a DID Document, its value, in this case, is a single URL value, i.e., not a full Verification Method instance (I presume all verification methods SHOULD be defined on the DID Document level). 

Also, I have not defined it as an array either; maybe it does make sense to have an array of verification references, maybe not, I am not sure.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/554.html" title="Last updated on Jan 18, 2021, 10:55 AM UTC (a7d4e82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/554/af9c06b...a7d4e82.html" title="Last updated on Jan 18, 2021, 10:55 AM UTC (a7d4e82)">Diff</a>