### PR TITLE
Fix "ordered map" language and ensure testability of all MUST statements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1179,7 +1179,7 @@ Considerations
       <tbody>
         <tr>
           <td>
-<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+<a data-cite="INFRA#maps">map</a>
           </td>
           <td>
 A finite ordered sequence of key/value pairs, with no key appearing twice as
@@ -1730,7 +1730,8 @@ rules in Section <a href="#did-url-syntax"></a>.
             </dd>
             <dt>type</dt>
             <dd>
-The value of the <code>type</code> property MUST be exactly one <a>verification
+The value of the <code>type</code> property MUST be a <a
+data-cite="INFRA#string">string</a> that references exactly one <a>verification
 method</a> type. In order to maximize global interoperability, the
 <a>verification method</a> type SHOULD be registered in the DID Specification
 Registries [[?DID-SPEC-REGISTRIES]].
@@ -1738,7 +1739,7 @@ Registries [[?DID-SPEC-REGISTRIES]].
             <dt>controller</dt>
             <dd>
 The value of the <code>controller</code> property MUST be a <a
-data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
+data-cite="INFRA#string">string</a> that conforms to the rules in <a
 href="#did-syntax"></a>.
             </dd>
           </dl>
@@ -2528,7 +2529,7 @@ JSON Representation Type
           <tbody>
             <tr>
               <td>
-<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+<a data-cite="INFRA#maps">map</a>
               </td>
               <td>
 A <a data-cite="RFC8259#section-4">JSON Object</a>, where each entry is
@@ -2673,8 +2674,8 @@ Data&nbsp;Type
 <a data-cite="RFC8259#section-4">JSON Object</a>
               </td>
               <td>
-An <a data-cite="INFRA#maps">ordered&nbsp;map</a>, where each member of the JSON
-Object is added as an entry to the ordered map. Each entry key is set as the
+An <a data-cite="INFRA#maps">map</a>, where each member of the JSON
+Object is added as an entry to the map. Each entry key is set as the
 JSON Object member name. Each entry value is set by converting the JSON Object
 member value according to the JSON representation type as defined in this table.
 Since order is not specified by JSON Objects, no insertion order is guaranteed.
@@ -2962,7 +2963,7 @@ CBOR Representation Type
           <tbody>
             <tr>
               <td>
-<a data-cite="INFRA#maps">ordered&nbsp;map</a>
+<a data-cite="INFRA#maps">map</a>
               </td>
               <td>
 A <a data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5), where each
@@ -3153,8 +3154,8 @@ Data&nbsp;Type
 <a data-cite="RFC8949#section-3.1">CBOR map</a> (major type 5)
               </td>
               <td>
-An <a data-cite="INFRA#maps">ordered&nbsp;map</a>, where each data item of the
-CBOR map is added as an entry to the ordered map with the entry key being the
+An <a data-cite="INFRA#maps">map</a>, where each data item of the
+CBOR map is added as an entry to the map with the entry key being the
 data item name and the value converted based on the CBOR type and, if available,
 entry definition, as defined here; as no order can be enforced for general CBOR
 maps, no insertion order is guaranteed.
@@ -3742,9 +3743,10 @@ The input variables of the <code>dereference</code> function are as follows:
 didUrl
         </dt>
         <dd>
-A conformant <a>DID URL</a> as a single string. This is the <a>DID URL</a> to
-dereference. To dereference a <a>DID fragment</a>, the complete <a>DID URL</a>
-including the <a>DID fragment</a> MUST be used. This input is REQUIRED.
+A conformant <a>DID URL</a> as a single <a data-cite="INFRA#string">string</a>.
+This is the <a>DID URL</a> to dereference. To dereference a <a>DID fragment</a>,
+the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be used. This
+input is REQUIRED.
         </dd>
         <dt>
 dereferencingOptions

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,8 @@ Considerations
           </td>
           <td>
 A finite ordered sequence of key/value pairs, with no key appearing twice as
-specified in [[INFRA]]. Sometimes referred to as just "map".
+specified in [[INFRA]]. A map is sometimes referred to as an
+<a data-cite="INFRA#maps">ordered map</a> in [[INFRA]].
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
I have completed the second pass to make sure that all machine-testable normative MUST/REQUIRED statements are, in fact, machine testable. There was only one issue that I found, a missing link around a `string` type. I also cleaned up the "ordered map" language -> just "map"... because we don't expect people to assume the maps are ordered so we should stop saying "ordered map" everywhere and just say "map".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/686.html" title="Last updated on Feb 21, 2021, 9:14 PM UTC (f7f247f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/686/a93c6c0...f7f247f.html" title="Last updated on Feb 21, 2021, 9:14 PM UTC (f7f247f)">Diff</a>