### PR TITLE
Editorial change on the introductory para DID URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -802,8 +802,8 @@ Section <a href="#method-schemes"></a>.
 
       <p>
 A <a>DID URL</a> is a network location identifier for a specific
-<a>resource</a>. It can be used to identify things like <a>DID subjects</a>,
-<a>verification methods</a>, <a>services</a>, specific parts of a <a>DID
+<a>resource</a>. It can be used to identify things like representations
+of <a>DID subjects</a>, <a>verification methods</a>, <a>services</a>, specific parts of a <a>DID
 document</a>, or other resources.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -803,8 +803,8 @@ Section <a href="#method-schemes"></a>.
       <p>
 A <a>DID URL</a> is a network location identifier for a specific
 <a>resource</a>. It can be used to retrieve things like representations
-of <a>DID subjects</a>, <a>verification methods</a>, <a>services</a>, specific parts of a <a>DID
-document</a>, or other resources.
+of <a>DID subjects</a>, <a>verification methods</a>, <a>services</a>,
+specific parts of a <a>DID document</a>, or other resources.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -802,7 +802,7 @@ Section <a href="#method-schemes"></a>.
 
       <p>
 A <a>DID URL</a> is a network location identifier for a specific
-<a>resource</a>. It can be used to identify things like representations
+<a>resource</a>. It can be used to retrieve things like representations
 of <a>DID subjects</a>, <a>verification methods</a>, <a>services</a>, specific parts of a <a>DID
 document</a>, or other resources.
       </p>


### PR DESCRIPTION
This is the PR version of issue #647 on the introductory paragraph of [§3.2](https://w3c.github.io/did-core/#did-url-syntax).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/655.html" title="Last updated on Feb 16, 2021, 4:15 PM UTC (b769f1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/655/d355bda...b769f1d.html" title="Last updated on Feb 16, 2021, 4:15 PM UTC (b769f1d)">Diff</a>