### PR TITLE
Change "DID dereferencing" to "DID URL dereferencing".

### DIFF
--- a/index.html
+++ b/index.html
@@ -4099,7 +4099,7 @@ of this specification, but all conforming <a>DID resolvers</a> implement
 the following function which has the following abstract form:
       </p>
 
-      <pre title="Abstract functions for DID Dereferencing">
+      <pre title="Abstract functions for DID URL Dereferencing">
 dereference(didUrl, dereferenceOptions) →
    « dereferencingMetadata, contentStream, contentMetadata »
       </pre>
@@ -5753,8 +5753,8 @@ DIDs and DID documents are recorded on a Verifiable Data Registry;
 DIDs resolve to DID documents; DIDs identify DID subjects; a DID controller controls
 a DID document; DID URLs contains a DID; DID URLs dereferenced to DID document fragments or
 external resources;
-DID resolver implements resolve function; DID derefernecer implements dereferencing function;
-DID method operates a Verfiable Data Registry; DID resolver and DID dereferencer instruct a DID method.
+DID resolver implements resolve function; DID URL dereferencer implements dereferencing function;
+DID method operates a Verfiable Data Registry; DID resolver and DID URL dereferencer instruct a DID method.
       " >
       <figcaption>
 Detailed overview of DID architecture and the relationship of the basic components.


### PR DESCRIPTION
Addresses https://github.com/w3c/did-core/issues/618


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/624.html" title="Last updated on Feb 11, 2021, 9:46 PM UTC (daa2fee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/624/1dda7f5...daa2fee.html" title="Last updated on Feb 11, 2021, 9:46 PM UTC (daa2fee)">Diff</a>