### PR TITLE
Add support for percent-encoded characters for did:web.

### DIFF
--- a/index.html
+++ b/index.html
@@ -788,7 +788,8 @@ did                = "did:" method-name ":" method-specific-id
 method-name        = 1*method-char
 method-char        = %x61-7A / DIGIT
 method-specific-id = *( *idchar ":" ) 1*idchar
-idchar             = ALPHA / DIGIT / "." / "-" / "_"
+idchar             = ALPHA / DIGIT / "." / "-" / "_" / pct-encoded
+pct-encoded        = "%" HEXDIG HEXDIG
               </pre>
             </td>
           </tr>


### PR DESCRIPTION
This PR is being raised to address issue #699, which was a bug in the spec.

Marking this as substantive as it affects implementations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/703.html" title="Last updated on Feb 26, 2021, 4:25 PM UTC (7220ae6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/703/ed12dd5...7220ae6.html" title="Last updated on Feb 26, 2021, 4:25 PM UTC (7220ae6)">Diff</a>