### PR TITLE
Remove the IANA section for application/did+dag+cbor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5992,66 +5992,6 @@ according to the rules defined in <a href="#fragment"></a>.
       </p>
     </section>
 
-    <section>
-      <h2>application/did+dag+cbor</h2>
-      <dl>
-        <dt>Type name:</dt>
-        <dd>application</dd>
-        <dt>Subtype name:</dt>
-        <dd>did+dag+cbor</dd>
-        <dt>Required parameters:</dt>
-        <dd>None</dd>
-        <dt>Optional parameters:</dt>
-        <dd>None</dd>
-        <dt>Encoding considerations:</dt>
-        <dd>
-See <a data-cite="RFC8949#section-4.2.1">RFC&nbsp;8949, section 4.2.1</a>.
-        </dd>
-        <dt>Security considerations:</dt>
-        <dd>
-See <a data-cite="RFC8949#section-10">RFC&nbsp;8949, section 10</a> [[RFC8949]].
-        </dd>
-        <dt>Interoperability considerations:</dt>
-        <dd>Not Applicable</dd>
-        <dt>Published specification:</dt>
-        <dd>http://www.w3.org/TR/did-core/</dd>
-        <dt>Applications that use this media type:</dt>
-        <dd>
-Any application that requires an identifier that is decentralized, persistent,
-cryptographically verifiable, and resolvable. Applications typically consist of
-cryptographic identity systems, decentralized networks of devices, and
-websites that issue or verify W3C Verifiable Credentials.
-        </dd>
-        <dt>Additional information:</dt>
-        <dd>
-          <dl>
-            <dt>Magic number(s):</dt>
-            <dd>Not Applicable</dd>
-            <dt>File extension(s):</dt>
-            <dd>.did</dd>
-            <dt>Macintosh file type code(s):</dt>
-            <dd>TEXT</dd>
-          </dl>
-        </dd>
-        <dt>Person &amp; email address to contact for further information:</dt>
-        <dd>Ivan Herman &lt;ivan@w3.org&gt;</dd>
-        <dt>Intended usage:</dt>
-        <dd>Common</dd>
-        <dt>Restrictions on usage:</dt>
-        <dd>None</dd>
-        <dt>Author(s):</dt>
-        <dd>Drummond Reed, Manu Sporny, Markus Sabadello, Dave Longley, Christopher Allen</dd>
-        <dt>Change controller:</dt>
-        <dd>W3C</dd>
-      </dl>
-
-       <p>
-Fragment identifiers used with
-<a href="#application-did-dag-cbor">application/did+dag+cbor</a> are treated
-according to the rules defined in <a href="#fragment"></a>.
-      </p>
-    </section>
-
   </section>
 
   <section class="appendix">


### PR DESCRIPTION
This should have been removed by PR #593 https://github.com/w3c/did-core/pull/593/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L6254 ... but the section has somehow reappeared in the spec. Removing again. Harder, this time.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/650.html" title="Last updated on Feb 15, 2021, 5:20 PM UTC (631174a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/650/d355bda...631174a.html" title="Last updated on Feb 15, 2021, 5:20 PM UTC (631174a)">Diff</a>