### PR TITLE
parameters: Remove resource parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -927,18 +927,7 @@ parameter is OPTIONAL. If present, the associated value MUST be an
 <a data-lt="ascii string">ASCII string</a>.
               </td>
             </tr>
-            <tr>
-              <td>
-<code>resource</code>
-              </td>
-              <td>
-Indicates that the resource to be dereferenced is the <a>DID Subject</a>, rather
-than the <a>DID Document</a>. This parameter is used to retrieve an information
-resource identified by a <a>DID</a>. Support for this parameter is OPTIONAL.
-If present, the associated value MUST be the
-<a data-lt="ascii string">ASCII string</a> <code>true</code>.
-              </td>
-            </tr>
+
           </tbody>
         </table>
 
@@ -978,10 +967,6 @@ did:foo:21tDAKCERh95uGgKbJNHYp?service=agent
         <pre class="example nohighlight"
           title="A DID URL with a 'version-time' DID parameter">
 did:foo:21tDAKCERh95uGgKbJNHYp?version-time=2002-10-10T17:00:00Z
-        </pre>
-
-        <pre class="example nohighlight" title="A DID URL with a 'resource' DID parameter">
-did:foo:21tDAKCERh95uGgKbJNHYp?resource=true
         </pre>
 
         <p class="note" title="DID parameters and DID resolution">


### PR DESCRIPTION
Per resolution https://www.w3.org/2019/did-wg/Meetings/Minutes/2021-01-14-did-topic#resolution1

PR opened in DID Spec Registries to add it, but that is incomplete as it the definition needs to go into another document. Who is taking ownership of this parameter?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/572.html" title="Last updated on Jan 23, 2021, 9:15 PM UTC (1a7cc16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/572/2e78762...1a7cc16.html" title="Last updated on Jan 23, 2021, 9:15 PM UTC (1a7cc16)">Diff</a>