### PR TITLE
Add DID document example in JSON representation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2690,6 +2690,19 @@ the root object. Entries MAY define additional data sub structures subject
 to the value representation rules in the list above.
         </p>
 
+      <pre class="example nohighlight"
+        title="Example DID document in JSON representation">
+{
+	"id": "did:example:123456789abcdefghi",
+	"authentication": [{
+		"id": "did:example:123456789abcdefghi#keys-1",
+		"type": "Ed25519VerificationKey2018",
+		"controller": "did:example:123456789abcdefghi",
+		"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+	}]
+}
+      </pre>
+
       </section>
 
       <section>


### PR DESCRIPTION
This adds an example of a DID document in the JSON representation. @msporny @OR13 do you agree with this?

This example shows the same DID document in JSON that we already have as an example in the CBOR section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/628.html" title="Last updated on Feb 12, 2021, 4:31 AM UTC (b6dede2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/628/1dda7f5...b6dede2.html" title="Last updated on Feb 12, 2021, 4:31 AM UTC (b6dede2)">Diff</a>