### PR TITLE
Restore example of 'service' and 'relativeRef' parameters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -939,7 +939,7 @@ did:example:123?versionTime=2021-05-10T17:00:00Z
 
         <pre class="example nohighlight"
           title="A DID URL with a 'service' and a 'relativeRef' DID parameter">
-did:example:123?service=website&relativeRef=/credentials
+did:example:123?service=files&relativeRef=/resume.pdf
         </pre>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -937,6 +937,11 @@ identifier for a <a>resource</a>.
 did:example:123?versionTime=2021-05-10T17:00:00Z
         </pre>
 
+        <pre class="example nohighlight"
+          title="A DID URL with a 'service' and a 'relativeRef' DID parameter">
+did:example:123?service=agent&relativeRef=/credentials
+        </pre>
+
         <p>
 Some DID parameters are completely independent of of any specific <a>DID
 method</a> and function the same way for all <a>DIDs</a>. Other DID parameters

--- a/index.html
+++ b/index.html
@@ -939,7 +939,7 @@ did:example:123?versionTime=2021-05-10T17:00:00Z
 
         <pre class="example nohighlight"
           title="A DID URL with a 'service' and a 'relativeRef' DID parameter">
-did:example:123?service=agent&relativeRef=/credentials
+did:example:123?service=website&relativeRef=/credentials
         </pre>
 
         <p>


### PR DESCRIPTION
https://github.com/w3c/did-core/pull/627 removed an example of a DID URL with a `service` parameter. I think it would be helpful to have such an example, so this PR adds one again.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/657.html" title="Last updated on Feb 18, 2021, 2:09 PM UTC (be2cbcf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/657/7839264...be2cbcf.html" title="Last updated on Feb 18, 2021, 2:09 PM UTC (be2cbcf)">Diff</a>