### PR TITLE
Update jsonld-production rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -2891,13 +2891,11 @@ entry.
             <p>
 The <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD
 specification</a> defines values that are valid for this entry. This entry
-contains representation-specific syntax and therefore could be present in the <a
-href="#data-model">data model</a> to aid in lossless conversion. If the entry
-is present in the <a href="#data-model">data model</a>, it MUST be used during
-production unless either an alternative <code>@context</code> value is
-explicitly provided to the producer or if the value from the data model is not
-valid according to the consumption rules.
-            </p>
+contains representation-specific syntax that could be present in the <a
+href="#data-model">data model</a> as a result of consuming <code>application/did+ld+json</code>. 
+If absent, this entry MUST be added to the <a href="#data-model">data model</a>, 
+prior to serialization of <code>application/did+ld+json</code>. 
+          </p>
 
             <p>
 The value of <code>@context</code> MUST be exactly one of these values.


### PR DESCRIPTION
- Clarify that `@context` might be present in the ADM as a result of consumption (weaken implication that it might be there for other reasons)
- Clarify that `@context` MUST be added to the ADM prior to serialization of `application/did+ld+json` (explain where it comes from without requiring it to always be present in the ADM)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/626.html" title="Last updated on Feb 12, 2021, 1:33 AM UTC (2d51131)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/626/1dda7f5...2d51131.html" title="Last updated on Feb 12, 2021, 1:33 AM UTC (2d51131)">Diff</a>