### PR TITLE
Add Candidate Recommendation variables to spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
     // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
     specStatus: "WD",
 
+    // W3C Candidate Recommendation information
+    crEnd: "2021-04-30",
+    implementationReportURI: "https://w3c.github.io/did-test-suite/",
+
     // Editor's Draft URL
     edDraftURI: "https://w3c.github.io/did-core/",
 
@@ -44,7 +48,7 @@
 
     // previously published draft, uncomment this and set its
     // YYYY-MM-DD date and its maturity status
-    previousPublishDate:  "2020-11-08",
+    previousPublishDate:  "2021-02-22",
     previousMaturity:  "WD",
 
     // automatically allow term pluralization


### PR DESCRIPTION
This PR adds the CR header config values to the DID Core spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/607.html" title="Last updated on Feb 9, 2021, 10:18 PM UTC (4524c4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/607/6645c05...4524c4b.html" title="Last updated on Feb 9, 2021, 10:18 PM UTC (4524c4b)">Diff</a>