### PR TITLE
Removing example with verification method in a service

### DIFF
--- a/index.html
+++ b/index.html
@@ -2381,11 +2381,6 @@ standard specification.
     "type": "AgentService",
     "serviceEndpoint": "https://agent.example.com/8377464"
   }, {
-    "id": "did:example:123456789abcdefghi#hub",
-    "type": "IdentityHub",
-    "verificationMethod": "did:example:123456789abcdefghi#key-1",
-    "serviceEndpoint": ["did:example:456", "did:example:789"]
-  }, {
     "id": "did:example:123456789abcdefghi#messages",
     "type": "MessagingService",
     "serviceEndpoint": "https://example.com/messages/8377464"


### PR DESCRIPTION
This is the alternative to #554 : removing the example of a service with a verification method.

This is also relevant to #404.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/565.html" title="Last updated on Jan 28, 2021, 11:00 AM UTC (a650f65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/565/090f81f...a650f65.html" title="Last updated on Jan 28, 2021, 11:00 AM UTC (a650f65)">Diff</a>