### PR TITLE
Fix editorial and normative issues in DID URL Syntax section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -800,8 +800,8 @@ Section <a href="#method-schemes"></a>.
       <p>
 A <a>DID URL</a> is a network location identifier for a specific
 <a>resource</a>. It can be used to identify things like <a>DID subjects</a>,
-<a>verification methods</a>, <a>services</a>, and a specific part of a <a>DID
-document</a> at a specific point in time.
+<a>verification methods</a>, <a>services</a>, specific parts of a <a>DID
+document</a>, or other resources.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -798,24 +798,42 @@ Section <a href="#method-schemes"></a>.
       <h3>DID URL Syntax</h3>
 
       <p>
-A <a>DID URL</a> always identifies a <a>resource</a> to be located. It can be
-used, for example, to identify a specific part of a <a>DID document</a>.
+A <a>DID URL</a> is a network location identifier for a specific
+<a>resource</a>. It can be used to identify things like <a>DID subjects</a>,
+<a>verification methods</a>, <a>services</a>, and a specific part of a <a>DID
+document</a> at a specific point in time.
       </p>
 
       <p>
-This following is the ABNF definition using the syntax in [[!RFC5234]]. It
-builds on the <code>did</code> scheme defined in <a href="#did-syntax"></a>. The
-<a data-cite="!rfc3986#section-3.3"><code>path-abempty</code></a>,
-<a data-cite="!rfc3986#section-3.4"><code>query</code></a>, and
-<a data-cite="!rfc3986#section-3.5"><code>fragment</code></a>
-components are identical to the ABNF rules defined in [[!RFC3986]].
+The following is the ABNF definition using the syntax in [[!RFC5234]]. It builds
+on the <code>did</code> scheme defined in <a href="#did-syntax"></a>. The <a
+data-cite="!rfc3986#section-3.3"><code>path-abempty</code></a>, <a
+data-cite="!rfc3986#section-3.4"><code>query</code></a>, and <a
+data-cite="!rfc3986#section-3.5"><code>fragment</code></a> components are
+defined in [[!RFC3986]]. All <a>DID URLs</a> MUST conform to the
+DID URL Syntax ABNF Rules.
       </p>
 
-      <pre class="nohighlight">
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>
+The DID URL Syntax ABNF Rules
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <pre class="nohighlight">
 did-url = did path-abempty [ "?" query ] [ "#" fragment ]
-      </pre>
+              </pre>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-      <p class="note">
+      <p class="note" title="Semicolon character is reserved for future use">
 This specification reserves the semicolon (<code>;</code>) character for
 possible future use as a sub-delimiter for parameters as described in
 [[?MATRIX-URIS]].
@@ -3846,7 +3864,7 @@ contentType
                 <dd>
 The MIME type of the returned <code>didDocumentStream</code>. This property is
 REQUIRED if resolution is successful and if the
-<code>resolveRepresentation</code> function was called. 
+<code>resolveRepresentation</code> function was called.
 This property MUST NOT
 be present if the <code>resolve</code> function was called. The value of this
 property MUST be an <a data-lt="ascii string">ASCII string</a> that is the MIME


### PR DESCRIPTION
This PR creates a new normative requirement that I expect the WG intended to have in the specification, but failed to assert regarding the DID URL ABNF Syntax. At no point did we say that conforming producers and consumers MUST follow the ABNF rules. Woops.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/621.html" title="Last updated on Feb 12, 2021, 5:36 PM UTC (b0cbde0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/621/5d0cdbc...b0cbde0.html" title="Last updated on Feb 12, 2021, 5:36 PM UTC (b0cbde0)">Diff</a>