### PR TITLE
Changed the note on semicolon usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,7 +844,7 @@ did-url = did path-abempty [ "?" query ] [ "#" fragment ]
       </table>
 
       <p class="note" title="Semicolon character is reserved for future use">
-        Although the semicolon (<code>;</code>) character may be used according to the rules of the DID URL syntax, future versions of this specification may use it as a sub-delimiter for parameters as described in [[?MATRIX-URIS]]]. To avoid future conflicts, developers should restrain using it.
+        Although the semicolon (<code>;</code>) character may be used according to the rules of the DID URL syntax, future versions of this specification may use it as a sub-delimiter for parameters as described in [[?MATRIX-URIS]]]. To avoid future conflicts, developers should restrain from using it.
       </p>
 
       <section class="notoc">

--- a/index.html
+++ b/index.html
@@ -844,7 +844,10 @@ did-url = did path-abempty [ "?" query ] [ "#" fragment ]
       </table>
 
       <p class="note" title="Semicolon character is reserved for future use">
-        Although the semicolon (<code>;</code>) character may be used according to the rules of the DID URL syntax, future versions of this specification may use it as a sub-delimiter for parameters as described in [[?MATRIX-URIS]]]. To avoid future conflicts, developers should restrain from using it.
+Although the semicolon (<code>;</code>) character can be used according to the
+rules of the <a>DID URL</a> syntax, future versions of this specification may
+use it as a sub-delimiter for parameters as described in [[?MATRIX-URIS]]]. To
+avoid future conflicts, developers ought to refrain from using it.
       </p>
 
       <section class="notoc">

--- a/index.html
+++ b/index.html
@@ -844,9 +844,7 @@ did-url = did path-abempty [ "?" query ] [ "#" fragment ]
       </table>
 
       <p class="note" title="Semicolon character is reserved for future use">
-This specification reserves the semicolon (<code>;</code>) character for
-possible future use as a sub-delimiter for parameters as described in
-[[?MATRIX-URIS]].
+        Although the semicolon (<code>;</code>) character may be used according to the rules of the DID URL syntax, future versions of this specification may use it as a sub-delimiter for parameters as described in [[?MATRIX-URIS]]]. To avoid future conflicts, developers should restrain using it.
       </p>
 
       <section class="notoc">


### PR DESCRIPTION
See #674 for the underlying discussion.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/682.html" title="Last updated on Feb 21, 2021, 9:07 PM UTC (3b50f66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/682/69f7eff...3b50f66.html" title="Last updated on Feb 21, 2021, 9:07 PM UTC (3b50f66)">Diff</a>