### PR TITLE
Replace "service endpoint" with "service" where appropriate.

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,9 +178,9 @@ subject.
     </p>
     <p>
 Each <a>DID document</a> can express cryptographic material, verification
-methods, or <a>service endpoints</a>, which provide a set of mechanisms enabling
-a <a>DID controller</a> to prove control of the <a>DID</a>. <a>Service
-endpoints</a> enable trusted interactions associated with the <a>DID
+methods, or <a>services</a>, which provide a set of mechanisms enabling
+a <a>DID controller</a> to prove control of the <a>DID</a>. <a>Services</a>
+enable trusted interactions associated with the <a>DID
 subject</a>. A <a>DID document</a> might contain the <a>DID subject</a> itself,
 if the <a>DID subject</a> is an information resource such as a data model.
     </p>
@@ -408,7 +408,7 @@ Decentralization
             <td>
 Eliminate the requirement for centralized authorities or single point
 failure in identifier management, including the registration of globally unique
-identifiers, public verification keys, <a>service endpoints</a>, and other
+identifiers, public verification keys, <a>services</a>, and other
 information.
             </td>
           </tr>
@@ -1076,7 +1076,7 @@ be interpreted in the same way across representations.
             <pre class="example nohighlight">did:example:123#public-key-0</pre>
           </li>
 
-          <li>A unique <a>service endpoint</a> in a <a>DID Document</a>
+          <li>A unique <a>service</a> in a <a>DID Document</a>
             <pre class="example nohighlight">did:example:123#agent</pre>
           </li>
 
@@ -1326,7 +1326,7 @@ property.
     <ol>
       <li>properties defined for a <a>DID Document</a>, serializing the topmost <a data-cite="INFRA#ordered-map">map</a> in the  <a href="#data-model">data model</a>;</li>
       <li>properties defined for a <a>Verification Method</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#verification-methods"></a>; </li>
-      <li>properties defined for a <a>Service Endpoint</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#service-endpoints"></a>.</li>
+      <li>properties defined for a <a>Service</a>, serializing a concept represented by a <a data-cite="INFRA#ordered-map">map</a> in the <a href="#data-model">data model</a>, and specified in Section <a href="#services"></a>.</li>
     </ol>
 
     <p class="note" title="Repeated properties">Some of the properties (e.g., <code>id</code> or <code>type</code>) are present in different classes but with possible differences in the associated constraints. Hence their repeated presence in the tables in Section <a href="#property-summary"></a>.</p>
@@ -1416,7 +1416,7 @@ property.
             <tr>
               <td><code><a>service</a></code></td>
               <td>OPTIONAL</td>
-              <td>An <a data-cite="INFRA#ordered-set">ordered set</a> of <a>Service Endpoint</a> <a data-cite="INFRA#ordered-map">maps</a>  (see <a href="#core-properties-for-a-service-endpoint"></a>).</td>
+              <td>An <a data-cite="INFRA#ordered-set">ordered set</a> of <a>Service</a> <a data-cite="INFRA#ordered-map">maps</a>  (see <a href="#core-properties-for-a-service"></a>).</td>
             </tr>
           </tbody>
         </table>
@@ -1474,7 +1474,7 @@ property.
 
 
       <section>
-        <h2>Core Properties for a Service Endpoint</h2>
+        <h2>Core Properties for a Service</h2>
 
       <table class=simple>
           <thead>
@@ -1489,7 +1489,7 @@ property.
               <td><code>id</code></td>
               <td>REQUIRED</td>
               <td>
-                when used on a <a>Service Endpoint</a>: a <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URIs</a>.
+                when used on a <a>Service</a>: a <a data-cite="INFRA#string">string</a> that conforms to the rules of [[RFC3986]] for <a>URIs</a>.
               </td>
             </tr>
             <tr>
@@ -2287,10 +2287,10 @@ to a party other than themselves.
     </section>
 
     <section>
-      <h2>Service Endpoints</h2>
+      <h2>Services</h2>
 
       <p>
-<a>Service endpoints</a> are used in <a>DID documents</a> to express ways of
+<a>Services</a> are used in <a>DID documents</a> to express ways of
 communicating with the <a>DID subject</a> or associated entities.
 <a>Services</a> listed in the <a>DID document</a> can contain information about
 privacy preserving messaging services, or more public information, such as
@@ -2311,7 +2311,7 @@ properties, as well as a <code><a>serviceEndpoint</a></code> property with a
 
       <p>
 One of the primary purposes of a <a>DID document</a> is to enable discovery of
-<a>service endpoints</a>. A <a>service endpoint</a> can be any type of service
+<a>services</a>. A <a>services</a> can be any type of service
 the <a>DID subject</a> wants to advertise, including
 <a>decentralized identity management</a> services for further discovery,
 authentication, authorization, or interaction.
@@ -2327,8 +2327,8 @@ A <a>DID document</a> MAY include a <code><a>service</a></code> property.
           <p>
 If a <a>DID document</a> includes a <code>service</code> property, the value
 of the property MUST be an <a data-cite="INFRA#ordered-set">ordered set</a>
-of <a>service endpoints</a>, where each service endpoint is described by a set
-of properties. Each <a>service endpoint</a> MUST have <code><a>id</a></code>,
+of <a>services</a>, where each service is described by a set
+of properties. Each <a>service</a> MUST have <code><a>id</a></code>,
 <code>type</code>, and <code><a>serviceEndpoint</a></code> properties, and MAY
 include additional properties.
           </p>
@@ -2354,11 +2354,11 @@ with the extension.
       </dl>
 
       <p>
-It is expected that the <a>service endpoint</a> protocol is published in an open
+It is expected that the <a>service</a> protocol is published in an open
 standard specification.
       </p>
 
-      <pre class="example nohighlight" title="Various service endpoints">
+      <pre class="example nohighlight" title="Various services">
 {
   "service": [{
     "id":"did:example:123#linked-domain",
@@ -2408,7 +2408,7 @@ standard specification.
 
       <p>
 For more information about security considerations regarding authentication
-<a>service endpoints</a> see Sections <a href="#method-schemes"></a>
+<a>services</a> see Sections <a href="#method-schemes"></a>
 and <a href="#authentication"></a>.
       </p>
     </section>
@@ -3687,8 +3687,8 @@ with all known <a>DLTs</a>, the expected burdens of those resources SHOULD be
 discussed in relation to denial of service.
       </p>
       <p>
-<a>DID methods</a> that introduce new authentication <a>service endpoint</a>
-types (see Section <a href="#service-endpoints"></a>) SHOULD consider the
+<a>DID methods</a> that introduce new authentication <a>service</a>
+types (see Section <a href="#services"></a>) SHOULD consider the
 security requirements of the supported authentication protocol.
       </p>
 
@@ -4592,9 +4592,9 @@ Authentication Service Endpoints
       </h2>
 
       <p>
-If a <a>DID document</a> publishes a <a>service endpoint</a> intended for
+If a <a>DID document</a> publishes a <a>service</a> intended for
 authentication or authorization of the <a>DID subject</a> (see Section <a
-href="#service-endpoints"></a>), it is the responsibility of the <a>service
+href="#services"></a>), it is the responsibility of the <a>service
 endpoint</a> provider, subject, or requesting party to comply with the
 requirements of the authentication protocols supported at that <a>service
 endpoint</a>.
@@ -4756,7 +4756,7 @@ the same set of features, the less it can be manipulated by malicious actors.
         <p>
 As an example, consider that a single edit to a <a>DID document</a> can change
 anything except the root <code><a>id</a></code> property of the document. But
-is it actually desirable for a <a>service endpoint</a> to change its
+is it actually desirable for a <a>service</a> to change its
 <code>type</code> after it is defined? Or for a key to change its value? Or
 would it be better to require a new <code><a>id</a></code> when certain
 fundamental properties of an object change? Malicious takeovers of a website


### PR DESCRIPTION
I feel like we're saying "service endpoint" in a lot of places where we should be saying "service". A service may or may not have a service endpoint.

**EDIT:** The second sentence above is wrong; see discussion below.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/564.html" title="Last updated on Jan 25, 2021, 6:35 AM UTC (136216c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/564/2e78762...136216c.html" title="Last updated on Jan 25, 2021, 6:35 AM UTC (136216c)">Diff</a>