### PR TITLE
Remove Current Issues appendix.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5720,44 +5720,6 @@ practice to avoid dislosing unnecessary information in JWE headers.
   </section>
 
   <section class="appendix">
-    <h1>Current Issues</h1>
-
-    <p>
-The list of issues below are under active discussion and are likely to
-result in changes to this specification.
-    </p>
-
-<div class="issue" data-number="504">Issues in "Note on Persistence" in DID Syntax section</div>
-<div class="issue" data-number="495">`updated` property's initial value is not defined clearly</div>
-<div class="issue" data-number="468">Should "deactivated" be an error code?</div>
-<div class="issue" data-number="463">Naming classes of properties and syntax</div>
-<div class="issue" data-number="453">The relationship between Verifiable Data Registry and DID Document haven't shown in Figure 1</div>
-<div class="issue" data-number="452">Compound key is not clear and points to wikipedia not a normative definition</div>
-<div class="issue" data-number="447">Differentiate external properties in examples</div>
-<div class="issue" data-number="425">DID Spec Registries needs terminolgical criteria</div>
-<div class="issue" data-number="404">Precise specification of the DID Core Vocabulary</div>
-<div class="issue" data-number="399">DID Fragment semantics cleanup needed</div>
-<div class="issue" data-number="391">Section "Authentication and Verifiable Claims": Add subsection about key security</div>
-<div class="issue" data-number="386">need to clarify revocation vs. rotation</div>
-<div class="issue" data-number="373">Proposed Appendices on DID Identification Architecture</div>
-<div class="issue" data-number="370">Consider EFF / ACLU objections by distinguaishing accountable vs. voluntary DIDs</div>
-<div class="issue" data-number="337">When should did parameters be dropped?</div>
-<div class="issue" data-number="324">Privacy Considerations for service endpoints</div>
-<div class="issue" data-number="292">Horizontal Review Tracking</div>
-<div class="issue" data-number="291">PING Horizontal Review</div>
-<div class="issue" data-number="208">IETF did+ld+json media type registration</div>
-<div class="issue" data-number="199">Clarification on what DIDs might identify</div>
-<div class="issue" data-number="170">Public key "id" and "type" members duplicate JWK "kid" and "kty" members</div>
-<div class="issue" data-number="163">Uses of terms defined in the specification should be links to their definitions</div>
-<div class="issue" data-number="119">Horizontal Review: offer review opportunity to TAG</div>
-<div class="issue" data-number="118">Specification needs to be compliant with WCAG 2.0</div>
-<div class="issue" data-number="105">Horizontal Review: Accessibility self test</div>
-<div class="issue" data-number="104">Horizontal Review: Internationalization self test</div>
-<div class="issue" data-number="72">Privacy Considerations - Specifically call out GDPR</div>
-
-  </section>
-
-  <section class="appendix">
     <h1>Detailed Architecture Overview Diagram</h1>
     <p>
 Following is a diagram showing the relationships among


### PR DESCRIPTION
Remove the Current Issues appendix. We shouldn't have one when going into Candidate Recommendation because all issues have been either addressed or defered.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/649.html" title="Last updated on Feb 15, 2021, 3:55 PM UTC (34325de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/649/d355bda...34325de.html" title="Last updated on Feb 15, 2021, 3:55 PM UTC (34325de)">Diff</a>