### PR TITLE
markup: remove spacing around headings, fixes #537

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,9 +243,7 @@ Sporny, Drummond Reed, Joe Andrieu, and Heather Vescent.
   </section>
 
   <section class="informative">
-    <h1>
-Introduction
-    </h1>
+    <h1>Introduction</h1>
     <p>
 As individuals and organizations, many of us use globally unique identifiers in
 a wide variety of contexts. They serve as communications addresses (telephone
@@ -325,9 +323,7 @@ between the worlds of centralized, federated, and decentralized identifiers.
     </p>
 
     <section class="informative">
-      <h2>
-A Simple Example
-      </h2>
+      <h2>A Simple Example</h2>
 
       <p>
 A <a>DID</a> is a simple text string consisting of three parts, the:
@@ -378,9 +374,7 @@ well as <a>services</a> that can be used to interact with the <a>DID subject</a>
     </section>
 
     <section class="informative">
-      <h2>
-Design Goals
-      </h2>
+      <h2>Design Goals</h2>
 
       <p>
 <a>Decentralized Identifiers</a> are a component of larger systems, such as
@@ -710,9 +704,7 @@ produce errors when consuming non-conforming <a>DIDs</a> or <a>DID documents</a>
   </section>
 
   <section class="informative">
-    <h2>
-Terminology
-    </h2>
+    <h2>Terminology</h2>
 
     <div data-include="terms.html">
     </div>
@@ -1624,9 +1616,7 @@ necessarily appropriate, <em>even with</em> a reciprocal relationship.
     </section>
 
     <section>
-     <h2>
-DID Controller
-      </h2>
+     <h2>DID Controller</h2>
 
       <p>
 A <a>DID controller</a> is an entity that is authorized to make changes to
@@ -2665,9 +2655,7 @@ to the value representation rules in the list above.
       </section>
 
       <section>
-        <h3>
-Consumption
-        </h3>
+        <h3>Consumption</h3>
 
         <p>
 The topmost element MUST be a JSON object. Any other data type at the topmost
@@ -2848,9 +2836,7 @@ require them.
       </ul>
 
       <section>
-        <h3>
-Production
-        </h3>
+        <h3>Production</h3>
 
         <p>
 The <a>DID document</a> MUST be serialized according to the
@@ -2933,9 +2919,7 @@ defined via the <code>@context</code>. Properties that are not defined via the
       </section>
 
       <section>
-        <h3>
-Consumption
-        </h3>
+        <h3>Consumption</h3>
 
         <p>
 The <a>DID document</a> MUST be deserialized as a JSON document according to
@@ -3430,9 +3414,7 @@ d8 2a                                # tag(42)
   </section>
 
   <section>
-    <h1>
-Methods
-    </h1>
+    <h1>Methods</h1>
 
     <p>
 <a>DID methods</a> provide the means to implement this specification on
@@ -3557,9 +3539,7 @@ operations is implemented, including any necessary cryptographic operations.
       </p>
 
       <section>
-        <h3>
-Create
-        </h3>
+        <h3>Create</h3>
 
         <p>
 The <a>DID method</a> specification MUST specify how a <a>DID controller</a>
@@ -3570,9 +3550,7 @@ proof of control.
       </section>
 
       <section>
-        <h3>
-Read/Verify
-        </h3>
+        <h3>Read/Verify</h3>
 
         <p>
 The <a>DID method</a> specification MUST specify how a <a>DID resolver</a> uses
@@ -3583,9 +3561,7 @@ of the response.
       </section>
 
       <section>
-        <h3>
-Update
-        </h3>
+        <h3>Update</h3>
 
         <p>
 The <a>DID method</a> specification MUST specify how a <a>DID controller</a> can
@@ -3605,9 +3581,7 @@ update that does not result in changes to the <a>DID document</a>.
       </section>
 
       <section>
-        <h3>
-Deactivate
-        </h3>
+        <h3>Deactivate</h3>
 
         <p>
 The <a>DID method</a> specification MUST specify how a <a>DID controller</a> can
@@ -3619,9 +3593,7 @@ cryptographic operations necessary to establish proof of deactivation,
     </section>
 
     <section>
-      <h2>
-Security Requirements
-      </h2>
+      <h2>Security Requirements</h2>
       <p>
 <a>DID method</a> specifications MUST include their own Security
 Considerations sections. This section MUST consider all the requirements
@@ -3695,9 +3667,7 @@ security requirements of the supported authentication protocol.
     </section>
 
     <section class='normative'>
-      <h2>
-Privacy Requirements
-      </h2>
+      <h2>Privacy Requirements</h2>
 
       <p>
 <a>DID method</a> specifications MUST include their own Privacy
@@ -3716,9 +3686,7 @@ identification, secondary use, disclosure, exclusion.
   </section>
 
   <section class='normative'>
-    <h1>
-Resolution
-    </h1>
+    <h1>Resolution</h1>
 
     <p>
 This section defines the inputs and outputs of <a>DID resolution</a> and <a>DID
@@ -3734,9 +3702,7 @@ document</a> in at least one conformant representation.
     </p>
 
     <section>
-        <h2>
-DID Resolution
-        </h2>
+        <h2>DID Resolution</h2>
         <p>
 The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>.
@@ -3857,9 +3823,7 @@ additional functions with different signatures in addition to the
         </p>
 
         <section>
-            <h3>
-DID Resolution Input Metadata Properties
-            </h3>
+            <h3>DID Resolution Input Metadata Properties</h3>
 
             <p>
 The possible properties within this structure and their possible values are
@@ -3885,9 +3849,7 @@ available. This property is OPTIONAL. It is only used if the
         </section>
 
         <section>
-            <h3>
-DID Resolution Metadata Properties
-            </h3>
+            <h3>DID Resolution Metadata Properties</h3>
 
             <p>
 The possible properties within this structure and their possible values are
@@ -4141,9 +4103,7 @@ represents a full graph merge because the same DID document describes both the
     </section>
 
     <section>
-      <h2>
-DID URL Dereferencing
-      </h2>
+      <h2>DID URL Dereferencing</h2>
       <p>
 The DID URL dereferencing function dereferences a <a>DID URL</a> into
 a resource with contents depending on the <a>DID URL</a>'s components,
@@ -4264,9 +4224,7 @@ supported and available.
         </section>
 
         <section>
-            <h3>
-DID URL Dereferencing Metadata Properties
-            </h3>
+            <h3>DID URL Dereferencing Metadata Properties</h3>
 
             <p>
 The possible properties within this structure and their possible values are
@@ -4321,9 +4279,7 @@ dereferencing</a> function has been deactivated. (See
     </section>
 
     <section>
-        <h2>
-Metadata Structure
-        </h2>
+        <h2>Metadata Structure</h2>
 
         <p>
 Input and output metadata is often involved during the <a>DID Resolution</a>,
@@ -4332,7 +4288,8 @@ used to communicate this metadata MUST be a <a data-cite="INFRA#maps">map</a>
 of properties. Each property name MUST be a <a
 data-cite="INFRA#string">string</a>. Each property value MUST be a <a
 data-cite="INFRA#string">string</a>, <a data-cite="INFRA#maps">map</a>, <a
-data-cite="INFRA#list">list</a>, <a data-cite="INFRA#ordered-set">ordered set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
+data-cite="INFRA#list">list</a>, <a data-cite="INFRA#ordered-set">ordered
+set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
 <a data-cite="INFRA#null">null</a>. The values within any complex data
 structures such as maps and lists MUST be one of these data types as well.
 All metadata property definitions MUST define the value type, including any
@@ -4425,9 +4382,7 @@ This example corresponds to a metadata structure of the following format:
   </section>
 
   <section class="informative">
-    <h1>
-Security Considerations
-    </h1>
+    <h1>Security Considerations</h1>
 
     <p class="note" title="Note to implementers">
 During the Working Draft stage, this section focuses on security topics that
@@ -4440,9 +4395,7 @@ network.
     </p>
 
     <section>
-      <h2>
-Choosing DID Resolvers
-      </h2>
+      <h2>Choosing DID Resolvers</h2>
 
       <p>
 The DID Method Registry (see [[?DID-SPEC-REGISTRIES]] is an informative list of
@@ -4456,9 +4409,7 @@ use.
     </section>
 
     <section>
-      <h2>
-Binding of Identity
-      </h2>
+      <h2>Binding of Identity</h2>
 
       <p>
 The following sections describe binding identities to <a>DIDs</a> and
@@ -4466,9 +4417,7 @@ The following sections describe binding identities to <a>DIDs</a> and
       </p>
 
       <section>
-        <h3>
-Proving Control of a DID and DID Document
-        </h3>
+        <h3>Proving Control of a DID and DID Document</h3>
 
         <p>
 Signatures and <a>verifiable timestamps</a> allow <a>DID documents</a> to be
@@ -4521,9 +4470,7 @@ applicable.
       </section>
 
       <section>
-        <h3>
-Proving Control of a Public Key
-        </h3>
+        <h3>Proving Control of a Public Key</h3>
 
         <p>
 There are two methods for proving control of the private key corresponding to a
@@ -4553,9 +4500,7 @@ Verify the signature of the response message against the
       </section>
 
       <section>
-        <h3>
-Real-World Identity
-        </h3>
+        <h3>Real-World Identity</h3>
 
         <p>
 A <a>DID</a> and <a>DID document</a> do not inherently carry any
@@ -4583,9 +4528,7 @@ more information, see the [[VC-DATA-MODEL]] instead.
     </section>
 
     <section>
-      <h2>
-Authentication Service Endpoints
-      </h2>
+      <h2>Authentication Service Endpoints</h2>
 
       <p>
 If a <a>DID document</a> publishes a <a>service endpoint</a> intended for
@@ -4598,9 +4541,7 @@ endpoint</a>.
     </section>
 
     <section>
-      <h2>
-Non-Repudiation
-      </h2>
+      <h2>Non-Repudiation</h2>
 
       <p>
 Non-repudiation of <a>DIDs</a> and <a>DID document</a> updates is supported
@@ -4627,9 +4568,7 @@ system supports timestamps.
     </section>
 
     <section>
-      <h2>
-Notification of DID Document Changes
-      </h2>
+      <h2>Notification of DID Document Changes</h2>
 
       <p>
 One mitigation against unauthorized changes to a <a>DID document</a> is
@@ -4654,9 +4593,7 @@ vector of attack.
     </section>
 
     <section>
-      <h2>
-Key and Signature Expiration
-      </h2>
+      <h2>Key and Signature Expiration</h2>
 
       <p>
 In a <a>decentralized identifier</a> architecture, there are no centralized
@@ -4670,9 +4607,7 @@ of a resolver ought to be compatible with such extension behavior.
     </section>
 
     <section>
-      <h2>
-Key Revocation and Recovery
-      </h2>
+      <h2>Key Revocation and Recovery</h2>
 
       <p>
 Section <a href="#method-operations"></a> specifies the <a>DID</a> operations to
@@ -4693,9 +4628,7 @@ specification of this type of control is a matter for future work.
     </section>
 
     <section>
-      <h2>
-The Role of Human-Friendly Identifiers
-      </h2>
+      <h2>The Role of Human-Friendly Identifiers</h2>
 
       <p>
 <a>DIDs</a> achieve global uniqueness without the need for a central
@@ -4741,9 +4674,7 @@ addresses using DNS lookups is available at [[?DNS-DID]].
     </section>
 
     <section>
-        <h2>
-Immutability
-        </h2>
+        <h2>Immutability</h2>
 
         <p>
 Many cybersecurity abuses hinge on exploiting gaps between reality and the
@@ -4789,9 +4720,7 @@ assumed.
     </section>
 
     <section>
-      <h2>
-Encrypted Data in DID Documents
-      </h2>
+      <h2>Encrypted Data in DID Documents</h2>
       <p>
 DID documents are typically publicly available. Encryption algorithms have been
 known to fail due to advances in cryptography and computing power. Implementers
@@ -4850,9 +4779,7 @@ re-verified.
     </section>
 
     <section>
-      <h2>
-Content Integrity Protection
-      </h2>
+      <h2>Content Integrity Protection</h2>
       <p>
 DID documents which include external JSON-LD contexts (see
 <a href="#json-ld"></a>) or any other links to external machine-readable
@@ -4890,9 +4817,7 @@ delegates, and <a>DID subjects</a> should keep in mind.
     </p>
 
     <section>
-      <h2>
-Keep Personally-Identifiable Information (PII) Private
-      </h2>
+      <h2>Keep Personally-Identifiable Information (PII) Private</h2>
 
       <p>
 If a <a>DID method</a> specification is written for a public <a>verifiable data
@@ -4918,9 +4843,7 @@ forgotten</a>, because no personal data is written to an immutable
     </section>
 
     <section>
-      <h2>
-DID Correlation Risks and Pseudonymous DIDs
-      </h2>
+      <h2>DID Correlation Risks and Pseudonymous DIDs</h2>
 
       <p>
 Like any type of globally unique identifier, <a>DIDs</a> might be used for
@@ -4937,9 +4860,7 @@ identification.
     </section>
 
     <section>
-      <h2>
-DID Document Correlation Risks
-      </h2>
+      <h2>DID Document Correlation Risks</h2>
 
       <p>
 The anti-correlation protections of pseudonymous <a>DIDs</a> are easily defeated
@@ -4960,9 +4881,7 @@ thousands or millions of <a>DIDs</a> controlled by many different subjects.
     </section>
 
     <section>
-      <h2>
-Assigning a type to the DID subject
-      </h2>
+      <h2>Assigning a type to the DID subject</h2>
       <p>
 It is dangerous to add properties to the <a>DID document</a> that can be used
 to indicate, explicitly or through inference, what <em>type</em> or nature of
@@ -4995,9 +4914,7 @@ using the <a>DID</a>.
     </section>
 
     <section>
-      <h2>
-Herd Privacy
-      </h2>
+      <h2>Herd Privacy</h2>
 
       <p>
 When a <a>DID subject</a> is indistinguishable from others in the herd, privacy
@@ -5014,9 +4931,7 @@ layers, and pad messages to standard lengths.
     </section>
 
     <section>
-      <h2>
-          Service Privacy
-      </h2>
+      <h2>Service Privacy</h2>
       <p>
 The ability for a controller to optionally state at least one service endpoint
 in the DID document increases their control and agency. Each additional
@@ -5072,9 +4987,7 @@ through herd immunity.
   </section>
 
   <section class="informative">
-    <h1>
-      Examples
-    </h1>
+    <h1>Examples</h1>
     <section class="informative">
       <h2>DID Documents</h2>
 
@@ -5438,9 +5351,7 @@ result in changes to this specification.
   </section>
 
 <section class="appendix">
-    <h1>
-IANA Considerations
-    </h1>
+    <h1>IANA Considerations</h1>
 
     <p>
 This section will be submitted to the Internet Engineering Steering Group


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/561.html" title="Last updated on Jan 19, 2021, 1:51 PM UTC (13bf3dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/561/4ecfda7...13bf3dd.html" title="Last updated on Jan 19, 2021, 1:51 PM UTC (13bf3dd)">Diff</a>