### PR TITLE
Added a remark whereby an ordered map is sometimes just referred to as "map".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1186,7 +1186,7 @@ Considerations
           </td>
           <td>
 A finite ordered sequence of key/value pairs, with no key appearing twice as
-specified in [[INFRA]].
+specified in [[INFRA]]. Sometimes referred to as just "map".
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
This remark is also present in the INFRA spec, and it is better to have it because our spec often just refers to a "map" instead of "ordered map".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/677.html" title="Last updated on Feb 18, 2021, 5:15 PM UTC (eb4b98f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/677/bb89040...eb4b98f.html" title="Last updated on Feb 18, 2021, 5:15 PM UTC (eb4b98f)">Diff</a>