### PR TITLE
Fix editorial and substantive issues in CBOR section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2948,7 +2948,7 @@ section will be removed from this specification.
         <h3>Production</h3>
 
         <p>
-All data structures expressed by the <a href="#data-model">data model</a>
+All <a>DID document</a> data structures expressed by the <a href="#data-model">data model</a>
 MUST be serialized to the CBOR <a>representation</a> according to the
 following <a>production</a> rules:
         </p>

--- a/index.html
+++ b/index.html
@@ -2931,6 +2931,12 @@ defined via the <code>@context</code>.
 
     <section>
       <h2>CBOR</h2>
+
+      <p>
+This section defines the <a>production</a> and <a>consumption</a> rules
+for the CBOR <a>representation</a>.
+      </p>
+
       <p class="issue atrisk">
 The Working Group is seeking volunteers to write tests for, and at least two
 independent and interoperable implementations of, the CBOR representation
@@ -2938,32 +2944,13 @@ during the Candidate Recommendation phase. If these goals are not met, this
 section will be removed from this specification.
       </p>
 
-      <p>
-Like Javascript Object Notation (JSON) [[RFC8259]], Concise Binary Object
-Representation (CBOR) [[RFC8949]] defines a set of formatting rules for the
-portable representation of structured data. CBOR is a more concise,
-machine-readable, language-independent data interchange format that is
-self-describing and has built-in semantics for interoperability.
-      </p>
-
-      <p>
-The following sections outline the rules for producing and consuming
-<a>DID documents</a> that are expressed in CBOR as indicated by a
-<code>contentType</code> of <code>application/did+cbor</code> in the resolver
-metadata.
-      </p>
-
       <section>
         <h3>Production</h3>
 
         <p>
-A <a>DID document</a> MUST be a single <a data-cite="RFC8949#section-3.1">CBOR
-Map</a> conforming to [[RFC8949]]. All topmost entries of the <a>DID
-document</a> MUST be represented by using the entry key as the name of the
-key of the CBOR Map. The values of entries of the <a href="#data-model">data
-model</a> described in Section <a href="#data-model"></a>, including all
-extensions, are encoded in CBOR [[RFC8949]] by mapping entry values to CBOR
-types as follows:
+All data structures expressed by the <a href="#data-model">data model</a>
+MUST be serialized to the CBOR <a>representation</a> according to the
+following <a>production</a> rules:
         </p>
 
         <table class="simple" id="cbor-representation-production">
@@ -2984,11 +2971,10 @@ CBOR Representation Type
 <a data-cite="INFRA#maps">ordered&nbsp;map</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5), each entry
-is represented as a member of the CBOR Map with the entry key, expressed as
-a <a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3</a>),
-as the key and the entry value according to its type, as defined in this
-section
+A <a data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5), where each
+entry is represented as a member of the CBOR map. The entry key is expressed
+as a <a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3) as the
+key and the entry value according to its type, as defined in this table.
               </td>
             </tr>
             <tr>
@@ -2996,9 +2982,9 @@ section
 <a data-cite="INFRA#list">list</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR array</a> (major type 4), each element
-of the list is added, in order, as a value of the array according to its type,
-as defined in this section
+A <a data-cite="RFC8949#section-3.1">CBOR array</a> (major type 4), where each
+element of the list is added, in order, as a value of the array according to its
+type, as defined in this table.
               </td>
             </tr>
             <tr>
@@ -3006,9 +2992,9 @@ as defined in this section
 <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR array</a> (major type 4), each element
-of the list is added, in order, as a value of the array according to its type,
-as defined in this section
+A <a data-cite="RFC8949#section-3.1">CBOR array</a> (major type 4), where each
+element of the list is added, in order, as a value of the array according to its
+type, as defined in this table.
               </td>
             </tr>
             <tr>
@@ -3016,7 +3002,7 @@ as defined in this section
 <a>datetime</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3) formatted as
+A <a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3) formatted as
 an <a data-cite="XMLSCHEMA11-2#dateTime">XML Datetime</a> normalized to
 UTC 00:00 and without sub-second decimal precision. For example:
 <code>2020-12-20T19:17:47Z</code>.
@@ -3027,7 +3013,7 @@ UTC 00:00 and without sub-second decimal precision. For example:
 <a data-cite="INFRA#string">string</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3)
+A <a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3).
               </td>
             </tr>
             <tr>
@@ -3035,8 +3021,8 @@ UTC 00:00 and without sub-second decimal precision. For example:
 <a>integer</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR integer</a> (major type 0 or 1),
-choosing the shortest byte representation
+A <a data-cite="RFC8949#section-3.1">CBOR integer</a> (major type 0 or 1),
+choosing the shortest byte representation.
               </td>
             </tr>
             <tr>
@@ -3044,7 +3030,7 @@ choosing the shortest byte representation
 <a>double</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.1">CBOR floating-point number</a> (major type
+A <a data-cite="RFC8949#section-3.1">CBOR floating-point number</a> (major type
 7). All floating point values MUST be encoded as 64-bits (additional type
 value 27), even for integral values.
               </td>
@@ -3054,8 +3040,8 @@ value 27), even for integral values.
 <a data-cite="INFRA#boolean">boolean</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.3">CBOR simple value</a> (major type 7,
-subtype 24) with a simple value of 21 (True) or 20 (False)
+A <a data-cite="RFC8949#section-3.3">CBOR simple value</a> (major type 7,
+subtype 24) with a simple value of 21 (true) or 20 (false).
               </td>
             </tr>
             <tr>
@@ -3063,36 +3049,48 @@ subtype 24) with a simple value of 21 (True) or 20 (False)
 <a data-cite="INFRA#null">null</a>
               </td>
               <td>
-<a data-cite="RFC8949#section-3.3">CBOR simple value</a> (major type 7,
-subtype 24) with a simple value of 22 (Null)
+A <a data-cite="RFC8949#section-3.3">CBOR simple value</a> (major type 7,
+subtype 24) with a simple value of 22 (null).
               </td>
             </tr>
           </tbody>
         </table>
 
-        <ul>
-          <li>
-Other Data Types not otherewise defined in the <a href="#data-model">data model</a> MUST be
-represented as a <a data-cite="RFC8949#section-3.1">CBOR
-String type</a> (major type 3).
-          </li>
+        <p>
+In addition to the data type production rules above, the following rules apply
+for <a>conforming producers</a> that serialize CBOR <a>representations</a>:
+        </p>
+        <ol>
           <li>
 Indefinite-length items are not allowed and MUST be made <a
-data-cite="RFC8949#section-3.2.2">CBOR definite
-length.</a>
+data-cite="RFC8949#section-3.2.2">CBOR definite length.</a>
           </li>
-        </ul>
+          <li>
+All CBOR tags MUST be retained regardless of whether they are optional.
+          </li>
+          <li>
+All four <a data-cite="RFC8949#section-4.2.1">Canonical CBOR rules</a>
+listed in [[RFC8949]] MUST be applied to all relevant data types.
+          </li>
+        </ol>
 
         <p>
-In addition to the production rules in this section, implementations
-MUST implement the four
-<a data-cite="RFC8949#section-4.2.1">Canonical CBOR rules</a>
-listed in [[RFC8949]]. All CBOR tags that appear in a message MUST be retained
-regardless of whether they are optional.
+All entries of a <a>DID document</a> MUST be included in the root <a
+data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5). Entries MAY contain
+additional data substructures subject to the value representation rules in the
+list above. When serializing a <a>DID document</a> in the CBOR
+<a>representation</a>, a <a>conforming producer</a> MUST specify a media type of
+<code>application/did+cbor</code> to downstream applications such as described
+in <a href="#did-resolution-metadata"></a>.
+        </p>
+
+        <p>
+The following examples express a CBOR <a>representation</a> of a
+<a>DID document</a> in hexidecimal notation, and in CBOR diagnostic notation:
         </p>
 
       <pre class="example nohighlight"
-        title="Example 2 DID Document encoded as CBOR (hexadecimal)">
+        title="DID Document encoded as CBOR (hexadecimal)">
 A2626964781E6469643A6578616D706C653A313233343536373839616263
 6465666768696E61757468656E7469636174696F6E81A462696478256469
 643A6578616D706C653A313233343536373839616263646566676869236B
@@ -3103,8 +3101,8 @@ A2626964781E6469643A6578616D706C653A313233343536373839616263
 6A5A70666B634A437744776E5A6E367A3377586D715056
       </pre>
 
-      <pre class="example nohighlight"
-        title="Example 2 DID Document encoded as CBOR (diagnostic notation)">
+      <pre style="font-size: 50%" class="example nohighlight"
+        title="DID Document encoded as CBOR (diagnostic notation)">
 A2                                   # map(2)
 62                                   # text(2)
    6964                              # "id"

--- a/index.html
+++ b/index.html
@@ -3134,15 +3134,11 @@ A2                                   # map(2)
 
       <section>
         <h3>Consumption</h3>
+
         <p>
-The topmost element MUST be a <a data-cite="RFC8949#section-3.1">CBOR map</a>
-(major type 5). Any other data type at the highest level of the
-<a>DID document</a> (the topmost <a data-cite="INFRA#ordered-map">map</a> in
-the <a href="#data-model">data model</a>) is an error and MUST be
-rejected. The topmost <a data-cite="RFC8949#section-3.1">CBOR map</a>
-represents the <a>DID document</a>, and all data items of this map are
-entries of the <a>DID document</a>. The data item key is the entry key,
-and the data item value is interpreted as follows:
+All data structures expressed by a CBOR <a>representation</a> MUST be
+deserialized into the <a href="#data-model">data model</a> according to the
+following <a>consumption</a> rules:
         </p>
 
         <table class="simple" id="cbor-representation-consumption">
@@ -3163,11 +3159,11 @@ Data&nbsp;Type
 <a data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5)
               </td>
               <td>
-<a data-cite="INFRA#maps">ordered&nbsp;map</a>, each data item of the CBOR map
-is added as an entry to the ordered map with the entry key being the data
-item name and the value converted based on the CBOR type and, if available,
-entry definition, as defined here; as no order can be enforced for general
-CBOR maps, no insertion order is guaranteed.
+An <a data-cite="INFRA#maps">ordered&nbsp;map</a>, where each data item of the
+CBOR map is added as an entry to the ordered map with the entry key being the
+data item name and the value converted based on the CBOR type and, if available,
+entry definition, as defined here; as no order can be enforced for general CBOR
+maps, no insertion order is guaranteed.
               </td>
             </tr>
             <tr>
@@ -3177,9 +3173,9 @@ href="#data-model">data model</a> entry value is a <a
 data-cite="INFRA#list">list</a> or unknown
               </td>
               <td>
-<a data-cite="INFRA#list">list</a>, each value of the
-<a data-cite="RFC8949#section-3.1">CBOR array</a> is added to the list in order,
-converted based on the CBOR type of the array value, as defined in this table
+A <a data-cite="INFRA#list">list</a>, where each value of the <a
+data-cite="RFC8949#section-3.1">CBOR array</a> is added to the list in order,
+converted based on the CBOR type of the array value, as defined in this table.
               </td>
             </tr>
             <tr>
@@ -3189,10 +3185,10 @@ href="#data-model">data model</a> entry value is an <a
 data-cite="INFRA#ordered-set">ordered&nbsp;set</a>
               </td>
               <td>
-<a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>, each value of the
-<a data-cite="RFC8949#section-3.1">CBOR array</a> is added to the ordered set
-in order, converted based on the CBOR type of the array value as defined
-in this table
+An <a data-cite="INFRA#ordered-set">ordered&nbsp;set</a>, where each value of
+the <a data-cite="RFC8949#section-3.1">CBOR array</a> is added to the ordered
+set in order, converted based on the CBOR type of the array value as defined in
+this table.
               </td>
             </tr>
             <tr>
@@ -3201,7 +3197,7 @@ in this table
 <a href="#data-model">data model</a> entry value is a <a>datetime</a>
               </td>
               <td>
-  <a>datetime</a>
+A <a>datetime</a>.
               </td>
             </tr>
             <tr>
@@ -3211,7 +3207,7 @@ href="#data-model">data model</a> entry value type is <a>string</a> or
 unknown
               </td>
               <td>
-<a data-cite="INFRA#string">string</a>
+A <a data-cite="INFRA#string">string</a>.
               </td>
             </tr>
             <tr>
@@ -3220,16 +3216,16 @@ unknown
 choosing the shortest byte representation
               </td>
               <td>
-<a>integer</a>
+An <a>integer</a>.
               </td>
             </tr>
             <tr>
               <td>
 <a data-cite="RFC8949#section-3.1">CBOR floating-point number</a> (major type
-7).
+7)
               </td>
               <td>
-<a>double</a>
+A <a>double</a>.
               </td>
             </tr>
             <tr>
@@ -3238,7 +3234,7 @@ choosing the shortest byte representation
 subtype 24) with a simple value of 21 (True) or 20 (False)
               </td>
               <td>
-<a data-cite="INFRA#boolean">boolean</a>
+A <a data-cite="INFRA#boolean">boolean</a>.
               </td>
             </tr>
             <tr>
@@ -3247,30 +3243,42 @@ subtype 24) with a simple value of 21 (True) or 20 (False)
 subtype 24) with a simple value of 22 (Null)
               </td>
               <td>
-<a data-cite="INFRA#null">null</a>
+A <a data-cite="INFRA#null">null</a> value.
               </td>
             </tr>
           </tbody>
         </table>
 
         <p>
-Additional Considerations:
+In addition to the data type consumption rules above, the following rules apply
+for <a>conforming consumers</a> that deserialize CBOR <a>representations</a>:
         </p>
 
-        <ul>
+        <ol>
           <li>
 <a data-cite="RFC8949#section-3.2.2">CBOR
-Indefinite-length items</a> are not allowed and MUST throw an Error.
+indefinite-length items</a> are not allowed and MUST produce an error.
           </li>
           <li>
-Duplicate key in the same CBOR map MUST throw an Error.
+A duplicate key in the same CBOR map MUST produce an error.
           </li>
           <li>
-<a data-cite="RFC8949#section-7.1">Unknown Additional
-Properties and Values</a> MUST be preserved by default
-and represented as major type 3 (UTF-8 String)
+All CBOR tags MUST be retained for CBOR <a>production</a> regardless of whether
+they are optional.
           </li>
-        </ul>
+        </ol>
+
+        <p>
+If media type information is available to a <a>conforming consumer</a> and the
+media type value is <code>application/did+json</code>: the data structure  being
+consumed is a <a>DID document</a> and the root element MUST be a <a
+data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5) where all members of
+the object are entries of the <a>DID document</a>. A <a>conforming consumer</a>
+for a CBOR <a>representation</a> that is consuming a <a>DID document</a> with a
+root element that is not a <a data-cite="RFC8949#section-3.1">CBOR map</a>
+(major type 5) MUST report an error.
+        </p>
+
 
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -2974,7 +2974,7 @@ CBOR Representation Type
 A <a data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5), where each
 entry is represented as a member of the CBOR map. The entry key is expressed
 as a <a data-cite="RFC8949#section-3.1">CBOR string</a> (major type 3) as the
-key and the entry value according to its type, as defined in this table.
+key, and the entry value according to its type, as defined in this table.
               </td>
             </tr>
             <tr>
@@ -3062,7 +3062,7 @@ for <a>conforming producers</a> that serialize CBOR <a>representations</a>:
         </p>
         <ol>
           <li>
-Indefinite-length items are not allowed and MUST be made <a
+Indefinite-length items are not allowed and MUST be made a <a
 data-cite="RFC8949#section-3.2.2">CBOR definite length.</a>
           </li>
           <li>
@@ -3078,14 +3078,14 @@ listed in [[RFC8949]] MUST be applied to all relevant data types.
 All entries of a <a>DID document</a> MUST be included in the root <a
 data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5). Entries MAY contain
 additional data substructures subject to the value representation rules in the
-list above. When serializing a <a>DID document</a> in the CBOR
+list above. When serializing a <a>DID document</a> to its CBOR
 <a>representation</a>, a <a>conforming producer</a> MUST specify a media type of
 <code>application/did+cbor</code> to downstream applications such as described
 in <a href="#did-resolution-metadata"></a>.
         </p>
 
         <p>
-The following examples express a CBOR <a>representation</a> of a
+The following examples express the CBOR <a>representation</a> of a
 <a>DID document</a> in hexidecimal notation, and in CBOR diagnostic notation:
         </p>
 
@@ -3270,8 +3270,8 @@ they are optional.
 
         <p>
 If media type information is available to a <a>conforming consumer</a> and the
-media type value is <code>application/did+json</code>: the data structure  being
-consumed is a <a>DID document</a> and the root element MUST be a <a
+media type value is <code>application/did+json</code>, then the data structure being
+consumed is a <a>DID document</a>, and the root element MUST be a <a
 data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5) where all members of
 the object are entries of the <a>DID document</a>. A <a>conforming consumer</a>
 for a CBOR <a>representation</a> that is consuming a <a>DID document</a> with a

--- a/index.html
+++ b/index.html
@@ -3275,36 +3275,6 @@ and represented as major type 3 (UTF-8 String)
         </ul>
 
       </section>
-
-      <section>
-        <h3>CBOR Extensibility</h3>
-        <p>
-In CBOR, one point of extensibility is with the use of CBOR tags. [[RFC8949]]
-defines a basic set of data types, as well as a tagging mechanism that enables
-extending the set of data types supported via the <a
-href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">IANA CBOR Tag
-Registry</a>. This allows for tags to enhance the semantic description of the
-data that follows.  Extensibility with CBOR tags also facilitates lossless
-conversion to other core <a>representations</a>. CBOR Tags number 21 to 23 indicate
-that a following byte string might require a specific encoding when
-interoperating with a text-based <a>representation</a> such as JSON.  These tags are
-useful when an encoder knows that the byte string data it is writing is likely
-to be later converted to a particular text-based usage such as JSON.  These
-three tag numbers suggest conversions to three of the base data encodings
-defined in [[RFC4648]].  Tag number 21 suggests conversion to base64url encoding
-(Section 5 of [[RFC4648]]), where padding is not used (see Section 3.2 of
-[[RFC4648]]); that is, all trailing equals signs ("=") are removed from the
-encoded string.  Tag number 22 suggests conversion to classical base64 encoding
-(Section 4 of [[RFC4648]] ), with padding as defined in [[RFC4648]].  For both
-base64url and base64, padding bits are set to zero (see Section 3.5 of
-[[RFC4648]] ), and encoding is performed without the inclusion of any line
-breaks, whitespace, or other additional characters.  Tag number 23 suggests
-conversion to base16 (hex) encoding, with uppercase alphabetics (see Section 8
-of [[RFC4648]]).  Note that, for all three tag numbers, the encoding of the
-empty byte string is the empty text string of other <a>representations</a>.
-        </p>
-
-      </section>
     </section>
   </section>
 


### PR DESCRIPTION
This PR reworks the CBOR section in the same way the JSON and JSON-LD sections were reworked. The changes are largely editorial or non-substantive, but there is one change that is substantive. 

There were rules regarding preserving "unknown data types"... except that there is no such thing in the ADM... we either know about the data type, or we can't represent it in the ADM. It is impossible for an "unknown data type" to exist in the ADM... all data types are known, or they're not representable. Similarly, it is impossible for a CBOR consumer to consume data with an unknown data type and preserve it in the ADM... because there is nowhere to put it (because the data type is unknown). You can't convert it to a string (which is what was specified) because the production rules would spit it out as a string (it wasn't a string when it was consumed -- so you'd get data corruption). I removed that normative statement because it was unimplementable.

There is also a rule that I'm concerned about, and that we handwave over, but is required if we want to preserve the CBOR Canonical Rules requirement. There is a requirement in CBOR Canonical Rules that you must specify whether you preserve CBOR Tags or not. If you don't, you can't round-trip from CBOR to some internal representation and back out to CBOR. The problem is that the ADM has no way to preserve the incoming CBOR Tags. So, the current consumption rules say: "CBOR tags MUST be retained for CBOR production". The production rules say "All CBOR tags MUST be retained regardless of whether they are optional." The statements are testable because you can provide a CBOR document with tags and fail if the same tags don't get added when you produce CBOR. In other words, if you can't round-trip, you don't have a conforming CBOR implementation... but honestly, this is a really high bar and it's not clear what we're getting out of it. The same is true for the CBOR Canonical Rules -- they're not easy to do exhaustive tests on... but I retained them because @jonnycrunch was so intent on having them in the spec.

So, keep an eye out for those items as you're reviewing.

/cc @jonnycrunch


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/663.html" title="Last updated on Feb 18, 2021, 2:30 PM UTC (4b201b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/663/24a6c92...4b201b5.html" title="Last updated on Feb 18, 2021, 2:30 PM UTC (4b201b5)">Diff</a>