### PR TITLE
Mark CBOR as a feature at risk.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2964,10 +2964,10 @@ defined via the <code>@context</code>.
     <section>
       <h2>CBOR</h2>
       <p class="issue atrisk">
-The Working Group is seeking volunteers to write tests and at least two
-interoperable implementations for the CBOR representation during the
-Candidate Recommendation phase. If these goals are not met, this section
-will be removed from this specification.
+The Working Group is seeking volunteers to write tests for, and at least two
+independent and interoperable implementations of, the CBOR representation
+during the Candidate Recommendation phase. If these goals are not met, this
+section will be removed from this specification.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -3114,7 +3114,6 @@ length.</a>
         </ul>
 
         <p>
-
   To produce a deterministic canonical CBOR representation of a DID document and
   faciliate maximal lossless compatiblity with other  core representations via the
   Abstract Data Model the following constraints of a CBOR representation of a DID

--- a/index.html
+++ b/index.html
@@ -2963,6 +2963,13 @@ defined via the <code>@context</code>.
 
     <section>
       <h2>CBOR</h2>
+      <p class="issue atrisk">
+The Working Group is seeking volunteers to write tests and at least two
+interoperable implementations for the CBOR representation during the
+Candidate Recommendation phase. If these goals are not met, this section
+will be removed from this specification.
+      </p>
+
       <p>
 Like Javascript Object Notation (JSON) [[RFC8259]], Concise Binary Object
 Representation (CBOR) [[RFC7049]] defines a set of formatting rules for the
@@ -3107,6 +3114,7 @@ length.</a>
         </ul>
 
         <p>
+
   To produce a deterministic canonical CBOR representation of a DID document and
   faciliate maximal lossless compatiblity with other  core representations via the
   Abstract Data Model the following constraints of a CBOR representation of a DID


### PR DESCRIPTION
It is currently not clear who is going to volunteer to write tests for the CBOR section or if all of the section is implementable. For example, there is still disagreement over whether the "canonicalization rules" constitute a "canonicalization algorithm" and whether or not the intent is for those rules to produce a deterministic canonical form that can be used to generate digital signatures or not. For these reasons, we should mark the section as at risk.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/594.html" title="Last updated on Feb 9, 2021, 9:30 PM UTC (2b73643)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/594/6f647ff...2b73643.html" title="Last updated on Feb 9, 2021, 9:30 PM UTC (2b73643)">Diff</a>