### PR TITLE
Re-writing the intro paragraph of §5.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,7 +1541,12 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules of
 
       <p>
 
-        A <a>DID document</a> must include identifiers referring to the <a>DID subject</a>, as well as to the <a>DID controller</a>. While the primary mechanism is to use the <a href="#did-syntax">DID Syntax</a>, the <a>DID document</a> may also include alternate identifiers to reference the <a>DID subject</a>. The following section elaborates on the mechanisms the <a>DID document</a> data model provides for so doing.
+It is necessary for <a>DID documents</a> t/o include identifiers referring to
+the <a>DID subject</a>, as well as to the <a>DID controller</a>. While the
+primary mechanism is to use the <a href="#did-syntax">DID Syntax</a>, the
+<a>DID document</a> could also include alternate identifiers to reference the
+<a>DID subject</a>. The following section elaborates on the mechanisms the
+<a>DID document</a> data model provides for so doing.
       </p>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1540,11 +1540,8 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules of
       <h2>Identifiers</h2>
 
       <p>
-It is necessary to learn the identifiers used within a <a>DID document</a> to
-refer to the <a>DID subject</a> and the <a>DID controller</a>, as well as any
-alternate identifiers that might also be used to reference the <a>DID subject</a>.
-The following section elaborates on the mechanisms the <a>DID document</a> data
-model provides for so doing.
+
+        A <a>DID document</a> must include identifiers referring to the <a>DID subject</a>, as well as to the <a>DID controller</a>. While the primary mechanism is to use the <a href="#did-syntax">DID Syntax</a>, the <a>DID document</a> may also include alternate identifiers to reference the <a>DID subject</a>. The following section elaborates on the mechanisms the <a>DID document</a> data model provides for so doing.
       </p>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1541,12 +1541,8 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules of
 
       <p>
 
-It is necessary for <a>DID documents</a> t/o include identifiers referring to
-the <a>DID subject</a>, as well as to the <a>DID controller</a>. While the
-primary mechanism is to use the <a href="#did-syntax">DID Syntax</a>, the
-<a>DID document</a> could also include alternate identifiers to reference the
-<a>DID subject</a>. The following section elaborates on the mechanisms the
-<a>DID document</a> data model provides for so doing.
+This section describes the mechanisms by which <a>DID documents</a>
+include identifiers for <a>DID subjects</a> and <a>DID controllers</a>.
       </p>
 
       <section>


### PR DESCRIPTION
The introductory paragraph in [§5.1](https://w3c.github.io/did-core/#identifiers) says:

> It is necessary to learn the identifiers used within a DID document to refer to the DID subject and the DID controller, as well as any alternate identifiers that might also be used to reference the DID subject. The following section elaborates on the mechanisms the DID document data model provides for so doing.

I was not fully sure  what this paragraph really tries to say and, in any case, "necessary to learn" is not an acceptable style for a specification. Also, the generic statement on identifiers is not accurate: identifiers in a DID document are also used to identify verification methods or services.

The PR proposes an alternate formulation based on my understanding (which may be entirely wrong!).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/683.html" title="Last updated on Feb 21, 2021, 9:09 PM UTC (3f51dfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/683/69f7eff...3f51dfa.html" title="Last updated on Feb 21, 2021, 9:09 PM UTC (3f51dfa)">Diff</a>