### PR TITLE
Add additional note to Verification Method Revocation section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4727,6 +4727,9 @@ the DID controller.
 
     <div class="note">
       <p>
+Trustless systems are those where all trust is derived from cryptographically 
+provable assertions, and more specifically, where no metadata outside of the 
+cryptographic system is factored into the determination of trust in the system.
 To verify a signature of proof for a verification method which has been revoked
 in a trustless system, a DID method needs to support either or both of the
 `versionId` or `versionTime`, as well as both the `updated` and `nextUpdate`,

--- a/index.html
+++ b/index.html
@@ -4713,25 +4713,6 @@ assertion was made &mdash; is expected to apply. Without that guarantee, someone
 could discover a revoked key and use it to make cryptographically
 verifiable statements with a simulated date in the past.
 <br/><br/>
-For example, for a DID method that supports the `versionId` query parameter as
-well as the `updated` and `nextUpdate` DID document metadata properties, a
-verifier can validate a signature or proof of a revoked key if and only if 
-all of the following are true:
-  <ol>
-    <li>
-The proof or signature contains the `versionId` to refer to the DID document
-that was used at the point the signature or proof was created.
-    </li>
-    <li>
-The verifier can determine at what point in time the signature or proof was
-made, e.g., it was anchored on a blockchain.
-    </li>
-    <li>
-For the DID document resolved using `versionId`, the `updated` timestamp is
-before 2, and the `nextUpdate` timestamp is after 2.
-    </li>
-  </ol>
-<br/><br/>
 Some DID methods only allow the retrieval of the current state of a DID.
 When this is true, or when the state of a DID at the time of
 cryptographically verifiable statement cannot be reliably determined,
@@ -4744,6 +4725,23 @@ the DID controller.
     </section>
 
 
+    <p class="note">
+In order to verify a signature of proof for a verification method which has
+been revoked in a trustless system a DID meethod needs to support either
+`versionId` or `versionTime`, as well as the `updated` and `nextUpdate` DID
+document metadata properties. A verifier can validate a signature or proof of a
+revoked key if and only if all of the following are true:
+    <br/><br/>
+The proof or signature contains the `versionId` or `versionTime` to refer to
+the DID document that was used at the point the signature or proof was created.
+    <br/>
+The verifier can determine the point in time at which the signature or proof
+was made, e.g., it was anchored on a blockchain.
+    <br/>
+For the resolved DID document metadata, the `updated` timestamp is before, and
+the `nextUpdate` timestamp is after, the point in time at which the signature or
+proof was made.
+    </p>
 
     <section>
       <h2>DID Recovery</h2>

--- a/index.html
+++ b/index.html
@@ -4713,6 +4713,15 @@ assertion was made &mdash; is expected to apply. Without that guarantee, someone
 could discover a revoked key and use it to make cryptographically
 verifiable statements with a simulated date in the past.
 <br/><br/>
+For example, for a DID method that supports the `versionId` query parameter as
+well as the `updated` and `nextUpdate` DID document metadata properties, a
+verifier can validate a signature or proof of a revoked key iif: (1) the proof
+or signature contains the `versionId` to refer to the DID document that was
+used at the point the signature or proof was created. (2) The verifier can
+determine at what point in time the signature or proof was made (e.g. it was
+anchored on a blockchain). (3) For the DID document resolved using `versionId`,
+the `updated` timestamp is before 2 and the `nextUpdate` timestamp is after 2.
+<br/><br/>
 Some DID methods only allow the retrieval of the current state of a DID.
 When this is true, or when the state of a DID at the time of
 cryptographically verifiable statement cannot be reliably determined,

--- a/index.html
+++ b/index.html
@@ -4715,7 +4715,8 @@ verifiable statements with a simulated date in the past.
 <br/><br/>
 For example, for a DID method that supports the `versionId` query parameter as
 well as the `updated` and `nextUpdate` DID document metadata properties, a
-verifier can validate a signature or proof of a revoked key IFF:
+verifier can validate a signature or proof of a revoked key if and only if 
+all of the following are true:
   <ol>
     <li>
 The proof or signature contains the `versionId` to refer to the DID document

--- a/index.html
+++ b/index.html
@@ -4725,23 +4725,30 @@ the DID controller.
     </section>
 
 
-    <p class="note">
-In order to verify a signature of proof for a verification method which has
-been revoked in a trustless system a DID meethod needs to support either
-`versionId` or `versionTime`, as well as the `updated` and `nextUpdate` DID
-document metadata properties. A verifier can validate a signature or proof of a
-revoked key if and only if all of the following are true:
-    <br/><br/>
-The proof or signature contains the `versionId` or `versionTime` to refer to
-the DID document that was used at the point the signature or proof was created.
-    <br/>
+    <div class="note">
+      <p>
+To verify a signature of proof for a verification method which has been revoked
+in a trustless system, a DID method needs to support either or both of the
+`versionId` or `versionTime`, as well as both the `updated` and `nextUpdate`,
+DID document metadata properties. A verifier can validate a signature or proof
+of a revoked key if and only if all of the following are true:
+      </p>
+      <ul>
+        <li>
+The proof or signature includes the `versionId` or `versionTime` of the DID
+document that was used at the point the signature or proof was created.
+        </li>
+        <li>
 The verifier can determine the point in time at which the signature or proof
 was made, e.g., it was anchored on a blockchain.
-    <br/>
+        </li>
+        <li>
 For the resolved DID document metadata, the `updated` timestamp is before, and
 the `nextUpdate` timestamp is after, the point in time at which the signature or
 proof was made.
-    </p>
+        </li>
+      </ul>
+    </div>
 
     <section>
       <h2>DID Recovery</h2>

--- a/index.html
+++ b/index.html
@@ -4715,12 +4715,21 @@ verifiable statements with a simulated date in the past.
 <br/><br/>
 For example, for a DID method that supports the `versionId` query parameter as
 well as the `updated` and `nextUpdate` DID document metadata properties, a
-verifier can validate a signature or proof of a revoked key iif: (1) the proof
-or signature contains the `versionId` to refer to the DID document that was
-used at the point the signature or proof was created. (2) The verifier can
-determine at what point in time the signature or proof was made (e.g. it was
-anchored on a blockchain). (3) For the DID document resolved using `versionId`,
-the `updated` timestamp is before 2 and the `nextUpdate` timestamp is after 2.
+verifier can validate a signature or proof of a revoked key IFF:
+  <ol>
+    <li>
+The proof or signature contains the `versionId` to refer to the DID document
+that was used at the point the signature or proof was created.
+    </li>
+    <li>
+The verifier can determine at what point in time the signature or proof was
+made, e.g., it was anchored on a blockchain.
+    </li>
+    <li>
+For the DID document resolved using `versionId`, the `updated` timestamp is
+before 2, and the `nextUpdate` timestamp is after 2.
+    </li>
+  </ol>
 <br/><br/>
 Some DID methods only allow the retrieval of the current state of a DID.
 When this is true, or when the state of a DID at the time of


### PR DESCRIPTION
After some discussion around key revocation with @OR13 he suggested that I add some additional context on how to securely verify proofs / signatures that where made in the past with a revoked key.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/oed/did-core/pull/668.html" title="Last updated on Feb 26, 2021, 1:25 PM UTC (b8574e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/668/f768dd1...oed:b8574e5.html" title="Last updated on Feb 26, 2021, 1:25 PM UTC (b8574e5)">Diff</a>