### PR TITLE
Make DID Resolution section concrete and testable (WebIDL).

### DIFF
--- a/index.html
+++ b/index.html
@@ -3710,8 +3710,8 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-DID Resolver implementations realize at least the following interface (or one
-that is functionally equivalent):
+<a>DID resolver</a> implementations realize at least the following interface
+(or one that is functionally equivalent):
         </p>
 
         <pre class="idl">
@@ -3720,11 +3720,6 @@ interface mixin DidResolver {
 };
         </pre>
 
-        <p>
-The {{DidResolver/resolve}} function returns a byte stream of the
-<a>DID Document</a> formatted in the corresponding representation,
-DID Resolution Metadata, and DID Document Metadata.
-        </p>
         <p>
 The input variables of the {{DidResolver/resolve}} function are as follows:
         </p>
@@ -3780,14 +3775,12 @@ an <code>error</code> property describing the error.
 didDocument
             </dt>
             <dd>
-If the resolution is successful, and if the <code>resolveRepresentation</code>
-function was called, this MUST be a byte stream of the resolved <a>DID
-document</a> in one of the conformant
+If the resolution is successful this MUST be a byte stream of the resolved
+<a>DID document</a> in one of the conformant
 <a href="#representations">representations</a>. The byte stream might then be
-parsed by the caller of the <code>resolveRepresentation</code> function into a
-<a href="#data-model">data model</a>, which can in turn be validated and
-processed. If the resolution is unsuccessful, this value MUST be an empty
-stream.
+parsed by the caller into a <a href="#data-model">data model</a>, which can in
+turn be validated and processed. If the resolution is unsuccessful, this value
+MUST be an empty stream.
             </dd>
             <dt>
 didDocumentMetadata
@@ -3796,13 +3789,13 @@ didDocumentMetadata
 If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>didDocument</code>. This metadata
+<code>didDocument</code> property. This metadata
 typically does not change between invocations of the {{DidResolver/resolve}}
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
 defined by this specification are in <a
-href="#did-document-metadata-properties"></a>.
+href="#did-document-metadata"></a>.
             </dd>
         </dl>
 
@@ -3842,7 +3835,7 @@ available. This property is OPTIONAL.
         </section>
 
         <section>
-            <h3>DID Resolution Metadata Properties</h3>
+            <h3>DID Resolution Metadata</h3>
 
             <p>
 The possible properties within this structure and their possible values are
@@ -3910,7 +3903,7 @@ deactivated. (See <a href="#deactivate"></a>.)
         </section>
 
         <section>
-          <h3>DID Document Metadata Properties</h3>
+          <h3>DID Document Metadata</h3>
 
           <p>
 The possible properties within this structure and their possible values SHOULD
@@ -3918,21 +3911,19 @@ be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
           </p>
 
-          <section>
-            <h4>created</h4>
-            <p>
+          <dl>
+            <dt><dfn>created</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include a <code>created</code> property to
 indicate the timestamp of the <a href="#create">Create operation</a>. The value
 of the property MUST be a <a data-cite="INFRA#string">string</a> formatted as an
 <a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC
 00:00:00 and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
-            </p>
-          </section>
+            </dd>
 
-          <section>
-            <h4>updated</h4>
-            <p>
+            <dt><dfn>updated</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include an <code>updated</code> property to
 indicate the timestamp of the last <a href="#update">Update operation</a> for
 the document version which was resolved. The value of the property MUST follow
@@ -3941,83 +3932,61 @@ the same formatting rules as the <code>created</code> property. The
 performed on the <a>DID document</a>. If an <code>updated</code> property exists, it
 can be the same value as the <code>created</code> property when the difference
 between the two timestamps is less than one second.
-                </p>
-              </section>
+            </dd>
 
-            <section>
-                <h4>
-                  nextUpdate
-                </h4>
-                <p>
+            <dt><dfn>nextUpdate</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include a <code>nextUpdate</code> property
 if the resolved document version is not the latest version of the document. It
 indicates the timestamp of the next <a href="#update">Update operation</a>. The
 value of the property MUST follow the same formatting rules as the
 <code>created</code> property.
-            </p>
-          </section>
+            </dd>
 
-          <section>
-              <h4>
-                versionId
-              </h4>
-              <p>
+            <dt><dfn>versionId</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include a <code>versionId</code> property to
 indicate the version of the last <a href="#update">Update operation</a> for the
 document version which was resolved. The value of the property MUST be an <a
 data-lt="ascii string">ASCII string</a>.
-              </p>
-            </section>
+            </dd>
 
-          <section>
-              <h4>
-                nextVersionId
-              </h4>
-              <p>
+            <dt><dfn>nextVersionId</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include a <code>nextVersionId</code>
 property if the resolved document version is not the latest version of the
 document. It indicates the version of the next
 <a href="#update">Update operation</a>. The value of the property MUST be an
 <a data-lt="ascii string">ASCII string</a>.
-              </p>
-            </section>
+            </dd>
 
-          <section>
-            <h4>equivalentId</h4>
-                <p>
+          <dt><dfn>equivalentId</dfn></dt>
+          <dd>
 A <a>DID Method</a> can define different forms of a <a>DID</a> that are
 logically equivalent. An example is when a <a>DID</a> takes one form prior to
 registration in a <a>verifiable data registry</a> and another form after such
 registration. In this case, the <a>DID Method</a> specification may need to
 express one or more <a>DIDs</a> that are logically equivalent to the resolved
 <a>DID</a> as a property of the <a>DID document</a>. This is the purpose of the
-<code><a>equivalentId</a></code>  property.
-                </p>
+<code><a>equivalentId</a></code>  property. <br><br>
 
-                <dl>
-                  <dt><dfn>equivalentId</dfn></dt>
-                  <dd>
 The value of <code>equivalentId</code> MUST be an
 <a data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is
 a <a data-cite="INFRA#string">string</a> that conforms to the rules in Section
-<a href="#did-syntax"></a>.
-                  </dd>
-                  <dd>
+<a href="#did-syntax"></a>.<br><br>
+
 The relationship is a statement that each <code><a>equivalentId</a></code> value
 is logically equivalent to the <code>id</code> property value and thus
-identifies the same <a>DID subject</a>.
-                  </dd>
-                  <dd>
+identifies the same <a>DID subject</a>.<br><br>
+
 Each <code><a>equivalentId</a></code> DID value MUST be produced by, and a form
 of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.
-<code>did:example:abc</code> == <code>did:example:ABC</code>)
-                  </dd>
-                  <dd>
+<code>did:example:abc</code> == <code>did:example:ABC</code>)<br><br>
+
 A conforming <a>DID Method</a> specification MUST guarantee that each
 <code><a>equivalentId</a></code> value is logically equivalent to the
-<code>id</code> property value.
-                  </dd>
-                  <dd>
+<code>id</code> property value.<br><br>
+
 A requesting party is expected to retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties to ensure any subsequent
 interactions with any of the values they contain are correctly handled as
@@ -4025,101 +3994,69 @@ logically equivalent (e.g. retain all variants in a database so an interaction
 with any one maps to the same underlying account). <span class="issue">The
 testability of requesting parties is currently under debate and normative
 statements related to requesting parties may be downgraded in the future from a
-MUST to a SHOULD/MAY or similar language.</span>
-                  </dd>
-                </dl>
+MUST to a SHOULD/MAY or similar language.</span><br><br>
 
-                <div class="note" title="Equivalence and equivalentId">
-                  <p>
 <code><a>equivalentId</a></code> is a much stronger form of equivalence than
 <code><a>alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
 the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a
 full graph merge because the same <a>DID document</a> describes both the
 <code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property
-<a>DID</a>.
-                  </p>
-                </div>
+<a>DID</a>.<br><br>
 
-                <div class="issue" title="Observance of equivalentId recommendations">
-                  <p>
 If a resolving party does not retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties and ensure any subsequent
 interactions with any of the values they contain are correctly handled as
 logically equivalent, there might be negative or unexpected issues that
 arise. Implementers are strongly advised to observe the
 directives related to this metadata property.
-                  </p>
-                </div>
-
-              </section>
-
-            <section>
-              <h4>canonicalId</h4>
-                <p>
+            </dd>
+            <dt><dfn>canonicalId</dfn></dt>
+            <dd>
 The <code><a>canonicalId</a></code> property is identical to the
 <code><a>equivalentId</a></code> property except: a) it accepts only a single
 value rather than a list, and b) that <a>DID</a> is defined to be the canonical ID for
-the <a>DID subject</a> within the scope of the containing <a>DID document</a>.
-                </p>
+the <a>DID subject</a> within the scope of the containing <a>DID document</a>.<br><br>
 
-                <dl>
-                  <dt><dfn>canonicalId</dfn></dt>
-                  <dd>
 The value of <code><a>canonicalId</a></code> MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-href="#did-syntax"></a>.
-                  </dd>
-                  <dd>
+href="#did-syntax"></a>.<br><br>
+
 The relationship is a statement that the <code><a>canonicalId</a></code> value
 is logically equivalent to the <code>id</code> property value and that the
 <code><a>canonicalId</a></code> value is defined by the <a>DID Method</a> to be
 the canonical ID for the <a>DID subject</a> in the scope of the containing <a>DID
-document</a>.
-                  </dd>
-                  <dd>
+document</a>.<br><br>
+
 A <code><a>canonicalId</a></code> value MUST be produced by, and a form of, the
 same <a>DID Method</a> as the <code>id</code> property value. (e.g.
-<code>did:example:abc</code> == <code>did:example:ABC</code>)
-                  </dd>
-                  <dd>
+<code>did:example:abc</code> == <code>did:example:ABC</code>)<br><br>
+
 A conforming <a>DID Method</a> specification MUST guarantee that the
 <code><a>canonicalId</a></code> value is logically equivalent to the
-<code>id</code> property value.
-                  </dd>
-                  <dd>
+<code>id</code> property value.<br><br>
+
 A requesting party is expected to use the <code><a>canonicalId</a></code> value
 as its primary ID value for the <a>DID subject</a> and treat all other equivalent
 values as secondary aliases. (e.g. update corresponding primary references in
 their systems to reflect the new canonical ID directive). <span
 class="issue">The testability of requesting parties is currently under debate and
 normative statements related to requesting parties may be downgraded in the
-future from a MUST to a SHOULD/MAY or similar language.</span>
-                  </dd>
-                </dl>
+future from a MUST to a SHOULD/MAY or similar language.</span><br><br>
 
-                <div class="note" title="Equivalence and canonicalId">
-                  <p>
 <code><a>canonicalId</a></code> is the same statement of equivalence as
 <code><a>equivalentId</a></code> except it is constrained to a single value that
 is defined to be canonical for the <a>DID subject</a> in the scope of the <a>DID document</a>.
 Like <code><a>equivalentId</a></code>, <code><a>canonicalId</a></code>
 represents a full graph merge because the same <a>DID document</a> describes both the
-<code><a>canonicalId</a></code> DID and the <code>id</code> property <a>DID</a>.
-                  </p>
-                </div>
+<code><a>canonicalId</a></code> DID and the <code>id</code> property <a>DID</a>.<br><br>
 
-                <div class="issue" title="Observance of canonicalId recommendations">
-                  <p>
 If a resolving party does not use the <code><a>canonicalId</a></code> value
 as its primary ID value for the DID subject and treat all other equivalent
 values as secondary aliases, there might be negative or unexpected issues that
 arise related to user experience. Implementers are strongly advised to observe the
-directives related to this metadata property.
-                  </p>
-                </div>
-
-        </section>
-      </section>
+directives related to this metadata property.<br><br>
+        </dd>
+      </dl>
     </section>
 
     <section>
@@ -4378,7 +4315,7 @@ This example corresponds to a metadata structure of the following format:
 
         <p>
 The next example demonstrates a JSON-encoded metadata structure that might be
-used as <a href="#did-document-metadata-properties">DID document metadata</a>
+used as <a href="#did-document-metadata">DID document metadata</a>
 to describe timestamps associated with the <a>DID document</a>.
         </p>
 
@@ -4585,7 +4522,7 @@ access control mechanism for the <a>DID method</a> (see Section
 
       <p>
 Non-repudiation is further supported if timestamps are included (see Section
-<a href="#did-document-metadata-properties"></a>) and the target <a>DLT</a>
+<a href="#did-document-metadata"></a>) and the target <a>DLT</a>
 system supports timestamps.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -708,6 +708,12 @@ DIDs</a> or <a>conforming DID documents</a>. A conforming consumer MUST
 produce errors when consuming non-conforming <a>DIDs</a> or <a>DID documents</a>.
       </p>
 
+      <p>
+A <dfn>conforming DID resolver</dfn> is any algorithm realized as software
+and/or hardware that complies with the relevant normative statements in
+Section <a href="#resolution"></a>.
+      </p>
+
     </section>
 
   </section>
@@ -4644,7 +4650,7 @@ of a resolver ought to be compatible with such extension behavior.
     <section>
 
       <h2>Verification Method Revocation</h2>
-  
+
       <p>
 Verification method revocation is a reactive security measure.
       </p>
@@ -4653,23 +4659,23 @@ Verification method revocation is a reactive security measure.
 Verification method revocation applies only to the current or latest
 version of a DID Document.
       </p>
-  
+
       <p>
         If a verification method is no longer exclusively accessible to the
         controller or parties trusted to act on behalf of the controller, it
         is expected to be revoked immediately to reduce the risk of masquerading, theft,
         and fraud.
       </p>
-  
+
       <p class="advisement">
 It is considered a best practice to support key revocation.
       </p>
-  
+
       <p class="advisement">
 A controller is expected to immediately revoke any verification method that is believed to
 be compromised.
       </p>
-  
+
       <p class="advisement">
 Revocation is expected to be understood as a controller expressing
 that proofs or signatures associated with a revoked verification method
@@ -4677,13 +4683,13 @@ might have been created by an attacker. Verifiers, however, might
 still choose to accept or reject such proofs or signatures at their
 own discretion.
       </p>
-  
+
       <p class="note">
 As described in Section <a href="#verification-method-types"></a>,
 absence of a verification method is the only form of revocation that
 applies to all DID Methods.
       </p>
-  
+
       <p>
 Section <a href="#method-operations"></a> specifies the <a>DID</a>
 operations to be supported by a <a>DID method</a> specification,
@@ -4695,14 +4701,14 @@ a DID Document.
       <p>
 Not all DID Methods support verification method revocation.
       </p>
-  
+
       <p>
 Even if a verification method is present in a DID Document, additional
 information, such as a public key revocation certificate, or an external
 allow or deny list, might be used to determine whether a verification
 method has been revoked.
       </p>
-  
+
       <p class="note">
 Compromise of the secrets associated with a verification method
 allows the attacker to use them according to the verification
@@ -4715,19 +4721,19 @@ was revoked.
 
       <p class="note">
 The day-to-day operation of any software relying on a compromised verification
-method, such as an individual's operating system, antivirus, or endpoint protection 
+method, such as an individual's operating system, antivirus, or endpoint protection
 software, might be impacted when the verification method is publicly revoked.
       </p>
 
 <p class="note">
-Although verifiers might choose not to accept proofs or signatures from a revoked verification method, 
+Although verifiers might choose not to accept proofs or signatures from a revoked verification method,
 knowing whether a verification was made with a revoked verification method is trickier than it might seem.
-Some DID methods provide the ability to look back at the state of a DID at a point in time, 
-or at a particular version of the DID document. When such a feature is 
-combined with a reliable way to determine the time or DID version that existed 
-when a cryptographically verifiable statement was made, then revocation 
-does not undo that statement. This can be the basis for using DIDs to make 
-binding commitments (e.g., to sign a mortgage). 
+Some DID methods provide the ability to look back at the state of a DID at a point in time,
+or at a particular version of the DID document. When such a feature is
+combined with a reliable way to determine the time or DID version that existed
+when a cryptographically verifiable statement was made, then revocation
+does not undo that statement. This can be the basis for using DIDs to make
+binding commitments (e.g., to sign a mortgage).
 <br><br>
 If these conditions are met, revocation is not retroactive; it only nullifies future use of the method.
 <br/><br/>

--- a/index.html
+++ b/index.html
@@ -3755,21 +3755,15 @@ contains the following properties:
 didResolutionMetadata
             </dt>
             <dd>
-              <p>
 A <a href="#metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID resolution</a> process. This structure
 is REQUIRED and MUST NOT be empty.
-              </p>
-              <p>
-This metadata is defined by <a href="#did-resolution-options"></a>.
-              </p>
-              <p>
+This metadata is defined by <a href="#did-resolution-metadata"></a>.
 If the resolution is successful this structure MUST contain a
 <code>contentType</code> property containing the mime-type of the
 <code>didDocument</code> in
 this result. If the resolution is not successful, this structure MUST contain
 an <code>error</code> property describing the error.
-              </p>
             </dd>
             <dt>
 didDocument
@@ -4062,31 +4056,34 @@ directives related to this metadata property.<br><br>
     <section>
       <h2>DID URL Dereferencing</h2>
       <p>
-The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into
-a <a>resource</a> with contents depending on the <a>DID URL</a>'s components,
-including the <a>DID method</a>, method-specific identifier, path, query,
-and fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
+The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
+<a>resource</a> with contents depending on the <a>DID URL</a>'s components,
+including the <a>DID method</a>, method-specific identifier, path, query, and
+fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
 contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
 multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
-and the function is defined to return the final resource after all
-steps are completed.
-The details of how this process is accomplished are outside the scope of this
-specification, but all conformant implementations implement a function
-which has the following abstract form:
+and the function is defined to return the final resource after all steps are
+completed. The details of how this process is accomplished are outside the scope
+of this specification, but all conforming <a>DID resolver</a> implementations
+realize at least the following interface (or one that is functionally
+equivalent):
       </p>
 
-      <p><code>
-dereference ( did-url, did-url-dereferencing-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereferencing-metadata, content-stream, content-metadata )
-      </code></p>
+      <pre class="idl">
+interface mixin DidDereferencer {
+DereferencingResponse dereference(USVString did,
+                                  DereferencingOptions dereferencingOptions);
+};
+      </pre>
 
       <p>
-The input variables of this function are as follows:
+The input variables of the {{DidDereferencer/dereference}} function are as
+follows:
       </p>
 
       <dl>
         <dt>
-did-url
+didUrl
         </dt>
         <dd>
 A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to
@@ -4094,57 +4091,57 @@ dereference. To dereference a <a>DID fragment</a>, the complete <a>DID URL</a>
 including the <a>DID fragment</a> MUST be used. This input is REQUIRED.
         </dd>
         <dt>
-did-url-dereferencing-input-metadata
+dereferencingOptions
         </dt>
         <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of input
 options to the <code>dereference</code> function in addition to the
-<code>did-url</code> itself. Properties defined by this specification are in
-<a href="#did-url-dereferencing-input-metadata-properties"></a>. This input is
-REQUIRED, but the structure MAY be empty.
+<code>didUrl</code> itself. Properties defined by this specification are in <a
+href="#did-url-dereferencing-options"></a>. This input is REQUIRED, but the
+structure MAY be empty.
         </dd>
       </dl>
 
       <p>
-The output variables of this function are as follows:
+The return value of the {{DidDereferencer/dereference}} function is a
+<dfn>DereferencingResponse</dfn> <a data-cite="INFRA#maps">map</a> that
+contains the following properties:
       </p>
 
       <dl>
         <dt>
-did-url-dereferencing-metadata
+dereferencingMetadata
         </dt>
         <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID URL dereferencing</a> process. This
 structure is REQUIRED and in the case of an error in the dereferencing process,
-this MUST NOT be empty.
-Properties defined by this specification are in
-<a href="#did-url-dereferencing-metadata-properties"></a>.
-If the dereferencing is not successful, this structure MUST contain an
-<code>error</code> property describing the error.
+this MUST NOT be empty. Properties defined by this specification are in <a
+href="#did-url-dereferencing-metadata"></a>. If the dereferencing is not
+successful, this structure MUST contain an <code>error</code> property
+describing the error.
         </dd>
         <dt>
-content-stream
+contentStream
         </dt>
         <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
-contain a <a>resource</a> corresponding to the <a>DID URL</a>.
-The <code>content-stream</code> SHOULD be a <a>DID document</a> in one of the
-conformant <a>representations</a> obtained through
-the resolution process.
+contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
+<code>content-stream</code> SHOULD be a <a>DID document</a> in one of the
+conformant <a>representations</a> obtained through the resolution process.<br><br>
 
 If the dereferencing is unsuccessful, this value MUST be empty.
         </dd>
         <dt>
-content-metadata
+contentMetadata
         </dt>
         <dd>
 If the dereferencing is successful, this MUST be a <a href="metadata-structure">
 metadata structure</a>, but the structure MAY be empty. This structure contains
-metadata about the <code>content-stream</code>.
-If the <code>content-stream</code> is a <a>DID document</a>, this MUST be a
-<code>did-document-metadata</code> structure as described in <a>DID
-Resolution</a>.
+metadata about the <code>contentStream</code>.
+If the <code>contentStream</code> is a <a>DID document</a>, this MUST be a
+<code>didDocumentMetadata</code> structure as described in <a>DID
+Resolution</a>.<br><br>
 
 If the dereferencing is unsuccessful, this output MUST be an empty <a
 href="metadata-structure">metadata structure</a>.
@@ -4162,12 +4159,14 @@ to the <code>dereference</code> function specified here.
     </p>
 
       <section>
-        <h3>DID URL Dereferencing Input Metadata Properties</h3>
+        <h3>DID URL Dereferencing Options</h3>
 
         <p>
 The possible properties within this structure and their possible values SHOULD
 be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
-This specification defines the following common properties.
+This specification defines the following common properties. This
+specification defines the following common properties for a
+<dfn>DereferencingOptions</dfn> <a data-cite="INFRA#maps">map</a>:
             </p>
 
             <dl>
@@ -4175,16 +4174,16 @@ This specification defines the following common properties.
 accept
                 </dt>
                 <dd>
-The MIME type the caller prefers for <code>content-stream</code>. The <a>DID
-URL dereferencing</a> implementation SHOULD use this value to determine the
-<a>representation</a> contained in the returned value if such a <a>representation</a> is
-supported and available.
+The MIME type the caller prefers for <code>contentStream</code>. The <a>DID URL
+dereferencing</a> implementation SHOULD use this value to determine the
+<a>representation</a> contained in the returned value if such a
+<a>representation</a> is supported and available.
                 </dd>
             </dl>
         </section>
 
         <section>
-            <h3>DID URL Dereferencing Metadata Properties</h3>
+            <h3>DID URL Dereferencing Metadata</h3>
 
             <p>
 The possible properties within this structure and their possible values are

--- a/index.html
+++ b/index.html
@@ -4049,8 +4049,9 @@ as its primary ID value for the DID subject and treat all other equivalent
 values as secondary aliases, there might be negative or unexpected issues that
 arise related to user experience. Implementers are strongly advised to observe the
 directives related to this metadata property.<br><br>
-        </dd>
-      </dl>
+          </dd>
+        </dl>
+      </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -951,7 +951,7 @@ did:foo:21tDAKCERh95uGgKbJNHYp?versionTime=2002-10-10T17:00:00Z
 The <a>DID resolution</a> and the <a>DID URL dereferencing</a> functions can
 be influenced by passing input metadata to a <a>DID resolver</a> that are
 not part of the <a>DID URL</a>. (See <a
-href="#did-resolution-input-metadata-properties"></a>). This is comparable to
+href="#did-resolution-options"></a>). This is comparable to
 HTTP, where certain parameters could either be included in an HTTP URL, or
 alternatively passed as HTTP headers during the dereferencing process. The
 important distinction is that DID parameters that are part of the <a>DID
@@ -1751,7 +1751,7 @@ formats such as JWK [[RFC7517]]. It is RECOMMENDED that JWK <code>kid</code>
 values are set to the public key fingerprint [[RFC7638]]. It is RECOMMENDED
 that verification methods that use JWKs to represent their public keys utilize
 the value of <code>kid</code> as their fragment identifier. See the first key
-in <a href="#example-16-various-verification-method-types"></a>
+in <a href="#example-15-various-verification-method-types"></a>
 for an example of a public key with a compound key identifier.
           </p>
 
@@ -2316,7 +2316,7 @@ properties, as well as a <code><a>serviceEndpoint</a></code> property with a
       </p>
 
       <dl>
-        <dt><dfn>service</dfn></dt>
+        <dt>service</dt>
         <dd>
           <p>
 The <code>service</code> property is OPTIONAL. If present, the associated
@@ -3692,9 +3692,9 @@ Recommendation stage.
 
     <p>
 This section defines the inputs and outputs of <a>DID resolution</a> and <a>DID
-URL dereferencing</a>. These functions are defined in an abstract way. Their
-exact implementation is out of scope for this specification, but some
-considerations for implementors are discussed in [[?DID-RESOLUTION]].
+URL dereferencing</a>.  Their exact implementation is out of scope for this
+specification, but some considerations for implementors are discussed in
+[[?DID-RESOLUTION]].
     </p>
 
     <p>
@@ -3706,28 +3706,19 @@ document</a> in at least one conformant <a>representation</a>.
     <section data-dfn-for="Resolver">
         <h2>DID Resolution</h2>
         <p>
-The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
-document</a> by using the "Read" operation of the applicable <a>DID method</a>.
-(See <a href="#read-verify"></a>.) The details of how this process is
-accomplished are outside the scope of this specification, but all conformant
-implementations implement at least the following function (or one that is
-equivalent):
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
+document</a> by using the "Read" operation of the applicable <a>DID method</a>
+as described in <a href="#read-verify"></a>. The details of how this process is
+accomplished are outside the scope of this specification, but all conforming
+DID Resolver implementations realize at least the following interface (or one
+that is functionally equivalent):
         </p>
 
         <pre class="idl">
 interface mixin DidResolver {
-  ResolutionResponse resolve(USVString did, ResolutionInputMetadata didResolutionInputMetadata);
+  ResolutionResponse resolve(USVString did, ResolutionOptions resolutionOptions);
 };
         </pre>
-        <p><code>
-resolve ( did, did-resolution-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document, did-document-metadata )
-        </code></p>
-
-        <p><code>
-resolveRepresentation ( did, did-resolution-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
-        </code></p>
 
         <p>
 The {{DidResolver/resolve}} function returns a byte stream of the
@@ -3747,13 +3738,13 @@ This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
 be a conformant <a>DID</a> as defined in <a href="#did-syntax"></a>.
             </dd>
             <dt>
-didResolutionInputMetadata
+resolutionOptions
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of input
 options to the {{DidResolver/resolve}} function in addition to the
 <code>did</code> itself. Properties defined by this
-specification are in <a href="#did-resolution-input-metadata-properties"></a>.
+specification are in <a href="#did-resolution-options"></a>.
 This input is REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
@@ -3775,7 +3766,7 @@ relating to the results of the <a>DID resolution</a> process. This structure
 is REQUIRED and MUST NOT be empty.
               </p>
               <p>
-This metadata is defined by <a href="#did-resolution-metadata-properties"></a>.
+This metadata is defined by <a href="#did-resolution-options"></a>.
               </p>
               <p>
 If the resolution is successful this structure MUST contain a
@@ -3826,13 +3817,13 @@ additional functions with different signatures in addition to the
         </p>
 
         <section>
-            <h3>DID Resolution Input Metadata Properties</h3>
+            <h3>DID Resolution Options</h3>
 
             <p>
 The possible properties within this structure and their possible values are
 registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]]. This
 specification defines the following common properties for a
-<dfn>ResolutionInputMetadata</dfn> <a data-cite="INFRA#maps">map</a>:
+<dfn>ResolutionOptions</dfn> <a data-cite="INFRA#maps">map</a>:
             </p>
 
             <dl>
@@ -4341,7 +4332,7 @@ scope of this specification.
 
         <p>
 The following example demonstrates a JSON-encoded metadata structure that
-might be used as <a href="#did-resolution-input-metadata-properties">DID
+might be used as <a href="#did-resolution-options">DID
 resolution input metadata</a>.
         </p>
 
@@ -4364,7 +4355,7 @@ This example corresponds to a metadata structure of the following format:
 
         <p>
 The next example demonstrates a JSON-encoded metadata structure that might be
-used as <a href="#did-resolution-metadata-properties">DID resolution
+used as <a href="#did-resolution-options">DID resolution
 metadata</a> if a <a>DID</a> was not found.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -3703,17 +3703,22 @@ functions for at least one <a>DID method</a> and MUST be able to return a <a>DID
 document</a> in at least one conformant <a>representation</a>.
     </p>
 
-    <section>
+    <section data-dfn-for="Resolver">
         <h2>DID Resolution</h2>
         <p>
 The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>.
 (See <a href="#read-verify"></a>.) The details of how this process is
 accomplished are outside the scope of this specification, but all conformant
-implementations implement two functions which have the following abstract
-forms:
+implementations implement at least the following function (or one that is
+equivalent):
         </p>
 
+        <pre class="idl">
+interface mixin DidResolver {
+  ResolutionResponse resolve(USVString did, ResolutionInputMetadata didResolutionInputMetadata);
+};
+        </pre>
         <p><code>
 resolve ( did, did-resolution-input-metadata ) <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document, did-document-metadata )
@@ -3725,13 +3730,12 @@ resolveRepresentation ( did, did-resolution-input-metadata ) <br>
         </code></p>
 
         <p>
-The <code>resolve</code> function returns the <a>DID document</a> in its
-abstract form.
-The <code>resolveRepresentation</code> function returns a byte stream of the
-<a>DID Document</a> formatted in the corresponding representation.
+The {{DidResolver/resolve}} function returns a byte stream of the
+<a>DID Document</a> formatted in the corresponding representation,
+DID Resolution Metadata, and DID Document Metadata.
         </p>
         <p>
-The input variables of these functions are as follows:
+The input variables of the {{DidResolver/resolve}} function are as follows:
         </p>
 
         <dl>
@@ -3743,24 +3747,24 @@ This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
 be a conformant <a>DID</a> as defined in <a href="#did-syntax"></a>.
             </dd>
             <dt>
-did-resolution-input-metadata
+didResolutionInputMetadata
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of input
-options to the <code>resolve</code> and <code>resolveRepresentation</code>
-functions in addition to the <code>did</code> itself. Properties defined by this
+options to the {{DidResolver/resolve}} function in addition to the
+<code>did</code> itself. Properties defined by this
 specification are in <a href="#did-resolution-input-metadata-properties"></a>.
 This input is REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
 
         <p>
-The output variables of these functions are as follows:
+The output variables of the {{DidResolver/resolve}} function are as follows:
         </p>
 
         <dl>
             <dt>
-did-resolution-metadata
+didResolutionMetadata
             </dt>
             <dd>
               <p>
@@ -3769,29 +3773,18 @@ relating to the results of the <a>DID resolution</a> process. This structure
 is REQUIRED and MUST NOT be empty.
               </p>
               <p>
-This metadata typically changes between invocations of the
-<code>resolve</code> and <code>resolveRepresentation</code> functions as it
-represents data about the resolution process itself. Properties defined by
-this specification are in <a href="#did-resolution-metadata-properties"></a>.
+This metadata is defined by <a href="#did-resolution-metadata-properties"></a>.
               </p>
               <p>
-If the resolution is successful, and if the <code>resolveRepresentation</code>
-function was called, this structure MUST contain a <code>contentType</code>
-property containing the mime-type of the <code>did-document-stream</code> in
+If the resolution is successful this structure MUST contain a
+<code>contentType</code> property containing the mime-type of the
+<code>didDocument</code> in
 this result. If the resolution is not successful, this structure MUST contain
 an <code>error</code> property describing the error.
               </p>
             </dd>
             <dt>
-did-document
-            </dt>
-            <dd>
-If the resolution is successful, and if the <code>resolve</code> function was
-called, this MUST be a <a>conforming DID document</a>. If the resolution is
-unsuccessful, this value MUST be empty.
-            </dd>
-            <dt>
-did-document-stream
+didDocument
             </dt>
             <dd>
 If the resolution is successful, and if the <code>resolveRepresentation</code>
@@ -3804,14 +3797,14 @@ processed. If the resolution is unsuccessful, this value MUST be an empty
 stream.
             </dd>
             <dt>
-did-document-metadata
+didDocumentMetadata
             </dt>
             <dd>
 If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>did-document</code> or <code>did-document-stream</code>. This metadata
-typically does not change between invocations of the <code>resolve</code>
+<code>didDocument</code>. This metadata
+typically does not change between invocations of the {{DidResolver/resolve}}
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
@@ -3822,12 +3815,12 @@ href="#did-document-metadata-properties"></a>.
 
         <p>
 Conforming <a>DID resolver</a> implementations do not alter the signature of
-these functions in any way. <a>DID resolver</a> implementations might map the
-<code>resolve</code> and <code>resolveRepresentation</code> functions to a
+these functions in any way. <a>DID resolver</a> implementations might map
+this function to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-<code>resolve</code> function specified here.
+{{DidResolver/resolve}} function specified here.
         </p>
 
         <section>
@@ -3848,10 +3841,8 @@ The MIME type expressed as an <a data-lt="ascii string">ASCII string</a> of the
 caller's preferred <a>representation</a> of the <a>DID
 document</a>. The <a>DID resolver</a> implementation SHOULD use this value to
 determine the <a>representation</a> contained in the returned
-<code>did-document-stream</code> if such a <a>representation</a> is supported and
-available. This property is OPTIONAL. It is only used if the
-<code>resolveRepresentation</code> function is called and MUST be ignored if the
-<code>resolve</code> function is called.
+<code>didDocument</code> if such a <a>representation</a> is supported and
+available. This property is OPTIONAL.
                 </dd>
             </dl>
         </section>
@@ -3870,14 +3861,13 @@ specification defines the following common properties.
 contentType
                 </dt>
                 <dd>
-The MIME type of the returned <code>did-document-stream</code>. This property is
-REQUIRED if resolution is successful and if the
-<code>resolveRepresentation</code> function was called. This property MUST NOT
-be present if the <code>resolve</code> function was called. The value of this
+The MIME type of the returned <code>didDocument</code>. This property is
+REQUIRED if resolution is successful. This property MUST NOT
+be present if the {{DidResolver/resolve}} function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of the <code>resolveRepresentation</code> function MUST use this value
-when determining how to parse and process the <code>did-document-stream</code>
+caller of {{DidResolver/resolve}} function MUST use this value
+when determining how to parse and process the <code>didDocument</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>
                 <dt>
@@ -3909,9 +3899,9 @@ representationNotSupported
                         </dt>
                         <dd>
 This error code is returned if the <a>representation</a> requested via the
-<code>accept</code> input metadata property is not supported by the <a>DID method</a>
-and/or <a>DID resolver</a> implementation.
-</dd>
+<code>accept</code> input metadata property is not supported by the <a>DID
+method</a> and/or <a>DID resolver</a> implementation.
+                        </dd>
                         <dt>
 deactivated
                         </dt>
@@ -3937,11 +3927,11 @@ This specification defines the following common properties.
           <section>
             <h4>created</h4>
             <p>
-<a>DID document</a> metadata SHOULD include a <code>created</code> property to indicate
-the timestamp of the <a href="#create">Create operation</a>. The value of the
-property MUST be a <a data-cite="INFRA#string">string</a> formatted as an <a
-data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC 00:00:00
-and without sub-second decimal precision. For example:
+<a>DID document</a> metadata SHOULD include a <code>created</code> property to
+indicate the timestamp of the <a href="#create">Create operation</a>. The value
+of the property MUST be a <a data-cite="INFRA#string">string</a> formatted as an
+<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC
+00:00:00 and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
             </p>
           </section>
@@ -3965,10 +3955,10 @@ between the two timestamps is less than one second.
                   nextUpdate
                 </h4>
                 <p>
-<a>DID document</a> metadata SHOULD include a <code>nextUpdate</code> property if
-the resolved document version is not the latest version of the document. It
-indicates the timestamp of the next <a href="#update">Update operation</a>.
-The value of the property MUST follow the same formatting rules as the
+<a>DID document</a> metadata SHOULD include a <code>nextUpdate</code> property
+if the resolved document version is not the latest version of the document. It
+indicates the timestamp of the next <a href="#update">Update operation</a>. The
+value of the property MUST follow the same formatting rules as the
 <code>created</code> property.
             </p>
           </section>
@@ -3990,31 +3980,33 @@ data-lt="ascii string">ASCII string</a>.
                 nextVersionId
               </h4>
               <p>
-<a>DID document</a> metadata SHOULD include a <code>nextVersionId</code> property if
-the resolved document version is not the latest version of the document. It
-indicates the version of the next <a href="#update">Update operation</a>. The
-value of the property MUST be an <a data-lt="ascii string">ASCII string</a>.
+<a>DID document</a> metadata SHOULD include a <code>nextVersionId</code>
+property if the resolved document version is not the latest version of the
+document. It indicates the version of the next
+<a href="#update">Update operation</a>. The value of the property MUST be an
+<a data-lt="ascii string">ASCII string</a>.
               </p>
             </section>
 
           <section>
             <h4>equivalentId</h4>
                 <p>
-A <a>DID Method</a> can define different forms of a <a>DID</a> that are logically
-equivalent. An example is when a <a>DID</a> takes one form prior to registration in a
-<a>verifiable data registry</a> and another form after such registration. In this case,
-the <a>DID Method</a> specification may need to express one or more <a>DIDs</a> that
-are logically equivalent to the resolved <a>DID</a> as a property of the <a>DID document</a>.
-This is the purpose of the <code><a>equivalentId</a></code>  property.
+A <a>DID Method</a> can define different forms of a <a>DID</a> that are
+logically equivalent. An example is when a <a>DID</a> takes one form prior to
+registration in a <a>verifiable data registry</a> and another form after such
+registration. In this case, the <a>DID Method</a> specification may need to
+express one or more <a>DIDs</a> that are logically equivalent to the resolved
+<a>DID</a> as a property of the <a>DID document</a>. This is the purpose of the
+<code><a>equivalentId</a></code>  property.
                 </p>
 
                 <dl>
                   <dt><dfn>equivalentId</dfn></dt>
                   <dd>
-The value of <code>equivalentId</code> MUST be an <a
-data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is a <a
-data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-href="#did-syntax"></a>.
+The value of <code>equivalentId</code> MUST be an
+<a data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is
+a <a data-cite="INFRA#string">string</a> that conforms to the rules in Section
+<a href="#did-syntax"></a>.
                   </dd>
                   <dd>
 The relationship is a statement that each <code><a>equivalentId</a></code> value
@@ -4047,9 +4039,10 @@ MUST to a SHOULD/MAY or similar language.</span>
                   <p>
 <code><a>equivalentId</a></code> is a much stronger form of equivalence than
 <code><a>alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
-the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a full
-graph merge because the same <a>DID document</a> describes both the
-<code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property <a>DID</a>.
+the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a
+full graph merge because the same <a>DID document</a> describes both the
+<code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property
+<a>DID</a>.
                   </p>
                 </div>
 

--- a/index.html
+++ b/index.html
@@ -3759,7 +3759,9 @@ This input is REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The output variables of the {{DidResolver/resolve}} function are as follows:
+The return value of the {{DidResolver/resolve}} function is a
+<dfn>ResolutionResponse</dfn> <a data-cite="INFRA#maps">map</a> that
+contains the following properties:
         </p>
 
         <dl>
@@ -3829,7 +3831,8 @@ additional functions with different signatures in addition to the
             <p>
 The possible properties within this structure and their possible values are
 registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]]. This
-specification defines the following common properties.
+specification defines the following common properties for a
+<dfn>ResolutionInputMetadata</dfn> <a data-cite="INFRA#maps">map</a>:
             </p>
 
             <dl>


### PR DESCRIPTION
This PR is intended to address issue #549 by converting the abstract functions discussed in the DID Resolution and DID URL Dereferencing sections into concrete, testable functions. The PR uses a very light amount of WebIDL while keeping much of what we had the same as before. It also tries to strike a balance by enabling at least one concrete realization of the interface without preventing other concrete interfaces from being realized.

There are a LOT of reformatting changes in this PR, it might be best to <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/587.html#resolution">look at the rendered preview for this PR</a>.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/587.html" title="Last updated on Feb 2, 2021, 3:51 PM UTC (51dc50b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/587/518362a...51dc50b.html" title="Last updated on Feb 2, 2021, 3:51 PM UTC (51dc50b)">Diff</a>