### PR TITLE
Fix mistake regarding empty didResolutionMetadata.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3381,7 +3381,8 @@ A <a href="#metadata-structure">metadata structure</a> consisting of values
 relating to the results of the <a>DID resolution</a> process which typically
 changes between invocations of the <code>resolve</code> and
 <code>resolveRepresentation</code> functions, as it represents data about the
-resolution process itself. This structure is REQUIRED, and MUST NOT be empty.
+resolution process itself. This structure is REQUIRED, and in the case of an
+error in the resolution process, this MUST NOT be empty.
 This metadata is defined by <a href="#did-resolution-metadata"></a>. If
 <code>resolveRepresentation</code> was called, this structure MUST contain a
 <code>contentType</code> property containing the Media Type of the


### PR DESCRIPTION
I believe this is the correct fix for https://github.com/w3c/did-core/issues/689, but need review by @jricher to make sure.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/696.html" title="Last updated on Feb 23, 2021, 4:49 PM UTC (d5a5e65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/696/3313fc6...d5a5e65.html" title="Last updated on Feb 23, 2021, 4:49 PM UTC (d5a5e65)">Diff</a>