### PR TITLE
Move 'deactivated' to DID document metadata (again).

### DIFF
--- a/index.html
+++ b/index.html
@@ -3517,13 +3517,6 @@ This error code is returned if the <a>representation</a> requested via the
 <code>accept</code> input metadata property is not supported by the <a>DID
 method</a> and/or <a>DID resolver</a> implementation.
                         </dd>
-                        <dt>
-deactivated
-                        </dt>
-                        <dd>
-The <a>DID</a> supplied to the <a>DID resolution</a> function has been
-deactivated as described in <a href="#method-operations"></a>.
-                        </dd>
                     </dl>
                 </dd>
             </dl>
@@ -3560,6 +3553,14 @@ property. The <code>updated</code> property is omitted if an Update operation
 has never been performed on the <a>DID document</a>. If an <code>updated</code>
 property exists, it can be the same value as the <code>created</code> property
 when the difference between the two timestamps is less than one second.
+            </dd>
+
+            <dt><dfn>deactivated</dfn></dt>
+            <dd>
+If a DID has been <a href="#method-operations">deactivated</a>,
+<a>DID document</a> metadata MUST include this property with the boolean value
+<code>true</code>. If a DID has not been deactivated, this property is OPTIONAL,
+but if included, MUST have the boolean value <code>false</code>.
             </dd>
 
             <dt><dfn>nextUpdate</dfn></dt>


### PR DESCRIPTION
This changes `deactivated` to be a DID document metadata property rather than error. This change was previously done in https://github.com/w3c/did-core/pull/581, but then apparently got lost somehow.

Addresses https://github.com/w3c/did-core/issues/687.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/691.html" title="Last updated on Feb 22, 2021, 10:54 AM UTC (af6736a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/691/14c5fa3...af6736a.html" title="Last updated on Feb 22, 2021, 10:54 AM UTC (af6736a)">Diff</a>