### PR TITLE
Fix non-substantive issues with Verification Methods section.

### DIFF
--- a/common.js
+++ b/common.js
@@ -120,7 +120,7 @@ var ccg = {
     },
     "BASE58": {
       title: "The Base58 Encoding Scheme",
-      date: "December 2019",
+      date: "October 2020",
       href: "https://tools.ietf.org/html/draft-msporny-base58",
       authors: [
         "Manu Sporny"
@@ -166,6 +166,17 @@ var ccg = {
       ],
       date: "2011",
       publisher: "Information and Privacy Commissioner"
+    },
+    "MULTIBASE": {
+      title: "The Multibase Encoding Scheme",
+      date: "August 2020",
+      href: "https://tools.ietf.org/html/draft-multiformats-multibase",
+      authors: [
+        "Juan Benet",
+        "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -1926,26 +1926,24 @@ both properties above is shown below.
       </section>
 
       <section>
-        <h3>Verification Methods by reference</h3>
+        <h3>Referring to Verification Methods</h3>
         <p>
-As well as the <code><a>verificationMethod</a></code> property, <a>verification
-methods</a> can be embedded in or referenced from properties associated with
-various <a>verification relationships</a> (see
-<a href="#verification-relationships"></a>). Referencing <a>verification methods</a>
-allows them to be used with more than one <a>verification relationship</a>.
+<a>Verification methods</a> can be embedded in or referenced from properties
+associated with various <a>verification relationships</a> as described in <a
+href="#verification-relationships"></a>. Referencing <a>verification methods</a>
+allows them to be used by more than one <a>verification relationship</a>.
         </p>
 
         <p>
-If the value of a <a>verification method</a> property is a
-<a data-cite="INFRA#ordered-map">map</a>, the <a>verification method</a> has
-been embedded and its properties can be accessed directly. However, if the
-value is a URL <a data-cite="INFRA#string">string</a>, the <a>verification
-method</a> has been included by reference and its properties will need to be
-retrieved from elsewhere in the <a>DID document</a> or from another <a>DID
-document</a>. This is done by dereferencing the URL and searching the
-resulting resource for a <a>verification method</a>
-<a data-cite="INFRA#ordered-map">map</a> with an <code>id</code> property
-whose value matches the URL.
+If the value of a <a>verification method</a> property is a <a
+data-cite="INFRA#ordered-map">map</a>, the <a>verification method</a> has been
+embedded and its properties can be accessed directly. However, if the value is a
+URL <a data-cite="INFRA#string">string</a>, the <a>verification method</a> has
+been included by reference and its properties will need to be retrieved from
+elsewhere in the <a>DID document</a> or from another <a>DID document</a>. This
+is done by dereferencing the URL and searching the resulting resource for a
+<a>verification method</a> <a data-cite="INFRA#ordered-map">map</a> with an
+<code>id</code> property whose value matches the URL.
         </p>
 
         <pre class="example nohighlight"
@@ -1954,7 +1952,8 @@ whose value matches the URL.
 <span class="comment">...</span>
 
   "authentication": [
-    <span class="comment">// this key is referenced, it may be used with more than one verification relationship</span>
+    <span class="comment">// this key is referenced and might be used by</span>
+    <span class="comment">// more than one verification relationship</span>
     "did:example:123456789abcdefghi#keys-1",
     <span class="comment">// this key is embedded and may *only* be used for authentication</span>
     {

--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,8 @@ data-cite="INFRA#ordered-map">map</a> MUST include the <code>id</code>,
 <code>type</code>, <code>controller</code>, and specific verification material
 properties that are determined by the value of <code>type</code> and are defined
 in <a href="#verification-material"></a>. A <a>verification method</a> MAY
-include additional properties.
+include additional properties. <a>Verification methods</a> SHOULD be registered
+in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
           </p>
 
           <dl>
@@ -1781,6 +1782,7 @@ href="#did-syntax"></a>.
             </dd>
           </dl>
         </dd>
+      </dl>
 
       <pre class="example" title="Example verification method structure">
 {
@@ -1820,67 +1822,67 @@ using the <code><a>controller</a></code> property at the highest level of the
         <h3>Verification Material</h3>
 
         <p>
-A public key can be used as a <a>verification method</a>.
+Verification material is defined as any information that is used by a process
+that applies a <a>verification method</a> and is typically determined by the
+value of the <a>verification method</a>'s <code>type</code> property. Examples
+of verification material properties are <code><a>publicKeyJwk</a></code> or
+<code><a>publicKeyBase58</a></code>. A verification suite definition is
+responsible for specifying the <a>verification method</a> <code>type</code> and
+its associated verification material. For example, see <a
+href="https://w3c-ccg.github.io/lds-jws2020/">JSON Web Signature 2020</a> and <a
+href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519 Signature 2018</a>.
+For all registered <a>verification method</a> types and associated  verification
+material available for <a>DIDs</a>, please see the DID Specification Registries
+[[?DID-SPEC-REGISTRIES]].
         </p>
 
         <p>
-This specification strives to limit the number of formats for expressing public
-key material in a <a>DID document</a> to the fewest possible, to increase the
-likelihood of interoperability. The fewer formats that implementers have to
+In order to increase the likelihood of interoperability, this specification
+limits the number of formats for expressing verification material in a <a>DID
+document</a> to the fewest possible. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
 approach attempts to strike a delicate balance between ease of implementation
-and supporting formats that have historically had broad deployment.
-        </p>
-
-        <p>
-A suite definition is responsible for specifying the <a>verification method</a>
-<code>type</code> and proof <code>type</code>. For example, see
-<a href="https://w3c-ccg.github.io/lds-jws2020/">JSON Web Signature 2020</a> and
-<a href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519 Signature
-2018</a>. For all registered and supported <a>verification method</a> types
-available for <a>DIDs</a>, please see the DID Specification Registries
-[[?DID-SPEC-REGISTRIES]].
-        </p>
-
-        <p>
-The property used is determined by the value of the
-<code>type</code> property. Examples of such properties are
-<code><a>publicKeyJwk</a></code> or <code><a>publicKeyBase58</a></code>;
-others can be found in the DID Specification Registries
-[[?DID-SPEC-REGISTRIES]].
+and supporting formats that have historically had broad deployment. The two most
+common supported verification material properties are listed below:
         </p>
 
         <dl>
+          <dt><dfn>publicKeyBase58</dfn></dt>
+          <dd>
+            <p>
+The <code>publicKeyBase58</code> property is OPTIONAL. This feature is
+non-normative. If present, the value MUST be a <a
+data-cite="INFRA#string">string</a> representation of a [[?BASE58]] encoded
+public key.
+            </p>
+            <p class="issue atrisk"
+               title="publicKeyBase58 and publicKeyMultibase">
+The DID Working Group is seeking implementer feedback on the preference of the
+ecosystem with respect to using <code>publicKeyBase58</code> [[?BASE58]]  or
+<code>publicKeyMultibase</code> [[?MULTIBASE]]. The latter can be used for
+encoding more base-representation formats and provides a more future proof path.
+Depending on implementer feedback, one or both options might be included in the
+final specification, or migrated into the DID Specification Registries as an
+extension.
+             </p>
+          </dd>
           <dt><dfn>publicKeyJwk</dfn></dt>
           <dd>
+            <p>
 The <code>publicKeyJwk</code> property is OPTIONAL. If present, the value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
 conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-contain "d", or any other members of the private information class as
-described in <a
-href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration
-Template</a>.
-          </dd>
-          <dt><dfn>publicKeyBase58</dfn></dt>
-          <dd>
-The <code>publicKeyBase58</code> property is OPTIONAL. If present, the value
-MUST be a <a data-cite="INFRA#string">string</a> representation of a base58btc
-encoded public key.
+contain "d", or any other members of the private information class as described
+in <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration
+Template</a>. It is RECOMMENDED that verification methods that use JWKs
+[[RFC7517]] to represent their public keys use the value of <code>kid</code> as
+their <a href="#fragment">fragment identifier</a>. It is RECOMMENDED that JWK
+<code>kid</code> values are set to the public key fingerprint [[RFC7638]]. See
+the first key in <a href="#example-various-verification-method-types"></a> for
+an example of a public key with a compound key identifier.
+            </p>
           </dd>
       </dl>
-
-        <p>
-In the case where a verification method is a public key, the value of the
-<code><a>id</a></code> property might contain a
-<a href="#fragment">fragment</a>. This is
-especially useful for integrating with existing key management systems and key
-formats such as JWK [[RFC7517]]. It is RECOMMENDED that verification methods
-that use JWKs to represent their public keys use the value of <code>kid</code>
-as their fragment identifier. It is RECOMMENDED that JWK <code>kid</code>
-values are set to the public key fingerprint [[RFC7638]]. See the first key
-in <a href="#example-various-verification-method-types"></a>
-for an example of a public key with a compound key identifier.
-        </p>
 
         <p>
 A <a>verification method</a> MUST NOT contain multiple verification material
@@ -1890,29 +1892,13 @@ properties for the same material. For example, expressing key material in a
         </p>
 
         <p>
-In order to maximize interoperability, support for public keys as
-<a>verification methods</a> is restricted: see
-<a href="#verification-method-types"></a>. For other types of <a>verification
-method</a>, the <a>verification method</a> SHOULD be registered in the DID
-Specification Registries [[?DID-SPEC-REGISTRIES]].
-        </p>
-
-        <p>
-The <a>DID document</a> does not express revoked keys using a <a>verification
-relationship</a>.
-        </p>
-        <p>
-If a referenced verification method is not in the <a>DID Document</a> used to
-dereference it, then that verification method is considered invalid or revoked.
-        </p>
-        <p>
-Each <a>DID method</a> specification is expected to detail how revocation is
-performed and tracked.
+An example of a <a>DID document</a> containing <a>verification methods</a> using
+both properties above is shown below.
         </p>
 
         <pre id="example-various-verification-method-types"
           class="example nohighlight"
-          title="Various verification method types">
+          title="Verification methods using publicKeyJwk and publicKeyBase58">
 {
   "@context": "https://www.w3.org/ns/did/v1",
   "id": "did:example:123456789abcdefghi",
@@ -2009,6 +1995,13 @@ relationship</a>. For example, a <a>verification method</a> in the value of
 the <code><a>authentication</a></code> property cannot be used to engage in
 key agreement protocols with the <a>DID subject</a>&mdash;the value of the
 <code><a>keyAgreement</a></code> property needs to be used for that.
+      </p>
+      <p>
+The <a>DID document</a> does not express revoked keys using a <a>verification
+relationship</a>. If a referenced verification method is not in the <a>DID
+Document</a> used to dereference it, then that verification method is considered
+invalid or revoked. Each <a>DID method</a> specification is expected to detail
+how revocation is performed and tracked.
       </p>
       <p>
 This specification defines several <a>verification relationships</a> below. A
@@ -4722,7 +4715,7 @@ own discretion.
       </p>
 
       <p class="note">
-As described in Section <a href="#verification-method-types"></a>,
+As described in <a href="#verification-material"></a>,
 absence of a verification method is the only form of revocation that
 applies to all DID Methods.
       </p>

--- a/index.html
+++ b/index.html
@@ -1732,131 +1732,59 @@ override malicious activity by an attacker. See Section
       <h2>Verification Methods</h2>
       <p>
 A <a>DID document</a> can express <a>verification methods</a>, such as
-cryptographic keys, which can be used to <a>authenticate</a>1 or authorize interactions
-with the <a>DID subject</a> or associated parties. The information expressed
-often includes globally unambiguous identifiers and public key material, which
-can be used to verify digital signatures. For example, a public key can be
-used as a <a>verification method</a> with respect to a digital signature; in such
-usage, it verifies that the signer possessed the associated private key.
-      </p>
-      <p>
-<a>Verification methods</a> might take many parameters. An example of this is a set
-of five cryptographic keys from which any three are required to contribute to
-a threshold signature. Methods need not be cryptographic.
-      </p>
-
-      <p>
-In order to maximize interoperability, support for public keys as
-<a>verification methods</a> is restricted: see
-<a href="#verification-method-types"></a>. For other types of <a>verification
-method</a>, the <a>verification method</a> SHOULD be registered in the DID
-Specification Registries [[?DID-SPEC-REGISTRIES]].
+cryptographic public keys, which can be used to <a>authenticate</a> or authorize
+interactions with the <a>DID subject</a> or associated parties. For example, a
+cryptographic public key can be used as a <a>verification method</a> with
+respect to a digital signature; in such usage, it verifies that the signer
+possessed the associated cryptographic private key. <a>Verification methods</a>
+might take many parameters. An example of this is a set of five cryptographic
+keys from which any three are required to contribute to a cryptographic
+threshold signature.
       </p>
 
       <dl>
         <dt><dfn>verificationMethod</dfn></dt>
         <dd>
           <p>
-The <code>verificationMethod</code> property is OPTIONAL. If present, the
-value MUST be an <a data-cite="INFRA#ordered-set">ordered
-set</a> of <a>verification methods</a>, where each <a>verification method</a> is described by
-a <a data-cite="INFRA#ordered-map">map</a>. The <a>verification method</a>
-<a data-cite="INFRA#ordered-map">map</a> MUST include the <code>id</code>,
-<code>type</code>, <code>controller</code>, and specific verification method
-properties as determined by the value of <code>type</code>, and MAY include
-additional properties.
-          </p>
-          <p>
-The value of the <code><a>id</a></code> property for a <a>verification method</a>
-MUST be a <a data-cite="INFRA#string">string</a> that conforms to the rules in
-Section <a href="#did-url-syntax"></a>. When more than one <a>verification method</a>
-is present, the value of <code><a>verificationMethod</a></code> MUST NOT
-contain multiple entries with the same <code>id</code>. If the value of
-<code><a>verificationMethod</a></code> contains multiple entries with the same
-<code>id</code>, a <a>DID document</a> processor MUST produce an error.
+The <code>verificationMethod</code> property is OPTIONAL. If present, the value
+MUST be an <a data-cite="INFRA#ordered-set">ordered set</a> of <a>verification
+methods</a>, where each <a>verification method</a> is expressed using a <a
+data-cite="INFRA#ordered-map">map</a>. The <a>verification method</a> <a
+data-cite="INFRA#ordered-map">map</a> MUST include the <code>id</code>,
+<code>type</code>, <code>controller</code>, and specific verification material
+properties that are determined by the value of <code>type</code> and are defined
+in <a href="#verification-material"></a>. A <a>verification method</a> MAY
+include additional properties.
           </p>
 
-          <p>
-In the case where a <a>verification method</a> is a public key, the value of the
-<code><a>id</a></code> property might be structured as a
-<a href="https://en.wikipedia.org/wiki/Compound_key">compound key</a>. This is
-especially useful for integrating with existing key management systems and key
-formats such as JWK [[RFC7517]]. It is RECOMMENDED that JWK <code>kid</code>
-values are set to the public key fingerprint [[RFC7638]]. It is RECOMMENDED
-that verification methods that use JWKs to represent their public keys utilize
-the value of <code>kid</code> as their fragment identifier. See the first key
-in <a href="#example-various-verification-method-types"></a>
-for an example of a public key with a compound key identifier.
-          </p>
-
-          <p>
+          <dl>
+            <dt>id</dt>
+            <dd>
+              <p>
+The value of the <code><a>id</a></code> property for a <a>verification
+method</a> MUST be a <a data-cite="INFRA#string">string</a> that conforms to the
+rules in Section <a href="#did-url-syntax"></a>.
+              </p>
+            </dd>
+            <dt>type</dt>
+            <dd>
 The value of the <code>type</code> property MUST be exactly one <a>verification
 method</a> type. In order to maximize global interoperability, the
 <a>verification method</a> type SHOULD be registered in the DID Specification
 Registries [[?DID-SPEC-REGISTRIES]].
-          </p>
-          <p>
+            </dd>
+            <dt>controller</dt>
+            <dd>
 The value of the <code>controller</code> property MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
 href="#did-syntax"></a>.
-          </p>
-          <p>
-The value of the <code>type</code> property MUST be exactly one verification
-method type expressed as a <a data-cite="INFRA#string">string</a>. In order to
-maximize interoperability, the <a>verification method</a> type SHOULD be
-registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
-          </p>
-
-          <p>
-A <a>verification method</a> MUST contain a property to express verification
-material. The property used is determined by the value of the
-<code>type</code> property. Examples of such properties are
-<code><a>publicKeyJwk</a></code> or <code><a>publicKeyBase58</a></code>;
-others can be found in the DID Specification Registries
-[[?DID-SPEC-REGISTRIES]].
-          </p>
-
-          <p>
-A <a>verification method</a> MUST NOT contain multiple verification material
-properties for the same material. For example, expressing key material in a
-<a>verification method</a> using both <code>publicKeyJwk</code> and
-<code>publicKeyBase58</code> at the same time is prohibited.
-          </p>
+            </dd>
+          </dl>
         </dd>
-        <dt><dfn>publicKeyJwk</dfn></dt>
-        <dd>
-The <code>publicKeyJwk</code> property is OPTIONAL. If present, the value MUST
-be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
-conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-contain "d", or any other members of the private information class as
-described in <a
-href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration
-Template</a>.
-        </dd>
-        <dt><dfn>publicKeyBase58</dfn></dt>
-        <dd>
-The <code>publicKeyBase58</code> property is OPTIONAL. If present, the value
-MUST be a <a data-cite="INFRA#string">string</a> representation of a base58btc
-encoded public key.
-        </dd>
-      </dl>
 
-      <p>
-In the case where a verification method is a public key, the value of the
-<code><a>id</a></code> property might contain a
-<a href="#fragment">fragment</a>. This is
-especially useful for integrating with existing key management systems and key
-formats such as JWK [[RFC7517]]. It is RECOMMENDED that verification methods
-that use JWKs to represent their public keys use the value of <code>kid</code>
-as their fragment identifier. It is RECOMMENDED that JWK <code>kid</code>
-values are set to the public key fingerprint [[RFC7638]]. See the first key
-in <a href="#example-various-verification-method-types"></a>
-for an example of a public key with a compound key identifier.
-      </p>
-
-      <pre class="example" title="Example verification methods">
+      <pre class="example" title="Example verification method structure">
 {
-  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/v1"],
+  "@context": "https://www.w3.org/ns/did/v1",
   "id": "did:example:123456789abcdefghi",
   <span class="comment">...</span>
   "verificationMethod": [{
@@ -1876,18 +1804,140 @@ for an example of a public key with a compound key identifier.
       <p class="note"
         title="Verification method controller(s) and DID controller(s)">
 The semantics of the <code>controller</code> property are the same when the
-subject of the relationship is the <a>DID document</a> as when the subject
-of the relationship is a <a>verification method</a>, such as a public key. Since a
-key (for example) can't control itself, and the key controller cannot be
-inferred from the <a>DID document</a>, it is necessary to explicitly express
-the identity of the controller of the key. The difference is that the value of
-<code>controller</code> for a <a>verification method</a> is <em>not</em> necessarily
-a <a>DID controller</a>. <a>DID controller(s)</a> are expressed using the
-<code><a>controller</a></code> property at the highest level of the
-<a>DID document</a> (the topmost <a data-cite="INFRA#ordered-map">map</a> in
-the <a href="#data-model">data model</a>); see
-<a href="#did-controller"></a>.
+subject of the relationship is the <a>DID document</a> as when the subject of
+the relationship is a <a>verification method</a>, such as a cryptographic public
+key. Since a key can't control itself, and the key controller cannot be inferred
+from the <a>DID document</a>, it is necessary to explicitly express the identity
+of the controller of the key. The difference is that the value of
+<code>controller</code> for a <a>verification method</a> is <em>not</em>
+necessarily a <a>DID controller</a>. <a>DID controller(s)</a> are expressed
+using the <code><a>controller</a></code> property at the highest level of the
+<a>DID document</a> (the topmost <a data-cite="INFRA#ordered-map">map</a> in the
+<a href="#data-model">data model</a>); see <a href="#did-controller"></a>.
       </p>
+
+      <section>
+        <h3>Verification Material</h3>
+
+        <p>
+A public key can be used as a <a>verification method</a>.
+        </p>
+
+        <p>
+This specification strives to limit the number of formats for expressing public
+key material in a <a>DID document</a> to the fewest possible, to increase the
+likelihood of interoperability. The fewer formats that implementers have to
+implement, the more likely it will be that they will support all of them. This
+approach attempts to strike a delicate balance between ease of implementation
+and supporting formats that have historically had broad deployment.
+        </p>
+
+        <p>
+A suite definition is responsible for specifying the <a>verification method</a>
+<code>type</code> and proof <code>type</code>. For example, see
+<a href="https://w3c-ccg.github.io/lds-jws2020/">JSON Web Signature 2020</a> and
+<a href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519 Signature
+2018</a>. For all registered and supported <a>verification method</a> types
+available for <a>DIDs</a>, please see the DID Specification Registries
+[[?DID-SPEC-REGISTRIES]].
+        </p>
+
+        <p>
+The property used is determined by the value of the
+<code>type</code> property. Examples of such properties are
+<code><a>publicKeyJwk</a></code> or <code><a>publicKeyBase58</a></code>;
+others can be found in the DID Specification Registries
+[[?DID-SPEC-REGISTRIES]].
+        </p>
+
+        <dl>
+          <dt><dfn>publicKeyJwk</dfn></dt>
+          <dd>
+The <code>publicKeyJwk</code> property is OPTIONAL. If present, the value MUST
+be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
+conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
+contain "d", or any other members of the private information class as
+described in <a
+href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration
+Template</a>.
+          </dd>
+          <dt><dfn>publicKeyBase58</dfn></dt>
+          <dd>
+The <code>publicKeyBase58</code> property is OPTIONAL. If present, the value
+MUST be a <a data-cite="INFRA#string">string</a> representation of a base58btc
+encoded public key.
+          </dd>
+      </dl>
+
+        <p>
+In the case where a verification method is a public key, the value of the
+<code><a>id</a></code> property might contain a
+<a href="#fragment">fragment</a>. This is
+especially useful for integrating with existing key management systems and key
+formats such as JWK [[RFC7517]]. It is RECOMMENDED that verification methods
+that use JWKs to represent their public keys use the value of <code>kid</code>
+as their fragment identifier. It is RECOMMENDED that JWK <code>kid</code>
+values are set to the public key fingerprint [[RFC7638]]. See the first key
+in <a href="#example-various-verification-method-types"></a>
+for an example of a public key with a compound key identifier.
+        </p>
+
+        <p>
+A <a>verification method</a> MUST NOT contain multiple verification material
+properties for the same material. For example, expressing key material in a
+<a>verification method</a> using both <code>publicKeyJwk</code> and
+<code>publicKeyBase58</code> at the same time is prohibited.
+        </p>
+
+        <p>
+In order to maximize interoperability, support for public keys as
+<a>verification methods</a> is restricted: see
+<a href="#verification-method-types"></a>. For other types of <a>verification
+method</a>, the <a>verification method</a> SHOULD be registered in the DID
+Specification Registries [[?DID-SPEC-REGISTRIES]].
+        </p>
+
+        <p>
+The <a>DID document</a> does not express revoked keys using a <a>verification
+relationship</a>.
+        </p>
+        <p>
+If a referenced verification method is not in the <a>DID Document</a> used to
+dereference it, then that verification method is considered invalid or revoked.
+        </p>
+        <p>
+Each <a>DID method</a> specification is expected to detail how revocation is
+performed and tracked.
+        </p>
+
+        <pre id="example-various-verification-method-types"
+          class="example nohighlight"
+          title="Various verification method types">
+{
+  "@context": "https://www.w3.org/ns/did/v1",
+  "id": "did:example:123456789abcdefghi",
+  <span class="comment">...</span>
+  "verificationMethod": [{
+    "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
+    "type": "JsonWebKey2020", <span class="comment">// external (property value)</span>
+    "controller": "did:example:123",
+    "publicKeyJwk": {
+      "crv": "Ed25519", <span class="comment">// external (property name)</span>
+      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ", <span class="comment">// external (property name)</span>
+      "kty": "OKP", <span class="comment">// external (property name)</span>
+      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A" <span class="comment">// external (property name)</span>
+    }
+  }, {
+    "id": "did:example:123456789abcdefghi#keys-1",
+    "type": "Ed25519VerificationKey2018", <span class="comment">// external (property value)</span>
+    "controller": "did:example:pqrstuvwxyz0987654321",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+  }],
+  <span class="comment">...</span>
+}
+        </pre>
+
+      </section>
 
       <section>
         <h3>Verification Methods by reference</h3>
@@ -1932,74 +1982,6 @@ whose value matches the URL.
 <span class="comment">...</span>
 }
         </pre>
-      </section>
-
-      <section>
-        <h3>Verification Method types</h3>
-
-        <p>
-A public key can be used as a <a>verification method</a>.
-        </p>
-
-        <p>
-This specification strives to limit the number of formats for expressing public
-key material in a <a>DID document</a> to the fewest possible, to increase the
-likelihood of interoperability. The fewer formats that implementers have to
-implement, the more likely it will be that they will support all of them. This
-approach attempts to strike a delicate balance between ease of implementation
-and supporting formats that have historically had broad deployment.
-        </p>
-
-        <p>
-A suite definition is responsible for specifying the <a>verification method</a>
-<code>type</code> and proof <code>type</code>. For example, see
-<a href="https://w3c-ccg.github.io/lds-jws2020/">JSON Web Signature 2020</a> and
-<a href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519 Signature
-2018</a>. For all registered and supported <a>verification method</a> types
-available for <a>DIDs</a>, please see the DID Specification Registries
-[[?DID-SPEC-REGISTRIES]].
-        </p>
-
-        <p>
-The <a>DID document</a> does not express revoked keys using a <a>verification
-relationship</a>.
-        </p>
-        <p>
-If a referenced verification method is not in the <a>DID Document</a> used to
-dereference it, then that verification method is considered invalid or revoked.
-        </p>
-        <p>
-Each <a>DID method</a> specification is expected to detail how revocation is
-performed and tracked.
-        </p>
-
-        <pre id="example-various-verification-method-types"
-          class="example nohighlight"
-          title="Various verification method types">
-{
-  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/v1"],
-  "id": "did:example:123456789abcdefghi",
-  <span class="comment">...</span>
-  "verificationMethod": [{
-    "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
-    "type": "JsonWebKey2020", <span class="comment">// external (property value)</span>
-    "controller": "did:example:123",
-    "publicKeyJwk": {
-      "crv": "Ed25519", <span class="comment">// external (property name)</span>
-      "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ", <span class="comment">// external (property name)</span>
-      "kty": "OKP", <span class="comment">// external (property name)</span>
-      "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A" <span class="comment">// external (property name)</span>
-    }
-  }, {
-    "id": "did:example:123456789abcdefghi#keys-1",
-    "type": "Ed25519VerificationKey2018", <span class="comment">// external (property value)</span>
-    "controller": "did:example:pqrstuvwxyz0987654321",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
-  }],
-  <span class="comment">...</span>
-}
-        </pre>
-
       </section>
     </section>
 
@@ -2481,6 +2463,13 @@ media type in the document's metadata. Consumers MUST determine the
 <a>representation</a> of a <a>DID document</a> via the <code>contentType</code> <a>DID
 resolver</a> metadata field (see <a href="#did-resolution"></a>), <em>not</em>
 through the content of the <a>DID document</a> alone.
+    </p>
+
+    <p>
+A <a>conforming producer</a>
+MUST NOT produce a <a>DID document</a> containing different entries with
+the same <code>id</code> value. A <a>conforming consumer</a> MUST produce
+an error if it detects different entries with the same <code>id</code> value.
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -1736,7 +1736,7 @@ cryptographic public keys, which can be used to <a>authenticate</a> or authorize
 interactions with the <a>DID subject</a> or associated parties. For example, a
 cryptographic public key can be used as a <a>verification method</a> with
 respect to a digital signature; in such usage, it verifies that the signer
-possessed the associated cryptographic private key. <a>Verification methods</a>
+could use the associated cryptographic private key. <a>Verification methods</a>
 might take many parameters. An example of this is a set of five cryptographic
 keys from which any three are required to contribute to a cryptographic
 threshold signature.
@@ -1812,7 +1812,7 @@ key. Since a key can't control itself, and the key controller cannot be inferred
 from the <a>DID document</a>, it is necessary to explicitly express the identity
 of the controller of the key. The difference is that the value of
 <code>controller</code> for a <a>verification method</a> is <em>not</em>
-necessarily a <a>DID controller</a>. <a>DID controller(s)</a> are expressed
+necessarily a <a>DID controller</a>. <a>DID controllers</a> are expressed
 using the <code><a>controller</a></code> property at the highest level of the
 <a>DID document</a> (the topmost <a data-cite="INFRA#ordered-map">map</a> in the
 <a href="#data-model">data model</a>); see <a href="#did-controller"></a>.
@@ -1822,28 +1822,29 @@ using the <code><a>controller</a></code> property at the highest level of the
         <h3>Verification Material</h3>
 
         <p>
-Verification material is defined as any information that is used by a process
-that applies a <a>verification method</a> and is typically determined by the
-value of the <a>verification method</a>'s <code>type</code> property. Examples
+Verification material is any information that is used by a process
+that applies a <a>verification method</a>. The <code>type</code>
+of a <a>verification method</a> is expected to be used to determine
+its compatibility with such processes. Examples
 of verification material properties are <code><a>publicKeyJwk</a></code> or
 <code><a>publicKeyBase58</a></code>. A verification suite definition is
 responsible for specifying the <a>verification method</a> <code>type</code> and
 its associated verification material. For example, see <a
 href="https://w3c-ccg.github.io/lds-jws2020/">JSON Web Signature 2020</a> and <a
 href="https://w3c-ccg.github.io/lds-ed25519-2018/">Ed25519 Signature 2018</a>.
-For all registered <a>verification method</a> types and associated  verification
+For all registered <a>verification method</a> types and associated verification
 material available for <a>DIDs</a>, please see the DID Specification Registries
 [[?DID-SPEC-REGISTRIES]].
         </p>
 
         <p>
-In order to increase the likelihood of interoperability, this specification
+To increase the likelihood of interoperable implementations, this specification
 limits the number of formats for expressing verification material in a <a>DID
-document</a> to the fewest possible. The fewer formats that implementers have to
+document</a>. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
 approach attempts to strike a delicate balance between ease of implementation
-and supporting formats that have historically had broad deployment. The two most
-common supported verification material properties are listed below:
+and supporting formats that have historically had broad deployment.
+Two supported verification material properties are listed below:
         </p>
 
         <dl>
@@ -1941,7 +1942,7 @@ embedded and its properties can be accessed directly. However, if the value is a
 URL <a data-cite="INFRA#string">string</a>, the <a>verification method</a> has
 been included by reference and its properties will need to be retrieved from
 elsewhere in the <a>DID document</a> or from another <a>DID document</a>. This
-is done by dereferencing the URL and searching the resulting resource for a
+is done by dereferencing the URL and searching the resulting <a>resource</a> for a
 <a>verification method</a> <a data-cite="INFRA#ordered-map">map</a> with an
 <code>id</code> property whose value matches the URL.
         </p>


### PR DESCRIPTION
This PR attempts to condense much of the language in the Verification Methods section, retitle some sections, and condense a few normative statements that were duplicates. It also introduces the concept that we're looking for feedback wrt. publicKeyBase58 and publicKeyMultibase as verification material properties. The editorial rework is significant, but all changes should be non-substantive.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/635.html" title="Last updated on Feb 16, 2021, 3:10 PM UTC (b19057c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/635/9b373a1...b19057c.html" title="Last updated on Feb 16, 2021, 3:10 PM UTC (b19057c)">Diff</a>