### PR TITLE
Describe `@context` as JSON member in JSON-LD production/consumption.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2859,8 +2859,8 @@ require them.
         <p>
 The <a>DID document</a> MUST be serialized according to the
 <a href="#production">production rules for JSON</a>, with one additional
-requirement: The <a>DID document</a> MUST include the <code>@context</code>
-entry.
+requirement: The JSON object that represents the <a>DID document</a>
+MUST include the <code>@context</code> member.
         </p>
 
         <dl>
@@ -2869,8 +2869,8 @@ entry.
 
             <p>
 The <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD
-specification</a> defines values that are valid for this entry. This entry
-contains representation-specific syntax and therefore could be present in the <a
+specification</a> defines values that are valid for this member. It
+contains representation-specific syntax and therefore could be present as an entry in the <a
 href="#data-model">data model</a> to aid in lossless conversion. If the entry
 is present in the <a href="#data-model">data model</a>, it MUST be used during
 production unless either an alternative <code>@context</code> value is
@@ -2884,7 +2884,7 @@ The value of <code>@context</code> MUST be exactly one of these values.
 
             <ul>
               <li>
-The <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a>
+The <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON String</a>
 <code>https://www.w3.org/ns/did/v1</code>.
                 <pre class="example">
 {
@@ -2894,11 +2894,11 @@ The <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a>
                 </pre>
               </li>
               <li>
-An <a data-cite="INFRA#ordered-set">INFRA ordered set</a>,
-with first item the <a href="https://infra.spec.whatwg.org/#strings">INFRA
-string</a> <code>https://www.w3.org/ns/did/v1</code>, and subsequent items of
-type <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a> or
-<a href="https://infra.spec.whatwg.org/#maps">INFRA map</a>.
+A <a href="https://tools.ietf.org/html/rfc8259#section-5">JSON Array</a>,
+with first item the <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
+String</a> <code>https://www.w3.org/ns/did/v1</code>, and subsequent items of
+type <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON String</a> or
+<a href="https://tools.ietf.org/html/rfc8259#section-4">JSON Object</a>.
                 <pre class="example">
 {
   "@context": [
@@ -2912,9 +2912,9 @@ type <a href="https://infra.spec.whatwg.org/#strings">INFRA string</a> or
             </ul>
 
             <p>
-All members of the <code>@context</code> property SHOULD exist in the DID
+All JSON-LD terms defined by the <code>@context</code> SHOULD exist in the DID
 Specification Registries [[?DID-SPEC-REGISTRIES]] in order to achieve
-interoperability across different <a>representations</a>. If a member does not exist
+interoperability across different <a>representations</a>. If a term does not exist
 in the DID Specification Registries, then the <a>DID document</a> might not be
 interoperable across <a>representations</a>.
             </p>
@@ -2942,15 +2942,15 @@ defined via the <code>@context</code>. Properties that are not defined via the
         <p>
 The <a>DID document</a> MUST be deserialized as a JSON document according to
 the <a href="#consumption">consumption rules for JSON</a>, with one additional
-requirement: The <a>DID document</a> MUST include the <code>@context</code>
-entry and be processed according to the rules below.
+requirement: The JSON object that represents the <a>DID document</a> MUST include the <code>@context</code>
+member and be processed according to the rules below.
         </p>
 
         <dl>
           <dt>@context</dt>
           <dd>
             <p>
-The value of the <code>@context</code> entry conforms to the
+The value of the <code>@context</code> member conforms to the
 <a href="#production-0">JSON-LD Production Rules</a>. If more than one
 <a>URI</a> is provided, the <a>URIs</a> MUST be interpreted as an
 <a data-cite="INFRA#ordered-set">ordered set</a>.

--- a/index.html
+++ b/index.html
@@ -2859,8 +2859,8 @@ require them.
         <p>
 The <a>DID document</a> MUST be serialized according to the
 <a href="#production">production rules for JSON</a>, with one additional
-requirement: The JSON object that represents the <a>DID document</a>
-MUST include the <code>@context</code> member.
+requirement: The serialized <a>DID document</a> MUST include the
+<code>@context</code> member.
         </p>
 
         <dl>
@@ -2870,7 +2870,8 @@ MUST include the <code>@context</code> member.
             <p>
 The <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD
 specification</a> defines values that are valid for this member. It
-contains representation-specific syntax and therefore could be present as an entry in the <a
+contains representation-specific syntax and therefore could be present as an
+entry in the <a
 href="#data-model">data model</a> to aid in lossless conversion. If the entry
 is present in the <a href="#data-model">data model</a>, it MUST be used during
 production unless either an alternative <code>@context</code> value is
@@ -2942,8 +2943,8 @@ defined via the <code>@context</code>. Properties that are not defined via the
         <p>
 The <a>DID document</a> MUST be deserialized as a JSON document according to
 the <a href="#consumption">consumption rules for JSON</a>, with one additional
-requirement: The JSON object that represents the <a>DID document</a> MUST include the <code>@context</code>
-member and be processed according to the rules below.
+requirement: The serialized <a>DID document</a> MUST include the
+<code>@context</code> member and be processed according to the rules below.
         </p>
 
         <dl>


### PR DESCRIPTION
Okay I know how controversial this will be, considering the discussions around my diagrams in https://github.com/w3c/did-core/pull/596 and https://github.com/w3c/did-core/pull/597), but I have to try.

This changes the language around `@context` in the JSON-LD production/consumption sections to treat it primarily as a member in a JSON object (concrete DID document representation), rather than an entry in the INFRA map (abstract DID document data model).

Explanation:

The JSON-LD production section as it's currently written seems to contradict itself. First it says

_"The DID document **MUST include the @context entry.**"_

but then it says

_"This entry [..] **could be present** [..]. **If the entry is present**" [..]._

I am pretty sure the intention here is to say that `@context` MUST be present in the JSON-LD representation, and it can be preserved as an entry in the abstract data model, but it is definitely NOT a REQUIRED entry in the abstract data model (it's not a Core Property). This PR clarifies this.

As an additional indication to support this, look at the examples in this section. They are JSON examples, not INFRA examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/610.html" title="Last updated on Feb 10, 2021, 10:01 AM UTC (aa2a17b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/610/6645c05...aa2a17b.html" title="Last updated on Feb 10, 2021, 10:01 AM UTC (aa2a17b)">Diff</a>