### PR TITLE
fixing `i.e.,` and `e.g.,` punctuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4026,7 +4026,7 @@ identifies the same <a>DID subject</a>.
                   </dd>
                   <dd>
 Each <code><a>equivalentId</a></code> DID value MUST be produced by, and a form
-of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.
+of, the same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
 <code>did:example:abc</code> == <code>did:example:ABC</code>)
                   </dd>
                   <dd>
@@ -4038,7 +4038,7 @@ A conforming <a>DID Method</a> specification MUST guarantee that each
 A requesting party is expected to retain the values from the <code>id</code> and
 <code><a>equivalentId</a></code> properties to ensure any subsequent
 interactions with any of the values they contain are correctly handled as
-logically equivalent (e.g. retain all variants in a database so an interaction
+logically equivalent (e.g., retain all variants in a database so an interaction
 with any one maps to the same underlying account). <span class="issue">The
 testability of requesting parties is currently under debate and normative
 statements related to requesting parties may be downgraded in the future from a
@@ -4094,7 +4094,7 @@ document</a>.
                   </dd>
                   <dd>
 A <code><a>canonicalId</a></code> value MUST be produced by, and a form of, the
-same <a>DID Method</a> as the <code>id</code> property value. (e.g.
+same <a>DID Method</a> as the <code>id</code> property value. (e.g.,
 <code>did:example:abc</code> == <code>did:example:ABC</code>)
                   </dd>
                   <dd>
@@ -4105,7 +4105,7 @@ A conforming <a>DID Method</a> specification MUST guarantee that the
                   <dd>
 A requesting party is expected to use the <code><a>canonicalId</a></code> value
 as its primary ID value for the <a>DID subject</a> and treat all other equivalent
-values as secondary aliases. (e.g. update corresponding primary references in
+values as secondary aliases. (e.g., update corresponding primary references in
 their systems to reflect the new canonical ID directive). <span
 class="issue">The testability of requesting parties is currently under debate and
 normative statements related to requesting parties may be downgraded in the
@@ -5038,7 +5038,7 @@ related to attacks against <a>DIDs</a> that are asserted to be equivalent.
       <p>
 The <code><a>equivalentId</a></code> and <code><a>canonicalId</a></code>
 properties that constrain equivalence assertions to variants of a single <a>DID</a>
-produced by the same <a>DID method</a> (e.g. <code>did:foo:123</code> ≡
+produced by the same <a>DID method</a> (e.g., <code>did:foo:123</code> ≡
 <code>did:foo:hash(123)</code>) can be trusted to the extent the requesting party
 trusts the <a>DID method</a> (and a conforming producer) itself.
       </p>
@@ -5050,7 +5050,7 @@ outside of the governing <a>DID method</a>. See additional guidence in
 <a href="#also-known-as"></a>.
       </p>
       <p>
-As with any other sensitive properties in the <a>DID document</a> (e.g. public key
+As with any other sensitive properties in the <a>DID document</a> (e.g., public key
 references), parties relying on any equivalence statement in a <a>DID document</a>
 should guard against the values of these properties being substituted by an
 attacker after the proper verification has been performed. Any write access to a


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/did-core/pull/605.html" title="Last updated on Feb 8, 2021, 6:01 PM UTC (49b88ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/605/e5cf7f3...TallTed:49b88ea.html" title="Last updated on Feb 8, 2021, 6:01 PM UTC (49b88ea)">Diff</a>