### PR TITLE
Adding definition of 'conforming DID URL dereferencer'

### DIFF
--- a/index.html
+++ b/index.html
@@ -712,6 +712,12 @@ and/or hardware that complies with the relevant normative statements in
 Section <a href="#resolution"></a>.
       </p>
 
+      <p>
+A <dfn>conforming DID URL dereferencer</dfn> is any algorithm realized as software
+and/or hardware that complies with the relevant normative statements in
+Section <a href="#resolution"></a>.
+      </p>
+
     </section>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -709,13 +709,13 @@ documents</a>.
       <p>
 A <dfn>conforming DID resolver</dfn> is any algorithm realized as software
 and/or hardware that complies with the relevant normative statements in
-Section <a href="#resolution"></a>.
+<a href="#did-resolution"></a>.
       </p>
 
       <p>
 A <dfn>conforming DID URL dereferencer</dfn> is any algorithm realized as software
 and/or hardware that complies with the relevant normative statements in
-Section <a href="#resolution"></a>.
+<a href="#did-url-dereferencing"></a>.
       </p>
 
     </section>


### PR DESCRIPTION
The definition is missing in the conformance section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shigeya/did-core/pull/643.html" title="Last updated on Feb 15, 2021, 10:17 AM UTC (043c7bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/643/d355bda...shigeya:043c7bf.html" title="Last updated on Feb 15, 2021, 10:17 AM UTC (043c7bf)">Diff</a>