### PR TITLE
references DID Spec registries for normative values to version properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2910,13 +2910,15 @@ valid according to the consumption rules.
             </p>
 
             <p>
-The value of <code>@context</code> MUST be exactly one of these values.
+The value of <code>@context</code> MUST be registered in the DID
+Specification Registries [[?DID-SPEC-REGISTRIES]].
             </p>
 
             <ul>
               <li>
 The <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON String</a>
-<code>https://www.w3.org/ns/did/v1</code>.
+being registered in the DID
+Specification Registries [[?DID-SPEC-REGISTRIES]].
                 <pre class="example">
 {
   "@context": "https://www.w3.org/ns/did/v1",
@@ -2927,7 +2929,8 @@ The <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON String</a>
               <li>
 A <a href="https://tools.ietf.org/html/rfc8259#section-5">JSON Array</a>,
 with first item the <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON
-String</a> <code>https://www.w3.org/ns/did/v1</code>, and subsequent items of
+  String</a> being a registered value in the DID Specification Registries
+[[?DID-SPEC-REGISTRIES]] and subsequent items of
 type <a href="https://tools.ietf.org/html/rfc8259#section-7">JSON String</a> or
 <a href="https://tools.ietf.org/html/rfc8259#section-4">JSON Object</a>.
                 <pre class="example">


### PR DESCRIPTION
This modification helps us to avoid having to have a normative errata change post recommendation status when we want to version the did context value. It coincides with PR https://github.com/w3c/did-spec-registries/pull/251 in the spec registries as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/645.html" title="Last updated on Feb 15, 2021, 1:14 AM UTC (765b49c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/645/d355bda...765b49c.html" title="Last updated on Feb 15, 2021, 1:14 AM UTC (765b49c)">Diff</a>