### PR TITLE
Changed the DID terminology entry (see issue #672)

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -26,7 +26,7 @@ library, or a network call such as an HTTPS request.
 
   <dd>
 A globally unique persistent identifier that does not require a centralized
-registration authority because it is generated and/or registered
+registration authority and is often generated and/or registered
 cryptographically. The generic format of a DID is defined in <a
 href="#did-syntax"></a>. A specific <a>DID scheme</a> is defined in a <a>DID
 method</a> specification. Many—but not all—DID methods make use of


### PR DESCRIPTION
Moving the discussion here from #672: changing the description for DID-s in the terminology section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/676.html" title="Last updated on Feb 18, 2021, 4:59 PM UTC (5840240)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/676/bb89040...5840240.html" title="Last updated on Feb 18, 2021, 4:59 PM UTC (5840240)">Diff</a>