### PR TITLE
Clean up DID Resolution section; enable testability via proof by construction

### DIFF
--- a/index.html
+++ b/index.html
@@ -4149,8 +4149,8 @@ to the <code>dereference</code> function specified here.
 The possible properties within this structure and their possible values SHOULD
 be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
 This specification defines the following common properties. This
-specification defines the following common properties for a
-<dfn>DereferencingOptions</dfn> <a data-cite="INFRA#maps">map</a>:
+specification defines the following common properties for dereferencing
+options:
             </p>
 
             <dl>

--- a/index.html
+++ b/index.html
@@ -4139,7 +4139,7 @@ contentStream
         <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
-<code>content-stream</code> SHOULD be a <a>DID document</a> in one of the
+<code>contentStream</code> SHOULD be a <a>DID document</a> in one of the
 conformant <a>representations</a> obtained through the resolution process.<br><br>
 
 If the dereferencing is unsuccessful, this value MUST be empty.
@@ -4208,7 +4208,7 @@ specification defines the following common properties.
 contentType
                 </dt>
                 <dd>
-The MIME type of the returned <code>content-stream</code> SHOULD be expressed
+The MIME type of the returned <code>contentStream</code> SHOULD be expressed
 using this property if dereferencing is successful.
                 </dd>
                 <dt>
@@ -4233,7 +4233,7 @@ notFound
                         </dt>
                         <dd>
 The <a>DID URL dereferencer</a> was unable to find the
-<code>content-stream</code> resulting from this dereferencing request.
+<code>contentStream</code> resulting from this dereferencing request.
                         </dd>
                     </dl>
                 </dd>

--- a/index.html
+++ b/index.html
@@ -3682,13 +3682,16 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-<a>DID resolvers</a> implement two functions which have the following abstract
-forms:
+<a>DID resolvers</a> implement at least one of the functions below which
+have the following abstract forms:
         </p>
 
         <pre title="Abstract functions for DID Resolution">
-resolve(did, options) -> Resolution
-resolveRepresentation(did, options) -> ResolutionRepresentation
+resolve(did, options) →
+   « didResolutionMetadata, didDocument, didDocumentMetadata »
+
+resolveRepresentation(did, options) →
+   « didResolutionMetadata, didDocumentStream, didDocumentMetadata »
         </pre>
 
         <p>
@@ -4071,7 +4074,8 @@ the following function which has the following abstract form:
       </p>
 
       <pre title="Abstract functions for DID Dereferencing">
-dereference(didUrl, options) -> DereferencingResponse
+dereference(didUrl, options) →
+   « didUrlDereferencingMetadata, contentStream, contentMetadata »
       </pre>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -3944,6 +3944,11 @@ document. It indicates the version of the next
 
           <dt><dfn>equivalentId</dfn></dt>
           <dd>
+            <p class="issue atrisk">
+The DID Working Group is seeking implementer feedback on this feature. If there
+is not enough implementation experience with this feature at the end of the
+Candidate Recommendation period, it will be removed from the specification.
+            </p>
             <p>
 A <a>DID Method</a> can define different forms of a <a>DID</a> that are
 logically equivalent. An example is when a <a>DID</a> takes one form prior to
@@ -3995,48 +4000,56 @@ directives related to this metadata property.
             </dd>
             <dt><dfn>canonicalId</dfn></dt>
             <dd>
+              <p class="issue atrisk">
+The DID Working Group is seeking implementer feedback on this feature. If there
+is not enough implementation experience with this feature at the end of the
+Candidate Recommendation period, it will be removed from the specification.
+              </p>
+              <p>
 The <code><a>canonicalId</a></code> property is identical to the
-<code><a>equivalentId</a></code> property except: a) it accepts only a single
-value rather than a list, and b) that <a>DID</a> is defined to be the canonical ID for
-the <a>DID subject</a> within the scope of the containing <a>DID document</a>.<br><br>
-
+<code><a>equivalentId</a></code> property except: a) it is associated with a
+single value rather than a ordered set, and b) the <a>DID</a> is defined to be
+the canonical ID for the <a>DID subject</a> within the scope of the containing
+<a>DID document</a>.
+              </p>
+              <p>
 The value of <code><a>canonicalId</a></code> MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-href="#did-syntax"></a>.<br><br>
-
-The relationship is a statement that the <code><a>canonicalId</a></code> value
-is logically equivalent to the <code>id</code> property value and that the
-<code><a>canonicalId</a></code> value is defined by the <a>DID Method</a> to be
-the canonical ID for the <a>DID subject</a> in the scope of the containing <a>DID
-document</a>.<br><br>
-
-A <code><a>canonicalId</a></code> value MUST be produced by, and a form of, the
-same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
-<code>did:example:abc</code> == <code>did:example:ABC</code>)
-                  </dd>
-                  <dd>
-
-A conforming <a>DID Method</a> specification MUST guarantee that the
+href="#did-syntax"></a>. The relationship is a statement that the
 <code><a>canonicalId</a></code> value is logically equivalent to the
-<code>id</code> property value.<br><br>
-
+<code>id</code> property value and that the <code><a>canonicalId</a></code>
+value is defined by the <a>DID Method</a> to be the canonical ID for the <a>DID
+subject</a> in the scope of the containing <a>DID document</a>. A
+<code><a>canonicalId</a></code> value MUST be produced by, and a form of, the
+same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
+<code>did:example:abc</code> == <code>did:example:ABC</code>). A conforming
+<a>DID Method</a> specification MUST guarantee that the
+<code><a>canonicalId</a></code> value is logically equivalent to the
+<code>id</code> property value.
+              </p>
+              <p>
 A requesting party is expected to use the <code><a>canonicalId</a></code> value
-as its primary ID value for the <a>DID subject</a> and treat all other equivalent
-values as secondary aliases. (e.g. update corresponding primary references in
-their systems to reflect the new canonical ID directive).<br><br>
-
+as its primary ID value for the <a>DID subject</a> and treat all other
+equivalent values as secondary aliases (e.g. update corresponding primary
+references in their systems to reflect the new canonical ID directive).
+              </p>
+              <p>
 <code><a>canonicalId</a></code> is the same statement of equivalence as
 <code><a>equivalentId</a></code> except it is constrained to a single value that
-is defined to be canonical for the <a>DID subject</a> in the scope of the <a>DID document</a>.
-Like <code><a>equivalentId</a></code>, <code><a>canonicalId</a></code>
-represents a full graph merge because the same <a>DID document</a> describes both the
-<code><a>canonicalId</a></code> DID and the <code>id</code> property <a>DID</a>.<br><br>
-
-If a resolving party does not use the <code><a>canonicalId</a></code> value
-as its primary ID value for the DID subject and treat all other equivalent
-values as secondary aliases, there might be negative or unexpected issues that
-arise related to user experience. Implementers are strongly advised to observe the
-directives related to this metadata property.<br><br>
+is defined to be canonical for the <a>DID subject</a> in the scope of the <a>DID
+document</a>. Like <code><a>equivalentId</a></code>,
+<code><a>canonicalId</a></code> represents a full graph merge because the same
+<a>DID document</a> describes both the <code><a>canonicalId</a></code> DID and
+the <code>id</code> property <a>DID</a>.
+              </p>
+              <p>
+If a resolving party does not use the <code><a>canonicalId</a></code> value as
+its primary ID value for the DID subject and treat all other equivalent values
+as secondary aliases, there might be negative or unexpected issues that arise
+related to user experience. Implementers are strongly advised to observe the
+directives related to this metadata property.
+              </p>
+              <p>
           </dd>
         </dl>
       </section>

--- a/index.html
+++ b/index.html
@@ -3736,10 +3736,10 @@ The return value of <code>resolve</code> is the
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID resolution</a> process. This structure is
-REQUIRED and MUST NOT be empty. This metadata is defined by
-<a href="#did-resolution-metadata"></a>. If the resolution is successful this
-structure MUST contain a <code>contentType</code> property containing the
-mime-type of the <code>didDocument</code> in this result. If the resolution is
+REQUIRED and MUST NOT be empty. This metadata is defined by <a
+href="#did-resolution-metadata"></a>. If <code>resolveRepresentation</code> was
+called, this structure MUST contain a <code>contentType</code> property
+containing the MIME type of the <code>didDocument</code>. If the resolution is
 not successful, this structure MUST contain an <code>error</code> property
 describing the error.
             </dd>
@@ -4142,7 +4142,7 @@ contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
 <code>contentStream</code> MAY be a <a>resource</a> such as a <a href="">DID
 Document</a>,  <a href="#verification-methods">Verification Method</a>,  or <a
 href="#services">service</a> that is serializable in one of the conformant
-<a>representations</a> obtained through the resolution process 
+<a>representations</a> obtained through the resolution process
 or any other resource format that can be identified via a MIME type. If the
 dereferencing is unsuccessful, this value MUST be empty.
         </dd>

--- a/index.html
+++ b/index.html
@@ -4047,7 +4047,7 @@ realize an interfaces that is functionally equivalent to the following example:
 
       <pre class="example" title="Conforming dereferencer interface in Typescript">
 interface DidDereferencer {
-  dereference(USVString did,
+  dereference(string did,
               DereferencingOptions dereferencingOptions): DereferencingResponse;
 };
       </pre>

--- a/index.html
+++ b/index.html
@@ -3709,8 +3709,8 @@ interface DidResolver {
         </pre>
 
         <p>
-The input variables of the <code>resolve()</code> and
-<code>resolveRepresentation()</code> functions are as follows:
+The input variables of the <code>resolve</code> and
+<code>resolveRepresentation</code> functions are as follows:
         </p>
 
         <dl>
@@ -3732,11 +3732,11 @@ REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The return value of <code>resolve()</code> is <dfn>Resolution</dfn> which is
+The return value of <code>resolve</code> is <dfn>Resolution</dfn> which is
 a <a data-cite="INFRA#maps">map</a> that contains the
 <a>didResolutionMetadata</a>, <a>didDocument</a>, and
 <a>didDocumentMetadata</a> properties. The return value of
-<code>resolveRepresentation()</code> is <dfn>ResolutionRepresentation</dfn>
+<code>resolveRepresentation</code> is <dfn>ResolutionRepresentation</dfn>
 which is a <a data-cite="INFRA#maps">map</a> that contains
 <a>didResolutionMetadata</a>, <a>didDocumentStream</a>, and
 <a>didDocumentMetadata</a> properties. These properties are described below:
@@ -3785,7 +3785,7 @@ If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
 <code>didDocument</code> property. This metadata
-typically does not change between invocations of the <code>resolveRepresentation()</code>
+typically does not change between invocations of the <code>resolveRepresentation</code>
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
@@ -3801,7 +3801,7 @@ this function to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-<code>resolveRepresentation()</code> function specified here.
+<code>resolveRepresentation</code> function specified here.
         </p>
 
         <section>
@@ -3845,10 +3845,10 @@ contentType
                 <dd>
 The MIME type of the returned <code>didDocument</code>. This property is
 REQUIRED if resolution is successful. This property MUST NOT
-be present if the <code>resolveRepresentation()</code> function was called. The value of this
+be present if the <code>resolveRepresentation</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of <code>resolveRepresentation()</code> function MUST use this value
+caller of <code>resolveRepresentation</code> function MUST use this value
 when determining how to parse and process the <code>didDocument</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>

--- a/index.html
+++ b/index.html
@@ -3676,8 +3676,8 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-DID Resolver implementations realize at least the following interface (or one
-that is functionally equivalent):
+<a>DID resolver</a> implementations realize at least the following interface
+(or one that is functionally equivalent):
         </p>
 
         <pre class="idl">
@@ -3686,11 +3686,6 @@ interface mixin DidResolver {
 };
         </pre>
 
-        <p>
-The {{DidResolver/resolve}} function returns a byte stream of the
-<a>DID Document</a> formatted in the corresponding representation,
-DID Resolution Metadata, and DID Document Metadata.
-        </p>
         <p>
 The input variables of the {{DidResolver/resolve}} function are as follows:
         </p>
@@ -3746,14 +3741,12 @@ an <code>error</code> property describing the error.
 didDocument
             </dt>
             <dd>
-If the resolution is successful, and if the <code>resolveRepresentation</code>
-function was called, this MUST be a byte stream of the resolved <a>DID
-document</a> in one of the conformant
+If the resolution is successful this MUST be a byte stream of the resolved
+<a>DID document</a> in one of the conformant
 <a href="#representations">representations</a>. The byte stream might then be
-parsed by the caller of the <code>resolveRepresentation</code> function into a
-<a href="#data-model">data model</a>, which can in turn be validated and
-processed. If the resolution is unsuccessful, this value MUST be an empty
-stream.
+parsed by the caller into a <a href="#data-model">data model</a>, which can in
+turn be validated and processed. If the resolution is unsuccessful, this value
+MUST be an empty stream.
             </dd>
             <dt>
 didDocumentMetadata
@@ -3762,13 +3755,13 @@ didDocumentMetadata
 If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>didDocument</code>. This metadata
+<code>didDocument</code> property. This metadata
 typically does not change between invocations of the {{DidResolver/resolve}}
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
 defined by this specification are in <a
-href="#did-document-metadata-properties"></a>.
+href="#did-document-metadata"></a>.
             </dd>
         </dl>
 
@@ -3807,7 +3800,7 @@ available. This property is OPTIONAL.
         </section>
 
         <section>
-            <h3>DID Resolution Metadata Properties</h3>
+            <h3>DID Resolution Metadata</h3>
 
             <p>
 The possible properties within this structure and their possible values are
@@ -3876,7 +3869,7 @@ deactivated. (See <a href="#deactivate"></a>.)
         </section>
 
         <section>
-          <h3>DID Document Metadata Properties</h3>
+          <h3>DID Document Metadata</h3>
 
           <p>
 The possible properties within this structure and their possible values SHOULD
@@ -3884,21 +3877,19 @@ be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
 This specification defines the following common properties.
           </p>
 
-          <section>
-            <h4>created</h4>
-            <p>
+          <dl>
+            <dt><dfn>created</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include a <code>created</code> property to
 indicate the timestamp of the <a href="#create">Create operation</a>. The value
 of the property MUST be a <a data-cite="INFRA#string">string</a> formatted as an
 <a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC
 00:00:00 and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
-            </p>
-          </section>
+            </dd>
 
-          <section>
-            <h4>updated</h4>
-            <p>
+            <dt><dfn>updated</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include an <code>updated</code> property to
 indicate the timestamp of the last <a href="#update">Update operation</a> for
 the document version which was resolved. The value of the property MUST follow
@@ -3907,83 +3898,53 @@ the same formatting rules as the <code>created</code> property. The
 performed on the <a>DID document</a>. If an <code>updated</code> property exists, it
 can be the same value as the <code>created</code> property when the difference
 between the two timestamps is less than one second.
-                </p>
-              </section>
+            </dd>
 
-          <section>
-            <h4>deactivated</h4>
-            <p>
-This property MUST be populated by a <a data-cite="INFRA#boolean">boolean</a>
-value that is true if the DID has been deactivated, and false if the DID is still active.
-`true` value if the DID Method determines that the <a>DID</a> supplied has been
-deactivated. (See <a href="#deactivate"></a>.)
-                </p>
-              </section>
-
-            <section>
-                <h4>
-                  nextUpdate
-                </h4>
-                <p>
+            <dt><dfn>nextUpdate</dfn></dt>
+            <dd>
 <a>DID document</a> metadata MAY include a <code>nextUpdate</code> property
 if the resolved document version is not the latest version of the document. It
 indicates the timestamp of the next <a href="#update">Update operation</a>. The
 value of the property MUST follow the same formatting rules as the
 <code>created</code> property.
-            </p>
-          </section>
+            </dd>
 
-          <section>
-              <h4>
-                versionId
-              </h4>
-              <p>
+            <dt><dfn>versionId</dfn></dt>
+            <dd>
 <a>DID document</a> metadata SHOULD include a <code>versionId</code> property to
 indicate the version of the last <a href="#update">Update operation</a> for the
 document version which was resolved. The value of the property MUST be an <a
 data-lt="ascii string">ASCII string</a>.
-              </p>
-            </section>
+            </dd>
 
-          <section>
-              <h4>
-                nextVersionId
-              </h4>
-              <p>
+            <dt><dfn>nextVersionId</dfn></dt>
+            <dd>
 <a>DID document</a> metadata MAY include a <code>nextVersionId</code>
 property if the resolved document version is not the latest version of the
 document. It indicates the version of the next
 <a href="#update">Update operation</a>. The value of the property MUST be an
 <a data-lt="ascii string">ASCII string</a>.
-              </p>
-            </section>
+            </dd>
 
-          <section>
-            <h4>equivalentId</h4>
-                <p>
+          <dt><dfn>equivalentId</dfn></dt>
+          <dd>
 A <a>DID Method</a> can define different forms of a <a>DID</a> that are
 logically equivalent. An example is when a <a>DID</a> takes one form prior to
 registration in a <a>verifiable data registry</a> and another form after such
 registration. In this case, the <a>DID Method</a> specification may need to
 express one or more <a>DIDs</a> that are logically equivalent to the resolved
 <a>DID</a> as a property of the <a>DID document</a>. This is the purpose of the
-<code><a>equivalentId</a></code>  property.
-                </p>
+<code><a>equivalentId</a></code>  property. <br><br>
 
-                <dl>
-                  <dt><dfn>equivalentId</dfn></dt>
-                  <dd>
 The value of <code>equivalentId</code> MUST be an
 <a data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is
 a <a data-cite="INFRA#string">string</a> that conforms to the rules in Section
-<a href="#did-syntax"></a>.
-                  </dd>
-                  <dd>
+<a href="#did-syntax"></a>.<br><br>
+
 The relationship is a statement that each <code><a>equivalentId</a></code> value
 is logically equivalent to the <code>id</code> property value and thus
-identifies the same <a>DID subject</a>.
-                  </dd>
-                  <dd>
+identifies the same <a>DID subject</a>.<br><br>
+
 Each <code><a>equivalentId</a></code> DID value MUST be produced by, and a form
 of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
 <code>did:example:abc</code> == <code>did:example:ABC</code>)
@@ -3991,9 +3952,8 @@ of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
                   <dd>
 A conforming <a>DID Method</a> specification MUST guarantee that each
 <code><a>equivalentId</a></code> value is logically equivalent to the
-<code>id</code> property value.
-                  </dd>
-                  <dd>
+<code>id</code> property value.<br><br>
+
 A requesting party is expected to retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties to ensure any subsequent
 interactions with any of the values they contain are correctly handled as
@@ -4001,101 +3961,71 @@ logically equivalent (e.g., retain all variants in a database so an interaction
 with any one maps to the same underlying account). <span class="issue">The
 testability of requesting parties is currently under debate and normative
 statements related to requesting parties may be downgraded in the future from a
-MUST to a SHOULD/MAY or similar language.</span>
-                  </dd>
-                </dl>
+MUST to a SHOULD/MAY or similar language.</span><br><br>
 
-                <div class="note" title="Equivalence and equivalentId">
-                  <p>
 <code><a>equivalentId</a></code> is a much stronger form of equivalence than
 <code><a>alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
 the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a
 full graph merge because the same <a>DID document</a> describes both the
 <code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property
-<a>DID</a>.
-                  </p>
-                </div>
+<a>DID</a>.<br><br>
 
-                <div class="issue" title="Observance of equivalentId recommendations">
-                  <p>
 If a resolving party does not retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties and ensure any subsequent
 interactions with any of the values they contain are correctly handled as
 logically equivalent, there might be negative or unexpected issues that
 arise. Implementers are strongly advised to observe the
 directives related to this metadata property.
-                  </p>
-                </div>
-
-              </section>
-
-            <section>
-              <h4>canonicalId</h4>
-                <p>
+            </dd>
+            <dt><dfn>canonicalId</dfn></dt>
+            <dd>
 The <code><a>canonicalId</a></code> property is identical to the
 <code><a>equivalentId</a></code> property except: a) it accepts only a single
 value rather than a list, and b) that <a>DID</a> is defined to be the canonical ID for
-the <a>DID subject</a> within the scope of the containing <a>DID document</a>.
-                </p>
+the <a>DID subject</a> within the scope of the containing <a>DID document</a>.<br><br>
 
-                <dl>
-                  <dt><dfn>canonicalId</dfn></dt>
-                  <dd>
 The value of <code><a>canonicalId</a></code> MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-href="#did-syntax"></a>.
-                  </dd>
-                  <dd>
+href="#did-syntax"></a>.<br><br>
+
 The relationship is a statement that the <code><a>canonicalId</a></code> value
 is logically equivalent to the <code>id</code> property value and that the
 <code><a>canonicalId</a></code> value is defined by the <a>DID Method</a> to be
 the canonical ID for the <a>DID subject</a> in the scope of the containing <a>DID
-document</a>.
-                  </dd>
-                  <dd>
+document</a>.<br><br>
+
 A <code><a>canonicalId</a></code> value MUST be produced by, and a form of, the
 same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
 <code>did:example:abc</code> == <code>did:example:ABC</code>)
                   </dd>
                   <dd>
+
 A conforming <a>DID Method</a> specification MUST guarantee that the
 <code><a>canonicalId</a></code> value is logically equivalent to the
-<code>id</code> property value.
-                  </dd>
-                  <dd>
+<code>id</code> property value.<br><br>
+
 A requesting party is expected to use the <code><a>canonicalId</a></code> value
 as its primary ID value for the <a>DID subject</a> and treat all other equivalent
 values as secondary aliases. (e.g., update corresponding primary references in
 their systems to reflect the new canonical ID directive). <span
 class="issue">The testability of requesting parties is currently under debate and
 normative statements related to requesting parties may be downgraded in the
-future from a MUST to a SHOULD/MAY or similar language.</span>
-                  </dd>
-                </dl>
+future from a MUST to a SHOULD/MAY or similar language.</span><br><br>
 
-                <div class="note" title="Equivalence and canonicalId">
-                  <p>
 <code><a>canonicalId</a></code> is the same statement of equivalence as
 <code><a>equivalentId</a></code> except it is constrained to a single value that
 is defined to be canonical for the <a>DID subject</a> in the scope of the <a>DID document</a>.
 Like <code><a>equivalentId</a></code>, <code><a>canonicalId</a></code>
 represents a full graph merge because the same <a>DID document</a> describes both the
-<code><a>canonicalId</a></code> DID and the <code>id</code> property <a>DID</a>.
-                  </p>
-                </div>
+<code><a>canonicalId</a></code> DID and the <code>id</code> property <a>DID</a>.<br><br>
 
-                <div class="issue" title="Observance of canonicalId recommendations">
-                  <p>
 If a resolving party does not use the <code><a>canonicalId</a></code> value
 as its primary ID value for the DID subject and treat all other equivalent
 values as secondary aliases, there might be negative or unexpected issues that
 arise related to user experience. Implementers are strongly advised to observe the
-directives related to this metadata property.
-                  </p>
-                </div>
-
-        </section>
-      </section>
+directives related to this metadata property.<br><br>
+        </dd>
+      </dl>
     </section>
 
     <section>
@@ -4347,7 +4277,7 @@ This example corresponds to a metadata structure of the following format:
 
         <p>
 The next example demonstrates a JSON-encoded metadata structure that might be
-used as <a href="#did-document-metadata-properties">DID document metadata</a>
+used as <a href="#did-document-metadata">DID document metadata</a>
 to describe timestamps associated with the <a>DID document</a>.
         </p>
 
@@ -4562,7 +4492,7 @@ access control mechanism for the <a>DID method</a> (see Section
 
       <p>
 Non-repudiation is further supported if timestamps are included (see Section
-<a href="#did-document-metadata-properties"></a>) and the target <a>DLT</a>
+<a href="#did-document-metadata"></a>) and the target <a>DLT</a>
 system supports timestamps.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -3721,21 +3721,15 @@ contains the following properties:
 didResolutionMetadata
             </dt>
             <dd>
-              <p>
 A <a href="#metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID resolution</a> process. This structure
 is REQUIRED and MUST NOT be empty.
-              </p>
-              <p>
-This metadata is defined by <a href="#did-resolution-options"></a>.
-              </p>
-              <p>
+This metadata is defined by <a href="#did-resolution-metadata"></a>.
 If the resolution is successful this structure MUST contain a
 <code>contentType</code> property containing the mime-type of the
 <code>didDocument</code> in
 this result. If the resolution is not successful, this structure MUST contain
 an <code>error</code> property describing the error.
-              </p>
             </dd>
             <dt>
 didDocument
@@ -4031,31 +4025,34 @@ directives related to this metadata property.<br><br>
     <section>
       <h2>DID URL Dereferencing</h2>
       <p>
-The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into
-a <a>resource</a> with contents depending on the <a>DID URL</a>'s components,
-including the <a>DID method</a>, method-specific identifier, path, query,
-and fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
+The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
+<a>resource</a> with contents depending on the <a>DID URL</a>'s components,
+including the <a>DID method</a>, method-specific identifier, path, query, and
+fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
 contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
 multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
-and the function is defined to return the final resource after all
-steps are completed.
-The details of how this process is accomplished are outside the scope of this
-specification, but all conformant implementations implement a function
-which has the following abstract form:
+and the function is defined to return the final resource after all steps are
+completed. The details of how this process is accomplished are outside the scope
+of this specification, but all conforming <a>DID resolver</a> implementations
+realize at least the following interface (or one that is functionally
+equivalent):
       </p>
 
-      <p><code>
-dereference ( did-url, did-url-dereferencing-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-url-dereferencing-metadata, content-stream, content-metadata )
-      </code></p>
+      <pre class="idl">
+interface mixin DidDereferencer {
+DereferencingResponse dereference(USVString did,
+                                  DereferencingOptions dereferencingOptions);
+};
+      </pre>
 
       <p>
-The input variables of this function are as follows:
+The input variables of the {{DidDereferencer/dereference}} function are as
+follows:
       </p>
 
       <dl>
         <dt>
-did-url
+didUrl
         </dt>
         <dd>
 A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to
@@ -4063,57 +4060,57 @@ dereference. To dereference a <a>DID fragment</a>, the complete <a>DID URL</a>
 including the <a>DID fragment</a> MUST be used. This input is REQUIRED.
         </dd>
         <dt>
-did-url-dereferencing-input-metadata
+dereferencingOptions
         </dt>
         <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of input
 options to the <code>dereference</code> function in addition to the
-<code>did-url</code> itself. Properties defined by this specification are in
-<a href="#did-url-dereferencing-input-metadata-properties"></a>. This input is
-REQUIRED, but the structure MAY be empty.
+<code>didUrl</code> itself. Properties defined by this specification are in <a
+href="#did-url-dereferencing-options"></a>. This input is REQUIRED, but the
+structure MAY be empty.
         </dd>
       </dl>
 
       <p>
-The output variables of this function are as follows:
+The return value of the {{DidDereferencer/dereference}} function is a
+<dfn>DereferencingResponse</dfn> <a data-cite="INFRA#maps">map</a> that
+contains the following properties:
       </p>
 
       <dl>
         <dt>
-did-url-dereferencing-metadata
+dereferencingMetadata
         </dt>
         <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID URL dereferencing</a> process. This
 structure is REQUIRED and in the case of an error in the dereferencing process,
-this MUST NOT be empty.
-Properties defined by this specification are in
-<a href="#did-url-dereferencing-metadata-properties"></a>.
-If the dereferencing is not successful, this structure MUST contain an
-<code>error</code> property describing the error.
+this MUST NOT be empty. Properties defined by this specification are in <a
+href="#did-url-dereferencing-metadata"></a>. If the dereferencing is not
+successful, this structure MUST contain an <code>error</code> property
+describing the error.
         </dd>
         <dt>
-content-stream
+contentStream
         </dt>
         <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
-contain a <a>resource</a> corresponding to the <a>DID URL</a>.
-The <code>content-stream</code> SHOULD be a <a>DID document</a> in one of the
-conformant <a>representations</a> obtained through
-the resolution process.
+contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
+<code>content-stream</code> SHOULD be a <a>DID document</a> in one of the
+conformant <a>representations</a> obtained through the resolution process.<br><br>
 
 If the dereferencing is unsuccessful, this value MUST be empty.
         </dd>
         <dt>
-content-metadata
+contentMetadata
         </dt>
         <dd>
 If the dereferencing is successful, this MUST be a <a href="metadata-structure">
 metadata structure</a>, but the structure MAY be empty. This structure contains
-metadata about the <code>content-stream</code>.
-If the <code>content-stream</code> is a <a>DID document</a>, this MUST be a
-<code>did-document-metadata</code> structure as described in <a>DID
-Resolution</a>.
+metadata about the <code>contentStream</code>.
+If the <code>contentStream</code> is a <a>DID document</a>, this MUST be a
+<code>didDocumentMetadata</code> structure as described in <a>DID
+Resolution</a>.<br><br>
 
 If the dereferencing is unsuccessful, this output MUST be an empty <a
 href="metadata-structure">metadata structure</a>.
@@ -4131,12 +4128,14 @@ to the <code>dereference</code> function specified here.
     </p>
 
       <section>
-        <h3>DID URL Dereferencing Input Metadata Properties</h3>
+        <h3>DID URL Dereferencing Options</h3>
 
         <p>
 The possible properties within this structure and their possible values SHOULD
 be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
-This specification defines the following common properties.
+This specification defines the following common properties. This
+specification defines the following common properties for a
+<dfn>DereferencingOptions</dfn> <a data-cite="INFRA#maps">map</a>:
             </p>
 
             <dl>
@@ -4144,16 +4143,16 @@ This specification defines the following common properties.
 accept
                 </dt>
                 <dd>
-The MIME type the caller prefers for <code>content-stream</code>. The <a>DID
-URL dereferencing</a> implementation SHOULD use this value to determine the
-<a>representation</a> contained in the returned value if such a <a>representation</a> is
-supported and available.
+The MIME type the caller prefers for <code>contentStream</code>. The <a>DID URL
+dereferencing</a> implementation SHOULD use this value to determine the
+<a>representation</a> contained in the returned value if such a
+<a>representation</a> is supported and available.
                 </dd>
             </dl>
         </section>
 
         <section>
-            <h3>DID URL Dereferencing Metadata Properties</h3>
+            <h3>DID URL Dereferencing Metadata</h3>
 
             <p>
 The possible properties within this structure and their possible values are

--- a/index.html
+++ b/index.html
@@ -3682,20 +3682,32 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-<a>DID resolver</a> implementations realize an interface that is
-functionally equivalent to the following example:
+<a>DID resolvers</a> implement two functions which have the following abstract
+forms:
+        </p>
+
+        <pre title="Abstract functions for DID Resolution">
+resolve(did, options) -> Resolution
+resolveRepresentation(did, options) -> ResolutionRepresentation
+        </pre>
+
+        <p>
+The abstract forms above might be concretely implemented in a variety of
+programming environments, such as in the following example:
         </p>
 
         <pre class="example" title="A conforming resolver interface in Typescript ">
 interface DidResolver {
+  resolve(did: string,
+          options: ResolutionOptions): Resolution;
   resolveRepresentation(did: string,
-                        resolutionOptions: ResolutionOptions): ResolutionResponse;
+                        options: ResolutionOptions): ResolutionRepresentation;
 };
         </pre>
 
         <p>
-The input variables of the <code>DidResolver.resolveRepresentation()</code>
-function are as follows:
+The input variables of the <code>resolve()</code> and
+<code>resolveRepresentation()</code> functions are as follows:
         </p>
 
         <dl>
@@ -3707,48 +3719,60 @@ This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
 be a conformant <a>DID</a> as defined in <a href="#did-syntax"></a>.
             </dd>
             <dt>
-resolutionOptions
+options
             </dt>
             <dd>
-A <a href="#metadata-structure">metadata structure</a> consisting of input
-options to the <code>DidResolver.resolveRepresentation()</code> function in
-addition to the <code>did</code> itself. Properties defined by this
-specification are in <a href="#did-resolution-options"></a>. This input is
+A <a href="#metadata-structure">metadata structure</a> containing properties
+defined in <a href="#did-resolution-options"></a>. This input is
 REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
 
         <p>
-The return value of the <code>DidResolver.resolveRepresentation()</code>
-function is a <dfn>ResolutionResponse</dfn> <a data-cite="INFRA#maps">map</a>
-that contains the following properties:
+The return value of <code>resolve()</code> is <dfn>Resolution</dfn> which is
+a <a data-cite="INFRA#maps">map</a> that contains the
+<a>didResolutionMetadata</a>, <a>didDocument</a>, and
+<a>didDocumentMetadata</a> properties. The return value of
+<code>resolveRepresentation()</code> is <dfn>ResolutionRepresentation</dfn>
+which is a <a data-cite="INFRA#maps">map</a> that contains
+<a>didResolutionMetadata</a>, <a>didDocumentStream</a>, and
+<a>didDocumentMetadata</a> properties. These properties are described below:
         </p>
 
         <dl>
             <dt>
-didResolutionMetadata
+<dfn>didResolutionMetadata</dfn>
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of values
-relating to the results of the <a>DID resolution</a> process. This structure
-is REQUIRED and MUST NOT be empty.
-This metadata is defined by <a href="#did-resolution-metadata"></a>.
-If the resolution is successful this structure MUST contain a
-<code>contentType</code> property containing the mime-type of the
-<code>didDocument</code> in
-this result. If the resolution is not successful, this structure MUST contain
-an <code>error</code> property describing the error.
+relating to the results of the <a>DID resolution</a> process. This structure is
+REQUIRED and MUST NOT be empty. This metadata is defined by
+<a href="#did-resolution-metadata"></a>. If the resolution is successful this
+structure MUST contain a <code>contentType</code> property containing the
+mime-type of the <code>didDocument</code> in this result. If the resolution is
+not successful, this structure MUST contain an <code>error</code> property
+describing the error.
             </dd>
             <dt>
-didDocument
+<dfn>didDocument</dfn>
             </dt>
             <dd>
-If the resolution is successful this MUST be a byte stream of the resolved
-<a>DID document</a> in one of the conformant
+If the resolution is successful, and if the <code>resolve</code> function was
+called, this MUST be a <a>conforming DID document</a>. If the resolution is
+unsuccessful, this value MUST be empty.
+            </dd>
+            <dt>
+<dfn>didDocumentStream</dfn>
+            </dt>
+            <dd>
+If the resolution is successful, and if the <code>resolveRepresentation</code>
+function was called, this MUST be a byte stream of the resolved <a>DID
+document</a> in one of the conformant
 <a href="#representations">representations</a>. The byte stream might then be
-parsed by the caller into a <a href="#data-model">data model</a>, which can in
-turn be validated and processed. If the resolution is unsuccessful, this value
-MUST be an empty stream.
+parsed by the caller of the <code>resolveRepresentation</code> function into a
+<a href="#data-model">data model</a>, which can in turn be validated and
+processed. If the resolution is unsuccessful, this value MUST be an empty
+stream.
             </dd>
             <dt>
 didDocumentMetadata
@@ -3758,7 +3782,7 @@ If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
 <code>didDocument</code> property. This metadata
-typically does not change between invocations of the <code>DidResolver.resolveRepresentation()</code>
+typically does not change between invocations of the <code>resolveRepresentation()</code>
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
@@ -3774,7 +3798,7 @@ this function to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-<code>DidResolver.resolveRepresentation()</code> function specified here.
+<code>resolveRepresentation()</code> function specified here.
         </p>
 
         <section>
@@ -3818,10 +3842,10 @@ contentType
                 <dd>
 The MIME type of the returned <code>didDocument</code>. This property is
 REQUIRED if resolution is successful. This property MUST NOT
-be present if the <code>DidResolver.resolveRepresentation()</code> function was called. The value of this
+be present if the <code>resolveRepresentation()</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of <code>DidResolver.resolveRepresentation()</code> function MUST use this value
+caller of <code>resolveRepresentation()</code> function MUST use this value
 when determining how to parse and process the <code>didDocument</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>

--- a/index.html
+++ b/index.html
@@ -708,6 +708,12 @@ DIDs</a> or <a>conforming DID documents</a>. A conforming consumer MUST
 produce errors when consuming non-conforming <a>DIDs</a> or <a>DID documents</a>.
       </p>
 
+      <p>
+A <dfn>conforming DID resolver</dfn> is any algorithm realized as software
+and/or hardware that complies with the relevant normative statements in
+Section <a href="#resolution"></a>.
+      </p>
+
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -3671,7 +3671,7 @@ specification, but some considerations for implementors are discussed in
 
     <p>
 All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a>
-functions for at least one <a>DID method</a> and MUST be able to return a <a>DID
+function for at least one <a>DID method</a> and MUST be able to return a <a>DID
 document</a> in at least one conformant <a>representation</a>.
     </p>
 
@@ -3688,13 +3688,14 @@ functionally equivalent to the following example:
 
         <pre class="example" title="A conforming resolver interface in Typescript ">
 interface DidResolver {
-  resolve(did: string, resolutionOptions: ResolutionOptions): ResolutionResponse;
+  resolveRepresentation(did: string,
+                        resolutionOptions: ResolutionOptions): ResolutionResponse;
 };
         </pre>
 
         <p>
-The input variables of the <code>DidResolver.resolve()</code> function are
-as follows:
+The input variables of the <code>DidResolver.resolveRepresentation()</code>
+function are as follows:
         </p>
 
         <dl>
@@ -3710,17 +3711,17 @@ resolutionOptions
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of input
-options to the <code>DidResolver.resolve()</code> function in addition to the
-<code>did</code> itself. Properties defined by this
-specification are in <a href="#did-resolution-options"></a>.
-This input is REQUIRED, but the structure MAY be empty.
+options to the <code>DidResolver.resolveRepresentation()</code> function in
+addition to the <code>did</code> itself. Properties defined by this
+specification are in <a href="#did-resolution-options"></a>. This input is
+REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
 
         <p>
-The return value of the <code>DidResolver.resolve()</code> function is a
-<dfn>ResolutionResponse</dfn> <a data-cite="INFRA#maps">map</a> that
-contains the following properties:
+The return value of the <code>DidResolver.resolveRepresentation()</code>
+function is a <dfn>ResolutionResponse</dfn> <a data-cite="INFRA#maps">map</a>
+that contains the following properties:
         </p>
 
         <dl>
@@ -3757,7 +3758,7 @@ If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
 <code>didDocument</code> property. This metadata
-typically does not change between invocations of the <code>DidResolver.resolve()</code>
+typically does not change between invocations of the <code>DidResolver.resolveRepresentation()</code>
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
@@ -3773,7 +3774,7 @@ this function to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-<code>DidResolver.resolve()</code> function specified here.
+<code>DidResolver.resolveRepresentation()</code> function specified here.
         </p>
 
         <section>
@@ -3817,10 +3818,10 @@ contentType
                 <dd>
 The MIME type of the returned <code>didDocument</code>. This property is
 REQUIRED if resolution is successful. This property MUST NOT
-be present if the <code>DidResolver.resolve()</code> function was called. The value of this
+be present if the <code>DidResolver.resolveRepresentation()</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of <code>DidResolver.resolve()</code> function MUST use this value
+caller of <code>DidResolver.resolveRepresentation()</code> function MUST use this value
 when determining how to parse and process the <code>didDocument</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>

--- a/index.html
+++ b/index.html
@@ -953,7 +953,7 @@ did:foo:21tDAKCERh95uGgKbJNHYp?versionTime=2002-10-10T17:00:00Z
 The <a>DID resolution</a> and the <a>DID URL dereferencing</a> functions can
 be influenced by passing input metadata to a <a>DID resolver</a> that are
 not part of the <a>DID URL</a>. (See <a
-href="#did-resolution-input-metadata-properties"></a>). This is comparable to
+href="#did-resolution-options"></a>). This is comparable to
 HTTP, where certain parameters could either be included in an HTTP URL, or
 alternatively passed as HTTP headers during the dereferencing process. The
 important distinction is that DID parameters that are part of the <a>DID
@@ -3658,9 +3658,9 @@ Issue 549</a>.
 
     <p>
 This section defines the inputs and outputs of <a>DID resolution</a> and <a>DID
-URL dereferencing</a>. These functions are defined in an abstract way. Their
-exact implementation is out of scope for this specification, but some
-considerations for implementors are discussed in [[?DID-RESOLUTION]].
+URL dereferencing</a>.  Their exact implementation is out of scope for this
+specification, but some considerations for implementors are discussed in
+[[?DID-RESOLUTION]].
     </p>
 
     <p>
@@ -3672,28 +3672,19 @@ document</a> in at least one conformant <a>representation</a>.
     <section data-dfn-for="Resolver">
         <h2>DID Resolution</h2>
         <p>
-The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
-document</a> by using the "Read" operation of the applicable <a>DID method</a>.
-(See <a href="#read-verify"></a>.) The details of how this process is
-accomplished are outside the scope of this specification, but all conformant
-implementations implement at least the following function (or one that is
-equivalent):
+The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
+document</a> by using the "Read" operation of the applicable <a>DID method</a>
+as described in <a href="#read-verify"></a>. The details of how this process is
+accomplished are outside the scope of this specification, but all conforming
+DID Resolver implementations realize at least the following interface (or one
+that is functionally equivalent):
         </p>
 
         <pre class="idl">
 interface mixin DidResolver {
-  ResolutionResponse resolve(USVString did, ResolutionInputMetadata didResolutionInputMetadata);
+  ResolutionResponse resolve(USVString did, ResolutionOptions resolutionOptions);
 };
         </pre>
-        <p><code>
-resolve ( did, did-resolution-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document, did-document-metadata )
-        </code></p>
-
-        <p><code>
-resolveRepresentation ( did, did-resolution-input-metadata ) <br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document-stream, did-document-metadata )
-        </code></p>
 
         <p>
 The {{DidResolver/resolve}} function returns a byte stream of the
@@ -3713,13 +3704,13 @@ This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
 be a conformant <a>DID</a> as defined in <a href="#did-syntax"></a>.
             </dd>
             <dt>
-didResolutionInputMetadata
+resolutionOptions
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of input
 options to the {{DidResolver/resolve}} function in addition to the
 <code>did</code> itself. Properties defined by this
-specification are in <a href="#did-resolution-input-metadata-properties"></a>.
+specification are in <a href="#did-resolution-options"></a>.
 This input is REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
@@ -3741,7 +3732,7 @@ relating to the results of the <a>DID resolution</a> process. This structure
 is REQUIRED and MUST NOT be empty.
               </p>
               <p>
-This metadata is defined by <a href="#did-resolution-metadata-properties"></a>.
+This metadata is defined by <a href="#did-resolution-options"></a>.
               </p>
               <p>
 If the resolution is successful this structure MUST contain a
@@ -3792,7 +3783,7 @@ additional functions with different signatures in addition to the
         </p>
 
         <section>
-            <h3>DID Resolution Input Metadata Properties</h3>
+            <h3>DID Resolution Options</h3>
 
             <p>
 The possible properties within this structure and their possible values are
@@ -4310,7 +4301,7 @@ scope of this specification.
 
         <p>
 The following example demonstrates a JSON-encoded metadata structure that
-might be used as <a href="#did-resolution-input-metadata-properties">DID
+might be used as <a href="#did-resolution-options">DID
 resolution input metadata</a>.
         </p>
 
@@ -4333,7 +4324,7 @@ This example corresponds to a metadata structure of the following format:
 
         <p>
 The next example demonstrates a JSON-encoded metadata structure that might be
-used as <a href="#did-resolution-metadata-properties">DID resolution
+used as <a href="#did-resolution-options">DID resolution
 metadata</a> if a <a>DID</a> was not found.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -3695,20 +3695,6 @@ resolveRepresentation(did, options) →
         </pre>
 
         <p>
-The abstract forms above might be concretely implemented in a variety of
-programming environments, such as in the following example:
-        </p>
-
-        <pre class="example" title="A conforming resolver interface in Typescript ">
-interface DidResolver {
-  resolve(did: string,
-          options: ResolutionOptions): Resolution;
-  resolveRepresentation(did: string,
-                        options: ResolutionOptions): ResolutionRepresentation;
-};
-        </pre>
-
-        <p>
 The input variables of the <code>resolve</code> and
 <code>resolveRepresentation</code> functions are as follows:
         </p>
@@ -3732,12 +3718,10 @@ REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The return value of <code>resolve</code> is <dfn>Resolution</dfn> which is
-a <a data-cite="INFRA#maps">map</a> that contains the
+The return value of <code>resolve</code> is the
 <a>didResolutionMetadata</a>, <a>didDocument</a>, and
 <a>didDocumentMetadata</a> properties. The return value of
-<code>resolveRepresentation</code> is <dfn>ResolutionRepresentation</dfn>
-which is a <a data-cite="INFRA#maps">map</a> that contains
+<code>resolveRepresentation</code> the
 <a>didResolutionMetadata</a>, <a>didDocumentStream</a>, and
 <a>didDocumentMetadata</a> properties. These properties are described below:
         </p>
@@ -4079,18 +4063,7 @@ dereference(didUrl, options) →
       </pre>
 
       <p>
-The abstract form above might be concretely implemented in a variety of
-programming environments, such as in the following example:
-      </p>
-
-      <pre class="example" title="Conforming dereferencer interface in Typescript">
-interface DidDereferencer {
-  dereference(didUrl: string, options: DereferencingOptions): DereferencingResponse;
-};
-      </pre>
-
-      <p>
-The input variables of the <code>dereference()</code> function are as follows:
+The input variables of the <code>dereference</code> function are as follows:
       </p>
 
       <dl>
@@ -4115,9 +4088,8 @@ structure MAY be empty.
       </dl>
 
       <p>
-The return value of the <code>dereference()</code> function is a
-<dfn>DereferencingResponse</dfn> <a data-cite="INFRA#maps">map</a> that
-contains the following properties:
+The return value of the <code>dereference</code> function contains the
+following properties:
       </p>
 
       <dl>

--- a/index.html
+++ b/index.html
@@ -3918,6 +3918,12 @@ between the two timestamps is less than one second.
 
             <dt><dfn>nextUpdate</dfn></dt>
             <dd>
+              <p class="issue atrisk">
+The DID Working Group is seeking implementer feedback on this feature. If there
+is not enough implementation experience with this feature at the end of the
+Candidate Recommendation period, it will be removed from the specification.
+              </p>
+
 <a>DID document</a> metadata MAY include a <code>nextUpdate</code> property
 if the resolved document version is not the latest version of the document. It
 indicates the timestamp of the next <a href="#update">Update operation</a>. The
@@ -3935,6 +3941,12 @@ data-lt="ascii string">ASCII string</a>.
 
             <dt><dfn>nextVersionId</dfn></dt>
             <dd>
+              <p class="issue atrisk">
+The DID Working Group is seeking implementer feedback on this feature. If there
+is not enough implementation experience with this feature at the end of the
+Candidate Recommendation period, it will be removed from the specification.
+              </p>
+
 <a>DID document</a> metadata MAY include a <code>nextVersionId</code>
 property if the resolved document version is not the latest version of the
 document. It indicates the version of the next

--- a/index.html
+++ b/index.html
@@ -3725,7 +3725,9 @@ This input is REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The output variables of the {{DidResolver/resolve}} function are as follows:
+The return value of the {{DidResolver/resolve}} function is a
+<dfn>ResolutionResponse</dfn> <a data-cite="INFRA#maps">map</a> that
+contains the following properties:
         </p>
 
         <dl>
@@ -3819,7 +3821,8 @@ available. This property is OPTIONAL.
             <p>
 The possible properties within this structure and their possible values are
 registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]]. This
-specification defines the following common properties.
+specification defines the following common properties for a
+<dfn>ResolutionInputMetadata</dfn> <a data-cite="INFRA#maps">map</a>:
             </p>
 
             <dl>

--- a/index.html
+++ b/index.html
@@ -3695,6 +3695,9 @@ resolveRepresentation(did, options) →
         </pre>
 
         <p>
+The <code>resolve</code> function returns the <a>DID document</a> in its
+abstract form. The <code>resolveRepresentation</code> function returns a byte
+stream of the <a>DID Document</a> formatted in the corresponding representation.
 The input variables of the <code>resolve</code> and
 <code>resolveRepresentation</code> functions are as follows:
         </p>

--- a/index.html
+++ b/index.html
@@ -3669,17 +3669,22 @@ functions for at least one <a>DID method</a> and MUST be able to return a <a>DID
 document</a> in at least one conformant <a>representation</a>.
     </p>
 
-    <section>
+    <section data-dfn-for="Resolver">
         <h2>DID Resolution</h2>
         <p>
 The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>.
 (See <a href="#read-verify"></a>.) The details of how this process is
 accomplished are outside the scope of this specification, but all conformant
-implementations implement two functions which have the following abstract
-forms:
+implementations implement at least the following function (or one that is
+equivalent):
         </p>
 
+        <pre class="idl">
+interface mixin DidResolver {
+  ResolutionResponse resolve(USVString did, ResolutionInputMetadata didResolutionInputMetadata);
+};
+        </pre>
         <p><code>
 resolve ( did, did-resolution-input-metadata ) <br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&gt; ( did-resolution-metadata, did-document, did-document-metadata )
@@ -3691,13 +3696,12 @@ resolveRepresentation ( did, did-resolution-input-metadata ) <br>
         </code></p>
 
         <p>
-The <code>resolve</code> function returns the <a>DID document</a> in its
-abstract form.
-The <code>resolveRepresentation</code> function returns a byte stream of the
-<a>DID Document</a> formatted in the corresponding representation.
+The {{DidResolver/resolve}} function returns a byte stream of the
+<a>DID Document</a> formatted in the corresponding representation,
+DID Resolution Metadata, and DID Document Metadata.
         </p>
         <p>
-The input variables of these functions are as follows:
+The input variables of the {{DidResolver/resolve}} function are as follows:
         </p>
 
         <dl>
@@ -3709,24 +3713,24 @@ This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
 be a conformant <a>DID</a> as defined in <a href="#did-syntax"></a>.
             </dd>
             <dt>
-did-resolution-input-metadata
+didResolutionInputMetadata
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of input
-options to the <code>resolve</code> and <code>resolveRepresentation</code>
-functions in addition to the <code>did</code> itself. Properties defined by this
+options to the {{DidResolver/resolve}} function in addition to the
+<code>did</code> itself. Properties defined by this
 specification are in <a href="#did-resolution-input-metadata-properties"></a>.
 This input is REQUIRED, but the structure MAY be empty.
             </dd>
         </dl>
 
         <p>
-The output variables of these functions are as follows:
+The output variables of the {{DidResolver/resolve}} function are as follows:
         </p>
 
         <dl>
             <dt>
-did-resolution-metadata
+didResolutionMetadata
             </dt>
             <dd>
               <p>
@@ -3735,29 +3739,18 @@ relating to the results of the <a>DID resolution</a> process. This structure
 is REQUIRED and MUST NOT be empty.
               </p>
               <p>
-This metadata typically changes between invocations of the
-<code>resolve</code> and <code>resolveRepresentation</code> functions as it
-represents data about the resolution process itself. Properties defined by
-this specification are in <a href="#did-resolution-metadata-properties"></a>.
+This metadata is defined by <a href="#did-resolution-metadata-properties"></a>.
               </p>
               <p>
-If the resolution is successful, and if the <code>resolveRepresentation</code>
-function was called, this structure MUST contain a <code>contentType</code>
-property containing the mime-type of the <code>did-document-stream</code> in
+If the resolution is successful this structure MUST contain a
+<code>contentType</code> property containing the mime-type of the
+<code>didDocument</code> in
 this result. If the resolution is not successful, this structure MUST contain
 an <code>error</code> property describing the error.
               </p>
             </dd>
             <dt>
-did-document
-            </dt>
-            <dd>
-If the resolution is successful, and if the <code>resolve</code> function was
-called, this MUST be a <a>conforming DID document</a>. If the resolution is
-unsuccessful, this value MUST be empty.
-            </dd>
-            <dt>
-did-document-stream
+didDocument
             </dt>
             <dd>
 If the resolution is successful, and if the <code>resolveRepresentation</code>
@@ -3770,14 +3763,14 @@ processed. If the resolution is unsuccessful, this value MUST be an empty
 stream.
             </dd>
             <dt>
-did-document-metadata
+didDocumentMetadata
             </dt>
             <dd>
 If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
-<code>did-document</code> or <code>did-document-stream</code>. This metadata
-typically does not change between invocations of the <code>resolve</code>
+<code>didDocument</code>. This metadata
+typically does not change between invocations of the {{DidResolver/resolve}}
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
@@ -3788,12 +3781,12 @@ href="#did-document-metadata-properties"></a>.
 
         <p>
 Conforming <a>DID resolver</a> implementations do not alter the signature of
-these functions in any way. <a>DID resolver</a> implementations might map the
-<code>resolve</code> and <code>resolveRepresentation</code> functions to a
+these functions in any way. <a>DID resolver</a> implementations might map
+this function to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-<code>resolve</code> function specified here.
+{{DidResolver/resolve}} function specified here.
         </p>
 
         <section>
@@ -3814,10 +3807,8 @@ The MIME type expressed as an <a data-lt="ascii string">ASCII string</a> of the
 caller's preferred <a>representation</a> of the <a>DID
 document</a>. The <a>DID resolver</a> implementation SHOULD use this value to
 determine the <a>representation</a> contained in the returned
-<code>did-document-stream</code> if such a <a>representation</a> is supported and
-available. This property is OPTIONAL. It is only used if the
-<code>resolveRepresentation</code> function is called and MUST be ignored if the
-<code>resolve</code> function is called.
+<code>didDocument</code> if such a <a>representation</a> is supported and
+available. This property is OPTIONAL.
                 </dd>
             </dl>
         </section>
@@ -3836,14 +3827,13 @@ specification defines the following common properties.
 contentType
                 </dt>
                 <dd>
-The MIME type of the returned <code>did-document-stream</code>. This property is
-REQUIRED if resolution is successful and if the
-<code>resolveRepresentation</code> function was called. This property MUST NOT
-be present if the <code>resolve</code> function was called. The value of this
+The MIME type of the returned <code>didDocument</code>. This property is
+REQUIRED if resolution is successful. This property MUST NOT
+be present if the {{DidResolver/resolve}} function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of the <code>resolveRepresentation</code> function MUST use this value
-when determining how to parse and process the <code>did-document-stream</code>
+caller of {{DidResolver/resolve}} function MUST use this value
+when determining how to parse and process the <code>didDocument</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>
                 <dt>
@@ -3875,9 +3865,16 @@ representationNotSupported
                         </dt>
                         <dd>
 This error code is returned if the <a>representation</a> requested via the
-<code>accept</code> input metadata property is not supported by the <a>DID method</a>
-and/or <a>DID resolver</a> implementation.
-</dd>
+<code>accept</code> input metadata property is not supported by the <a>DID
+method</a> and/or <a>DID resolver</a> implementation.
+                        </dd>
+                        <dt>
+deactivated
+                        </dt>
+                        <dd>
+The <a>DID</a> supplied to the <a>DID resolution</a> function has been
+deactivated. (See <a href="#deactivate"></a>.)
+                        </dd>
                     </dl>
                 </dd>
             </dl>
@@ -3896,11 +3893,11 @@ This specification defines the following common properties.
           <section>
             <h4>created</h4>
             <p>
-<a>DID document</a> metadata SHOULD include a <code>created</code> property to indicate
-the timestamp of the <a href="#create">Create operation</a>. The value of the
-property MUST be a <a data-cite="INFRA#string">string</a> formatted as an <a
-data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC 00:00:00
-and without sub-second decimal precision. For example:
+<a>DID document</a> metadata SHOULD include a <code>created</code> property to
+indicate the timestamp of the <a href="#create">Create operation</a>. The value
+of the property MUST be a <a data-cite="INFRA#string">string</a> formatted as an
+<a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to UTC
+00:00:00 and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
             </p>
           </section>
@@ -3934,10 +3931,10 @@ deactivated. (See <a href="#deactivate"></a>.)
                   nextUpdate
                 </h4>
                 <p>
-<a>DID document</a> metadata MAY include a <code>nextUpdate</code> property if
-the resolved document version is not the latest version of the document. It
-indicates the timestamp of the next <a href="#update">Update operation</a>.
-The value of the property MUST follow the same formatting rules as the
+<a>DID document</a> metadata MAY include a <code>nextUpdate</code> property
+if the resolved document version is not the latest version of the document. It
+indicates the timestamp of the next <a href="#update">Update operation</a>. The
+value of the property MUST follow the same formatting rules as the
 <code>created</code> property.
             </p>
           </section>
@@ -3959,31 +3956,33 @@ data-lt="ascii string">ASCII string</a>.
                 nextVersionId
               </h4>
               <p>
-<a>DID document</a> metadata MAY include a <code>nextVersionId</code> property if
-the resolved document version is not the latest version of the document. It
-indicates the version of the next <a href="#update">Update operation</a>. The
-value of the property MUST be an <a data-lt="ascii string">ASCII string</a>.
+<a>DID document</a> metadata MAY include a <code>nextVersionId</code>
+property if the resolved document version is not the latest version of the
+document. It indicates the version of the next
+<a href="#update">Update operation</a>. The value of the property MUST be an
+<a data-lt="ascii string">ASCII string</a>.
               </p>
             </section>
 
           <section>
             <h4>equivalentId</h4>
                 <p>
-A <a>DID Method</a> can define different forms of a <a>DID</a> that are logically
-equivalent. An example is when a <a>DID</a> takes one form prior to registration in a
-<a>verifiable data registry</a> and another form after such registration. In this case,
-the <a>DID Method</a> specification may need to express one or more <a>DIDs</a> that
-are logically equivalent to the resolved <a>DID</a> as a property of the <a>DID document</a>.
-This is the purpose of the <code><a>equivalentId</a></code>  property.
+A <a>DID Method</a> can define different forms of a <a>DID</a> that are
+logically equivalent. An example is when a <a>DID</a> takes one form prior to
+registration in a <a>verifiable data registry</a> and another form after such
+registration. In this case, the <a>DID Method</a> specification may need to
+express one or more <a>DIDs</a> that are logically equivalent to the resolved
+<a>DID</a> as a property of the <a>DID document</a>. This is the purpose of the
+<code><a>equivalentId</a></code>  property.
                 </p>
 
                 <dl>
                   <dt><dfn>equivalentId</dfn></dt>
                   <dd>
-The value of <code>equivalentId</code> MUST be an <a
-data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is a <a
-data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-href="#did-syntax"></a>.
+The value of <code>equivalentId</code> MUST be an
+<a data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is
+a <a data-cite="INFRA#string">string</a> that conforms to the rules in Section
+<a href="#did-syntax"></a>.
                   </dd>
                   <dd>
 The relationship is a statement that each <code><a>equivalentId</a></code> value
@@ -4016,9 +4015,10 @@ MUST to a SHOULD/MAY or similar language.</span>
                   <p>
 <code><a>equivalentId</a></code> is a much stronger form of equivalence than
 <code><a>alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
-the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a full
-graph merge because the same <a>DID document</a> describes both the
-<code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property <a>DID</a>.
+the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a
+full graph merge because the same <a>DID document</a> describes both the
+<code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property
+<a>DID</a>.
                   </p>
                 </div>
 

--- a/index.html
+++ b/index.html
@@ -3671,7 +3671,7 @@ specification, but some considerations for implementors are discussed in
 
     <p>
 All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a>
-function for at least one <a>DID method</a> and MUST be able to return a <a>DID
+functions for at least one <a>DID method</a> and MUST be able to return a <a>DID
 document</a> in at least one conformant <a>representation</a>.
     </p>
 
@@ -3775,7 +3775,7 @@ processed. If the resolution is unsuccessful, this value MUST be an empty
 stream.
             </dd>
             <dt>
-didDocumentMetadata
+<dfn>didDocumentMetadata</dfn>
             </dt>
             <dd>
 If the resolution is successful, this MUST be a <a
@@ -4066,20 +4066,27 @@ contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
 multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
 and the function is defined to return the final resource after all steps are
 completed. The details of how this process is accomplished are outside the scope
-of this specification, but all conforming <a>DID resolver</a> implementations
-realize an interfaces that is functionally equivalent to the following example:
+of this specification, but all conforming <a>DID resolvers</a> implement
+the following function which has the following abstract form:
+      </p>
+
+      <pre title="Abstract functions for DID Dereferencing">
+dereference(didUrl, options) -> DereferencingResponse
+      </pre>
+
+      <p>
+The abstract form above might be concretely implemented in a variety of
+programming environments, such as in the following example:
       </p>
 
       <pre class="example" title="Conforming dereferencer interface in Typescript">
 interface DidDereferencer {
-  dereference(string did,
-              DereferencingOptions dereferencingOptions): DereferencingResponse;
+  dereference(didUrl: string, options: DereferencingOptions): DereferencingResponse;
 };
       </pre>
 
       <p>
-The input variables of the <code>DidDereferencer.dereference()</code> function
-are as follows:
+The input variables of the <code>dereference()</code> function are as follows:
       </p>
 
       <dl>
@@ -4092,7 +4099,7 @@ dereference. To dereference a <a>DID fragment</a>, the complete <a>DID URL</a>
 including the <a>DID fragment</a> MUST be used. This input is REQUIRED.
         </dd>
         <dt>
-dereferencingOptions
+options
         </dt>
         <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of input
@@ -4104,7 +4111,7 @@ structure MAY be empty.
       </dl>
 
       <p>
-The return value of the <code>DidDereferencer.dereference()</code> function is a
+The return value of the <code>dereference()</code> function is a
 <dfn>DereferencingResponse</dfn> <a data-cite="INFRA#maps">map</a> that
 contains the following properties:
       </p>
@@ -4141,7 +4148,7 @@ If the dereferencing is successful, this MUST be a <a href="metadata-structure">
 metadata structure</a>, but the structure MAY be empty. This structure contains
 metadata about the <code>contentStream</code>.
 If the <code>contentStream</code> is a <a>DID document</a>, this MUST be a
-<code>didDocumentMetadata</code> structure as described in <a>DID
+<a>didDocumentMetadata</a> structure as described in <a>DID
 Resolution</a>.<br><br>
 
 If the dereferencing is unsuccessful, this output MUST be an empty <a

--- a/index.html
+++ b/index.html
@@ -3696,7 +3696,7 @@ resolveRepresentation(did, resolutionOptions) →
 
         <p>
 The <code>resolve</code> function returns the <a>DID document</a> in its
-abstract form. The <code>resolveRepresentation</code> function returns a byte
+abstract form (a <a data-cite="INFRA#maps">map</a>). The <code>resolveRepresentation</code> function returns a byte
 stream of the <a>DID Document</a> formatted in the corresponding representation.
 The input variables of the <code>resolve</code> and
 <code>resolveRepresentation</code> functions are as follows:

--- a/index.html
+++ b/index.html
@@ -3671,8 +3671,8 @@ specification, but some considerations for implementors are discussed in
 
     <p>
 All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a>
-functions for at least one <a>DID method</a> and MUST be able to return a <a>DID
-document</a> in at least one conformant <a>representation</a>.
+functions for at least one <a>DID method</a> and MUST be able to produce a
+<a>DID document</a> in at least one conformant <a>representation</a>.
     </p>
 
     <section data-dfn-for="Resolver">
@@ -3682,8 +3682,8 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-<a>DID resolvers</a> implement at least one of the functions below which
-have the following abstract forms:
+<a>DID resolvers</a> implement the functions below which have the following
+abstract forms:
         </p>
 
         <pre title="Abstract functions for DID Resolution">
@@ -3721,7 +3721,7 @@ REQUIRED, but the structure MAY be empty.
 The return value of <code>resolve</code> is the
 <a>didResolutionMetadata</a>, <a>didDocument</a>, and
 <a>didDocumentMetadata</a> properties. The return value of
-<code>resolveRepresentation</code> the
+<code>resolveRepresentation</code> is the
 <a>didResolutionMetadata</a>, <a>didDocumentStream</a>, and
 <a>didDocumentMetadata</a> properties. These properties are described below:
         </p>
@@ -3745,7 +3745,9 @@ describing the error.
             </dt>
             <dd>
 If the resolution is successful, and if the <code>resolve</code> function was
-called, this MUST be a <a>conforming DID document</a>. If the resolution is
+called, this MUST be a <a>DID document</a> (abstract data model) as described in
+<a href="#data-model"></a> that is capable of being transformed
+into a <a>conforming DID Document</a> (representation). If the resolution is
 unsuccessful, this value MUST be empty.
             </dd>
             <dt>
@@ -3806,7 +3808,7 @@ The MIME type expressed as an <a data-lt="ascii string">ASCII string</a> of the
 caller's preferred <a>representation</a> of the <a>DID
 document</a>. The <a>DID resolver</a> implementation SHOULD use this value to
 determine the <a>representation</a> contained in the returned
-<code>didDocument</code> if such a <a>representation</a> is supported and
+<code>didDocumentStream</code> if such a <a>representation</a> is supported and
 available. This property is OPTIONAL.
                 </dd>
             </dl>
@@ -3827,13 +3829,13 @@ specification defines the following common properties for a
 contentType
                 </dt>
                 <dd>
-The MIME type of the returned <code>didDocument</code>. This property is
+The MIME type of the returned <code>didDocumentStream</code>. This property is
 REQUIRED if resolution is successful. This property MUST NOT
-be present if the <code>resolveRepresentation</code> function was called. The value of this
+be present if the <code>resolve</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
 caller of <code>resolveRepresentation</code> function MUST use this value
-when determining how to parse and process the <code>didDocument</code>
+when determining how to parse and process the <code>didDocumentStream</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>
                 <dt>
@@ -3844,7 +3846,8 @@ The error code from the resolution process. This property is REQUIRED when there
 is an error in the resolution process. The value of this property MUST be a
 single keyword <a data-lt="ascii string">ASCII string</a>. The possible property
 values of this field SHOULD be registered in the DID Specification Registries
-[[?DID-SPEC-REGISTRIES]]. This specification defines the following error values:
+[[?DID-SPEC-REGISTRIES]]. This specification defines the following
+common error values:
                     <dl>
                         <dt>
 invalidDid

--- a/index.html
+++ b/index.html
@@ -3786,8 +3786,8 @@ specification are in <a href="#did-document-metadata"></a>.
 
         <p>
 Conforming <a>DID resolver</a> implementations do not alter the signature of
-these functions in any way. <a>DID resolver</a> implementations might map
-this function to a
+these functions in any way. <a>DID resolver</a> implementations might map the
+<code>resolve</code> and <code>resolveRepresentation</code> functions to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the

--- a/index.html
+++ b/index.html
@@ -3944,23 +3944,22 @@ document. It indicates the version of the next
 
           <dt><dfn>equivalentId</dfn></dt>
           <dd>
+            <p>
 A <a>DID Method</a> can define different forms of a <a>DID</a> that are
 logically equivalent. An example is when a <a>DID</a> takes one form prior to
 registration in a <a>verifiable data registry</a> and another form after such
-registration. In this case, the <a>DID Method</a> specification may need to
+registration. In this case, the <a>DID Method</a> specification might need to
 express one or more <a>DIDs</a> that are logically equivalent to the resolved
 <a>DID</a> as a property of the <a>DID document</a>. This is the purpose of the
-<code><a>equivalentId</a></code>  property. <br><br>
-
-The value of <code>equivalentId</code> MUST be an
-<a data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is
-a <a data-cite="INFRA#string">string</a> that conforms to the rules in Section
-<a href="#did-syntax"></a>.<br><br>
-
-The relationship is a statement that each <code><a>equivalentId</a></code> value
-is logically equivalent to the <code>id</code> property value and thus
-identifies the same <a>DID subject</a>.<br><br>
-
+<code><a>equivalentId</a></code>  property.
+            </p>
+            <p>
+The value of <code>equivalentId</code> MUST be an <a
+data-cite="INFRA#ordered-set">ordered set</a> where each item in the list is a
+<a data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
+href="#did-syntax"></a>. The relationship is a statement that each
+<code><a>equivalentId</a></code> value is logically equivalent to the
+<code>id</code> property value and thus identifies the same <a>DID subject</a>.
 Each <code><a>equivalentId</a></code> DID value MUST be produced by, and a form
 of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
 <code>did:example:abc</code> == <code>did:example:ABC</code>)
@@ -3968,30 +3967,31 @@ of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
                   <dd>
 A conforming <a>DID Method</a> specification MUST guarantee that each
 <code><a>equivalentId</a></code> value is logically equivalent to the
-<code>id</code> property value.<br><br>
-
+<code>id</code> property value.
+            </p>
+            <p>
 A requesting party is expected to retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties to ensure any subsequent
 interactions with any of the values they contain are correctly handled as
-logically equivalent (e.g., retain all variants in a database so an interaction
-with any one maps to the same underlying account). <span class="issue">The
-testability of requesting parties is currently under debate and normative
-statements related to requesting parties may be downgraded in the future from a
-MUST to a SHOULD/MAY or similar language.</span><br><br>
-
+logically equivalent (e.g. retain all variants in a database so an interaction
+with any one maps to the same underlying account).
+            </p>
+            <p>
 <code><a>equivalentId</a></code> is a much stronger form of equivalence than
 <code><a>alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
 the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a
 full graph merge because the same <a>DID document</a> describes both the
 <code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property
-<a>DID</a>.<br><br>
-
-If a resolving party does not retain the values from the <code>id</code> and
+<a>DID</a>.
+            </p>
+            <p>
+If a requesting party does not retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties and ensure any subsequent
 interactions with any of the values they contain are correctly handled as
 logically equivalent, there might be negative or unexpected issues that
 arise. Implementers are strongly advised to observe the
 directives related to this metadata property.
+              </p>
             </dd>
             <dt><dfn>canonicalId</dfn></dt>
             <dd>
@@ -4022,11 +4022,8 @@ A conforming <a>DID Method</a> specification MUST guarantee that the
 
 A requesting party is expected to use the <code><a>canonicalId</a></code> value
 as its primary ID value for the <a>DID subject</a> and treat all other equivalent
-values as secondary aliases. (e.g., update corresponding primary references in
-their systems to reflect the new canonical ID directive). <span
-class="issue">The testability of requesting parties is currently under debate and
-normative statements related to requesting parties may be downgraded in the
-future from a MUST to a SHOULD/MAY or similar language.</span><br><br>
+values as secondary aliases. (e.g. update corresponding primary references in
+their systems to reflect the new canonical ID directive).<br><br>
 
 <code><a>canonicalId</a></code> is the same statement of equivalence as
 <code><a>equivalentId</a></code> except it is constrained to a single value that

--- a/index.html
+++ b/index.html
@@ -4150,10 +4150,10 @@ contentStream
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
 <code>contentStream</code> MAY be a <a>resource</a> such as a <a href="">DID
-Document</a>,  <a href="#verification-methods">Verification Method</a>,  or <a
-href="#services">service</a> that is serializable in one of the conformant
-<a>representations</a> obtained through the resolution process
-or any other resource format that can be identified via a MIME type. If the
+Document</a> that is serializable in one of the conformant
+<a>representations</a>,  a <a href="#verification-methods">Verification Method</a>,  a <a
+href="#services">service</a>, or any other resource format that can be identified via a MIME type
+and obtained through the resolution process. If the
 dereferencing is unsuccessful, this value MUST be empty.
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -3804,10 +3804,10 @@ specification defines the following common properties.
 accept
                 </dt>
                 <dd>
-The MIME type expressed as an <a data-lt="ascii string">ASCII string</a> of the
-caller's preferred <a>representation</a> of the <a>DID
-document</a>. The <a>DID resolver</a> implementation SHOULD use this value to
-determine the <a>representation</a> contained in the returned
+The MIME type of the caller's preferred <a>representation</a> of the <a>DID
+document</a>. The MIME type MUST be expressed as an  <a data-lt="ascii
+string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
+value to determine the <a>representation</a> contained in the returned
 <code>didDocumentStream</code> if such a <a>representation</a> is supported and
 available. This property is OPTIONAL.
                 </dd>
@@ -4072,7 +4072,7 @@ the following function which has the following abstract form:
 
       <pre title="Abstract functions for DID Dereferencing">
 dereference(didUrl, options) →
-   « didUrlDereferencingMetadata, contentStream, contentMetadata »
+   « dereferencingMetadata, contentStream, contentMetadata »
       </pre>
 
       <p>
@@ -4124,10 +4124,11 @@ contentStream
         <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
-<code>contentStream</code> SHOULD be a <a>DID document</a> in one of the
-conformant <a>representations</a> obtained through the resolution process.<br><br>
-
-If the dereferencing is unsuccessful, this value MUST be empty.
+<code>contentStream</code> SHOULD be a <a>resource</a> such as a <a href="">DID
+Document</a>,  <a href="#verification-methods">Verification Method</a>,  or <a
+href="#services">service</a> that is serializable in one of the conformant
+<a>representations</a> obtained through the resolution process. If the
+dereferencing is unsuccessful, this value MUST be empty.
         </dd>
         <dt>
 contentMetadata
@@ -4135,13 +4136,10 @@ contentMetadata
         <dd>
 If the dereferencing is successful, this MUST be a <a href="metadata-structure">
 metadata structure</a>, but the structure MAY be empty. This structure contains
-metadata about the <code>contentStream</code>.
-If the <code>contentStream</code> is a <a>DID document</a>, this MUST be a
-<a>didDocumentMetadata</a> structure as described in <a>DID
-Resolution</a>.<br><br>
-
-If the dereferencing is unsuccessful, this output MUST be an empty <a
-href="metadata-structure">metadata structure</a>.
+metadata about the <code>contentStream</code>. If the <code>contentStream</code>
+is a <a>DID document</a>, this MUST be a <a>didDocumentMetadata</a> structure as
+described in <a>DID Resolution</a>. If the dereferencing is unsuccessful, this
+output MUST be an empty <a href="metadata-structure">metadata structure</a>.
         </dd>
     </dl>
 
@@ -4167,15 +4165,16 @@ options:
             </p>
 
             <dl>
-                <dt>
+              <dt>
 accept
-                </dt>
-                <dd>
-The MIME type the caller prefers for <code>contentStream</code>. The <a>DID URL
-dereferencing</a> implementation SHOULD use this value to determine the
-<a>representation</a> contained in the returned value if such a
+              </dt>
+              <dd>
+The MIME type that the caller prefers for <code>contentStream</code>. The  MIME
+type MUST be expressed as an <a data-lt="ascii string">ASCII string</a>.
+The <a>DID URL dereferencing</a> implementation SHOULD use this value to
+determine the <a>representation</a> contained in the returned value if such a
 <a>representation</a> is supported and available.
-                </dd>
+              </dd>
             </dl>
         </section>
 
@@ -4194,17 +4193,19 @@ contentType
                 </dt>
                 <dd>
 The MIME type of the returned <code>contentStream</code> SHOULD be expressed
-using this property if dereferencing is successful.
+using this property if dereferencing is successful. The MIME
+type value MUST be expressed as an <a data-lt="ascii string">ASCII string</a>.
                 </dd>
                 <dt>
 error
                 </dt>
                 <dd>
 The error code from the dereferencing process. This property is REQUIRED when
-there is an error in the dereferencing process. The value of this property is
-a single keyword string. The possible property values of this field SHOULD be
-registered in the DID Specification Registries [DID-SPEC-REGISTRIES]]. This
-specification defines the following error values:
+there is an error in the dereferencing process. The value of this property
+MUST be a single keyword expressed as an  <a data-lt="ascii string">ASCII
+string</a>. The possible property values of this field SHOULD be registered in
+the DID Specification Registries [[DID-SPEC-REGISTRIES]]. This specification
+defines the following common error values:
                     <dl>
                         <dt>
 invalidDidUrl

--- a/index.html
+++ b/index.html
@@ -4018,8 +4018,9 @@ as its primary ID value for the DID subject and treat all other equivalent
 values as secondary aliases, there might be negative or unexpected issues that
 arise related to user experience. Implementers are strongly advised to observe the
 directives related to this metadata property.<br><br>
-        </dd>
-      </dl>
+          </dd>
+        </dl>
+      </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -4242,19 +4242,21 @@ data-cite="INFRA#list">list</a>, <a data-cite="INFRA#ordered-set">ordered
 set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
 <a data-cite="INFRA#null">null</a>. The values within any complex data
 structures such as maps and lists MUST be one of these data types as well.
-All metadata property definitions MUST define the value type, including any
+All metadata property definitions registered in the DID Specification
+Registries [[DID-SPEC-REGISTRIES] MUST define the value type, including any
 additional formats or restrictions to that value (for example, a string
 formatted as a date or as a decimal integer). It is RECOMMENDED that property
-definitions use strings for values.
+definitions use strings for values. The entire metadata structure MUST be
+serializable in a conforming <a>representation</a>.
         </p>
 
         <p>
-All implementations of functions that use metadata structures as either input
-or output are able to fully represent all data types described here in a
+All implementations of functions that use metadata structures as either input or
+output are able to fully represent all data types described here in a
 deterministic fashion. As inputs and outputs using metadata structures are
 defined in terms of data types and not their serialization, the method for
-<a>representation</a> is internal to the implementation of the function and is out of
-scope of this specification.
+<a>representation</a> is internal to the implementation of the function and is
+out of scope of this specification.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3838,7 +3838,9 @@ contentType
                 </dt>
                 <dd>
 The MIME type of the returned <code>didDocumentStream</code>. This property is
-REQUIRED if resolution is successful. This property MUST NOT
+REQUIRED if resolution is successful and if the
+<code>resolveRepresentation</code> function was called. 
+This property MUST NOT
 be present if the <code>resolve</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The

--- a/index.html
+++ b/index.html
@@ -3750,7 +3750,7 @@ describing the error.
 If the resolution is successful, and if the <code>resolve</code> function was
 called, this MUST be a <a>DID document</a> (abstract data model) as described in
 <a href="#data-model"></a> that is capable of being transformed
-into a <a>conforming DID Document</a> (representation). If the resolution is
+into a <a>conforming DID Document</a> (representation), using the production rules specified by the representation. If the resolution is
 unsuccessful, this value MUST be empty.
             </dd>
             <dt>
@@ -3837,7 +3837,7 @@ REQUIRED if resolution is successful. This property MUST NOT
 be present if the <code>resolve</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of <code>resolveRepresentation</code> function MUST use this value
+caller of the <code>resolveRepresentation</code> function MUST use this value
 when determining how to parse and process the <code>didDocumentStream</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>
@@ -3996,7 +3996,7 @@ interactions with any of the values they contain are correctly handled as
 logically equivalent (e.g. retain all variants in a database so an interaction
 with any one maps to the same underlying account).
             </p>
-            <p>
+            <p class="note" title="Stronger equivalence">
 <code><a>equivalentId</a></code> is a much stronger form of equivalence than
 <code><a>alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
 the governing <a>DID method</a>. <code><a>equivalentId</a></code> represents a
@@ -4048,7 +4048,7 @@ as its primary ID value for the <a>DID subject</a> and treat all other
 equivalent values as secondary aliases (e.g. update corresponding primary
 references in their systems to reflect the new canonical ID directive).
               </p>
-              <p>
+              <p class="note" title="Canonical equivalence">
 <code><a>canonicalId</a></code> is the same statement of equivalence as
 <code><a>equivalentId</a></code> except it is constrained to a single value that
 is defined to be canonical for the <a>DID subject</a> in the scope of the <a>DID
@@ -4139,10 +4139,11 @@ contentStream
         <dd>
 If the <code>dereferencing</code> function was called and successful, this MUST
 contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
-<code>contentStream</code> SHOULD be a <a>resource</a> such as a <a href="">DID
+<code>contentStream</code> MAY be a <a>resource</a> such as a <a href="">DID
 Document</a>,  <a href="#verification-methods">Verification Method</a>,  or <a
 href="#services">service</a> that is serializable in one of the conformant
-<a>representations</a> obtained through the resolution process. If the
+<a>representations</a> obtained through the resolution process 
+or any other resource format that can be identified via a MIME type. If the
 dereferencing is unsuccessful, this value MUST be empty.
         </dd>
         <dt>
@@ -4187,7 +4188,7 @@ accept
 The MIME type that the caller prefers for <code>contentStream</code>. The  MIME
 type MUST be expressed as an <a data-lt="ascii string">ASCII string</a>.
 The <a>DID URL dereferencing</a> implementation SHOULD use this value to
-determine the <a>representation</a> contained in the returned value if such a
+determine the <code>contentType</code> of the <a>representation</a> contained in the returned value if such a
 <a>representation</a> is supported and available.
               </dd>
             </dl>
@@ -4258,7 +4259,7 @@ set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
 <a data-cite="INFRA#null">null</a>. The values within any complex data
 structures such as maps and lists MUST be one of these data types as well.
 All metadata property definitions registered in the DID Specification
-Registries [[DID-SPEC-REGISTRIES] MUST define the value type, including any
+Registries [[?DID-SPEC-REGISTRIES]] MUST define the value type, including any
 additional formats or restrictions to that value (for example, a string
 formatted as a date or as a decimal integer). It is RECOMMENDED that property
 definitions use strings for values. The entire metadata structure MUST be

--- a/index.html
+++ b/index.html
@@ -3671,14 +3671,14 @@ specification, but some considerations for implementors are discussed in
 
     <p>
 All conformant <a>DID resolvers</a> MUST implement the <a>DID resolution</a>
-functions for at least one <a>DID method</a> and MUST be able to produce a
+functions for at least one <a>DID method</a> and MUST be able to return a
 <a>DID document</a> in at least one conformant <a>representation</a>.
     </p>
 
     <section data-dfn-for="Resolver">
         <h2>DID Resolution</h2>
         <p>
-The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
+The <a>DID resolution</a> functions resolve a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
@@ -3687,10 +3687,10 @@ abstract forms:
         </p>
 
         <pre title="Abstract functions for DID Resolution">
-resolve(did, options) →
+resolve(did, resolutionOptions) →
    « didResolutionMetadata, didDocument, didDocumentMetadata »
 
-resolveRepresentation(did, options) →
+resolveRepresentation(did, resolutionOptions) →
    « didResolutionMetadata, didDocumentStream, didDocumentMetadata »
         </pre>
 
@@ -3711,7 +3711,7 @@ This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
 be a conformant <a>DID</a> as defined in <a href="#did-syntax"></a>.
             </dd>
             <dt>
-options
+resolutionOptions
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> containing properties
@@ -3721,12 +3721,14 @@ REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The return value of <code>resolve</code> is the
+These functions each return multiple values, and no limitations
+are placed on how these values are returned together.
+The return values of <code>resolve</code> are
 <a>didResolutionMetadata</a>, <a>didDocument</a>, and
-<a>didDocumentMetadata</a> properties. The return value of
-<code>resolveRepresentation</code> is the
+<a>didDocumentMetadata</a>. The return values of
+<code>resolveRepresentation</code> are
 <a>didResolutionMetadata</a>, <a>didDocumentStream</a>, and
-<a>didDocumentMetadata</a> properties. These properties are described below:
+<a>didDocumentMetadata</a>. These values are described below:
         </p>
 
         <dl>
@@ -3742,7 +3744,7 @@ resolution process itself. This structure is REQUIRED, and MUST NOT be empty.
 This metadata is defined by <a href="#did-resolution-metadata"></a>. If
 <code>resolveRepresentation</code> was called, this structure MUST contain a
 <code>contentType</code> property containing the MIME type of the
-<code>didDocument</code>. If the resolution is not successful, this structure
+representation found in the <code>didDocumentStream</code>. If the resolution is not successful, this structure
 MUST contain an <code>error</code> property describing the error.
             </dd>
             <dt>
@@ -3750,7 +3752,7 @@ MUST contain an <code>error</code> property describing the error.
             </dt>
             <dd>
 If the resolution is successful, and if the <code>resolve</code> function was
-called, this MUST be a <a>DID document</a> (abstract data model) as described in
+called, this MUST be a <a>DID document</a> abstract data model (a <a data-cite="INFRA#maps">map</a>) as described in
 <a href="#data-model"></a> that is capable of being transformed
 into a <a>conforming DID Document</a> (representation), using the production
 rules specified by the representation. If the resolution is
@@ -3792,7 +3794,7 @@ these functions in any way. <a>DID resolver</a> implementations might map the
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-<code>resolveRepresentation</code> function specified here.
+<code>resolve</code> and <code>resolveRepresentation</code> functions specified here.
         </p>
 
         <section>
@@ -3814,7 +3816,8 @@ document</a>. The MIME type MUST be expressed as an  <a data-lt="ascii
 string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 value to determine the <a>representation</a> contained in the returned
 <code>didDocumentStream</code> if such a <a>representation</a> is supported and
-available. This property is OPTIONAL.
+available. This property is OPTIONAL for the <code>resolveResolution</code> function
+and MUST NOT be used with the <code>resolve</code> function.
                 </dd>
             </dl>
         </section>
@@ -4088,7 +4091,7 @@ the following function which has the following abstract form:
       </p>
 
       <pre title="Abstract functions for DID Dereferencing">
-dereference(didUrl, options) →
+dereference(didUrl, dereferenceOptions) →
    « dereferencingMetadata, contentStream, contentMetadata »
       </pre>
 
@@ -4106,7 +4109,7 @@ dereference. To dereference a <a>DID fragment</a>, the complete <a>DID URL</a>
 including the <a>DID fragment</a> MUST be used. This input is REQUIRED.
         </dd>
         <dt>
-options
+dereferencingOptions
         </dt>
         <dd>
 A <a href="metadata-structure">metadata structure</a> consisting of input
@@ -4118,8 +4121,11 @@ structure MAY be empty.
       </dl>
 
       <p>
-The return value of the <code>dereference</code> function contains the
-following properties:
+This function returns multiple values, and no limitations
+are placed on how these values are returned together.
+The return values of the <code>dereference</code> include
+<code>dereferencingMetadata</code>, <code>contentStream</code>,
+and <code>contentMetadata</code>:
       </p>
 
       <dl>

--- a/index.html
+++ b/index.html
@@ -3735,13 +3735,15 @@ The return value of <code>resolve</code> is the
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of values
-relating to the results of the <a>DID resolution</a> process. This structure is
-REQUIRED and MUST NOT be empty. This metadata is defined by <a
-href="#did-resolution-metadata"></a>. If <code>resolveRepresentation</code> was
-called, this structure MUST contain a <code>contentType</code> property
-containing the MIME type of the <code>didDocument</code>. If the resolution is
-not successful, this structure MUST contain an <code>error</code> property
-describing the error.
+relating to the results of the <a>DID resolution</a> process and typically
+changes between invocations of the <code>resolve</code> and
+<code>resolveRepresentation</code> functions as it represents data about the
+resolution process itself. This structure is REQUIRED and MUST NOT be empty.
+This metadata is defined by <a href="#did-resolution-metadata"></a>. If
+<code>resolveRepresentation</code> was called, this structure MUST contain a
+<code>contentType</code> property containing the MIME type of the
+<code>didDocument</code>. If the resolution is not successful, this structure
+MUST contain an <code>error</code> property describing the error.
             </dd>
             <dt>
 <dfn>didDocument</dfn>

--- a/index.html
+++ b/index.html
@@ -3682,18 +3682,19 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-<a>DID resolver</a> implementations realize at least the following interface
-(or one that is functionally equivalent):
+<a>DID resolver</a> implementations realize an interface that is
+functionally equivalent to the following example:
         </p>
 
-        <pre class="idl">
-interface mixin DidResolver {
-  ResolutionResponse resolve(USVString did, ResolutionOptions resolutionOptions);
+        <pre class="example" title="A conforming resolver interface in Typescript ">
+interface DidResolver {
+  resolve(did: string, resolutionOptions: ResolutionOptions): ResolutionResponse;
 };
         </pre>
 
         <p>
-The input variables of the {{DidResolver/resolve}} function are as follows:
+The input variables of the <code>DidResolver.resolve()</code> function are
+as follows:
         </p>
 
         <dl>
@@ -3709,7 +3710,7 @@ resolutionOptions
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of input
-options to the {{DidResolver/resolve}} function in addition to the
+options to the <code>DidResolver.resolve()</code> function in addition to the
 <code>did</code> itself. Properties defined by this
 specification are in <a href="#did-resolution-options"></a>.
 This input is REQUIRED, but the structure MAY be empty.
@@ -3717,7 +3718,7 @@ This input is REQUIRED, but the structure MAY be empty.
         </dl>
 
         <p>
-The return value of the {{DidResolver/resolve}} function is a
+The return value of the <code>DidResolver.resolve()</code> function is a
 <dfn>ResolutionResponse</dfn> <a data-cite="INFRA#maps">map</a> that
 contains the following properties:
         </p>
@@ -3756,7 +3757,7 @@ If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
 metadata about the <a>DID document</a> contained in the
 <code>didDocument</code> property. This metadata
-typically does not change between invocations of the {{DidResolver/resolve}}
+typically does not change between invocations of the <code>DidResolver.resolve()</code>
 function unless the <a>DID document</a> changes, as it represents data about
 the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
 be an empty <a href="#metadata-structure">metadata structure</a>. Properties
@@ -3772,7 +3773,7 @@ this function to a
 method-specific internal function to perform the actual <a>DID resolution</a>
 process. <a>DID resolver</a> implementations might implement and expose
 additional functions with different signatures in addition to the
-{{DidResolver/resolve}} function specified here.
+<code>DidResolver.resolve()</code> function specified here.
         </p>
 
         <section>
@@ -3816,10 +3817,10 @@ contentType
                 <dd>
 The MIME type of the returned <code>didDocument</code>. This property is
 REQUIRED if resolution is successful. This property MUST NOT
-be present if the {{DidResolver/resolve}} function was called. The value of this
+be present if the <code>DidResolver.resolve()</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME
 type of the conformant <a>representations</a>. The
-caller of {{DidResolver/resolve}} function MUST use this value
+caller of <code>DidResolver.resolve()</code> function MUST use this value
 when determining how to parse and process the <code>didDocument</code>
 returned by this function into the <a href="#data-model">data model</a>.
                 </dd>
@@ -4041,20 +4042,19 @@ multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
 and the function is defined to return the final resource after all steps are
 completed. The details of how this process is accomplished are outside the scope
 of this specification, but all conforming <a>DID resolver</a> implementations
-realize at least the following interface (or one that is functionally
-equivalent):
+realize an interfaces that is functionally equivalent to the following example:
       </p>
 
-      <pre class="idl">
-interface mixin DidDereferencer {
-DereferencingResponse dereference(USVString did,
-                                  DereferencingOptions dereferencingOptions);
+      <pre class="example" title="Conforming dereferencer interface in Typescript">
+interface DidDereferencer {
+  dereference(USVString did,
+              DereferencingOptions dereferencingOptions): DereferencingResponse;
 };
       </pre>
 
       <p>
-The input variables of the {{DidDereferencer/dereference}} function are as
-follows:
+The input variables of the <code>DidDereferencer.dereference()</code> function
+are as follows:
       </p>
 
       <dl>
@@ -4079,7 +4079,7 @@ structure MAY be empty.
       </dl>
 
       <p>
-The return value of the {{DidDereferencer/dereference}} function is a
+The return value of the <code>DidDereferencer.dereference()</code> function is a
 <dfn>DereferencingResponse</dfn> <a data-cite="INFRA#maps">map</a> that
 contains the following properties:
       </p>

--- a/index.html
+++ b/index.html
@@ -3682,7 +3682,7 @@ The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
 document</a> by using the "Read" operation of the applicable <a>DID method</a>
 as described in <a href="#read-verify"></a>. The details of how this process is
 accomplished are outside the scope of this specification, but all conforming
-<a>DID resolvers</a> implement the functions below which have the following
+<a>DID resolvers</a> implement the functions below, which have the following
 abstract forms:
         </p>
 
@@ -3735,10 +3735,10 @@ The return value of <code>resolve</code> is the
             </dt>
             <dd>
 A <a href="#metadata-structure">metadata structure</a> consisting of values
-relating to the results of the <a>DID resolution</a> process and typically
+relating to the results of the <a>DID resolution</a> process which typically
 changes between invocations of the <code>resolve</code> and
-<code>resolveRepresentation</code> functions as it represents data about the
-resolution process itself. This structure is REQUIRED and MUST NOT be empty.
+<code>resolveRepresentation</code> functions, as it represents data about the
+resolution process itself. This structure is REQUIRED, and MUST NOT be empty.
 This metadata is defined by <a href="#did-resolution-metadata"></a>. If
 <code>resolveRepresentation</code> was called, this structure MUST contain a
 <code>contentType</code> property containing the MIME type of the
@@ -3752,7 +3752,8 @@ MUST contain an <code>error</code> property describing the error.
 If the resolution is successful, and if the <code>resolve</code> function was
 called, this MUST be a <a>DID document</a> (abstract data model) as described in
 <a href="#data-model"></a> that is capable of being transformed
-into a <a>conforming DID Document</a> (representation), using the production rules specified by the representation. If the resolution is
+into a <a>conforming DID Document</a> (representation), using the production
+rules specified by the representation. If the resolution is
 unsuccessful, this value MUST be empty.
             </dd>
             <dt>
@@ -4176,9 +4177,8 @@ to the <code>dereference</code> function specified here.
         <p>
 The possible properties within this structure and their possible values SHOULD
 be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
-This specification defines the following common properties. This
-specification defines the following common properties for dereferencing
-options:
+This specification defines the following common properties for
+dereferencing options:
             </p>
 
             <dl>
@@ -4219,7 +4219,7 @@ error
                 <dd>
 The error code from the dereferencing process. This property is REQUIRED when
 there is an error in the dereferencing process. The value of this property
-MUST be a single keyword expressed as an  <a data-lt="ascii string">ASCII
+MUST be a single keyword expressed as an <a data-lt="ascii string">ASCII
 string</a>. The possible property values of this field SHOULD be registered in
 the DID Specification Registries [[DID-SPEC-REGISTRIES]]. This specification
 defines the following common error values:

--- a/index.html
+++ b/index.html
@@ -3772,14 +3772,13 @@ stream.
             <dd>
 If the resolution is successful, this MUST be a <a
 href="#metadata-structure">metadata structure</a>. This structure contains
-metadata about the <a>DID document</a> contained in the
-<code>didDocument</code> property. This metadata
-typically does not change between invocations of the <code>resolveRepresentation</code>
-function unless the <a>DID document</a> changes, as it represents data about
-the <a>DID document</a>. If the resolution is unsuccessful, this output MUST
-be an empty <a href="#metadata-structure">metadata structure</a>. Properties
-defined by this specification are in <a
-href="#did-document-metadata"></a>.
+metadata about the <a>DID document</a> contained in the <code>didDocument</code>
+property. This metadata typically does not change between invocations of the
+<code>resolve</code> and <code>resolveRepresentation</code> functions unless the
+<a>DID document</a> changes, as it represents metadata about the <a>DID
+document</a>. If the resolution is unsuccessful, this output MUST be an empty <a
+href="#metadata-structure">metadata structure</a>. Properties defined by this
+specification are in <a href="#did-document-metadata"></a>.
             </dd>
         </dl>
 


### PR DESCRIPTION
This PR is intended to address issue #549 by adding to the abstract functions discussed in the DID Resolution and DID URL Dereferencing sections and ensuring that all statements are testable using a "proof by construction". That is, all statements that return abstract data models are testable due to additional normative statements that effectively state: "anything that returns an abstract data model MUST be serializable in one of the representations". Previously, that statement didn't apply to `didDocument`, the metadata structure, some of the dereferencing values, etc. This PR fixes that.

The PR also adds at-risk markers to some of the newer features requested by individuals (but not necessarily broadly requested by the WG -- such as nextUpdate, nextVersionId, equivalentId, and canonicalId. There are also a few bugs fixed in this version (such as stating that a contentType must be specified for the resolve call -- that returns an abstract didDocument... which is clearly wrong).

There are a LOT of reformatting changes in this PR, it might be best to <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/601.html#resolution">look at the rendered preview for this PR</a>.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/601.html" title="Last updated on Feb 10, 2021, 9:57 PM UTC (a58ae7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/601/3858d12...a58ae7f.html" title="Last updated on Feb 10, 2021, 9:57 PM UTC (a58ae7f)">Diff</a>