### PR TITLE
Align conformance statements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,23 +656,17 @@ bi-directional, and lossless, as described in <a href="#representations"></a>.
       </p>
 
       <p>
-A <dfn>conforming DID method</dfn> is any specification that complies with the
-relevant normative statements in <a href="#methods"></a>.
-      </p>
-
-      <p>
 A <dfn>conforming producer</dfn> is any algorithm realized as software and/or
-hardware that generates <a>conforming DIDs</a> or
-<a>conforming DID Documents</a>. A conforming producer
-MUST NOT produce non-conforming <a>DIDs</a> or <a>DID documents</a>.
+hardware that generates <a>conforming DIDs</a> or <a>conforming DID
+Documents</a> and complies with the relevant normative statements in <a
+href="#representations"></a>.
       </p>
 
       <p>
 A <dfn>conforming consumer</dfn> is any algorithm realized as software and/or
-hardware that consumes <a>conforming DIDs</a> or
-<a>conforming DID documents</a>. A conforming consumer
-MUST produce errors when consuming non-conforming <a>DIDs</a> or <a>DID
-documents</a>.
+hardware that consumes <a>conforming DIDs</a> or <a>conforming DID documents</a>
+and complies with the relevant normative statements in <a
+href="#representations"></a>.
       </p>
 
       <p>
@@ -685,6 +679,11 @@ and/or hardware that complies with the relevant normative statements in
 A <dfn>conforming DID URL dereferencer</dfn> is any algorithm realized as
 software and/or hardware that complies with the relevant normative statements in
 <a href="#did-url-dereferencing"></a>.
+      </p>
+
+      <p>
+A <dfn>conforming DID method</dfn> is any specification that complies with the
+relevant normative statements in <a href="#methods"></a>.
       </p>
 
     </section>
@@ -2436,6 +2435,10 @@ A <a>conforming producer</a> MUST return the Media Type <a
 data-cite="INFRA#string">string</a> associated with the <a>representation</a>
 after the <a>production</a> process completes.
         </li>
+        <li>
+A conforming producer MUST NOT produce non-conforming <a>DIDs</a> or <a>DID
+documents</a>.
+        </li>
       </ol>
 
       <p>
@@ -2468,6 +2471,10 @@ that do not have explicit processing rules for the <a>representation</a> being
 consumed to the <a>DID document</a> <a href="#data-model">data model</a> using
 only the <a>representation</a>'s data type processing rules and return the
 <a>DID document</a> data model after the <a>consumption</a> process completes.
+        </li>
+        <li>
+A conforming consumer MUST produce errors when consuming non-conforming
+<a>DIDs</a> or <a>DID documents</a>.
         </li>
       </ol>
 


### PR DESCRIPTION
This PR moves a few conformance statements around to migrate the normative requirements from the conformance section to the section on production/consumption (in order to group the production/consumption statements w/ the other statements).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/705.html" title="Last updated on Mar 1, 2021, 3:02 AM UTC (ddfea73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/705/c436145...ddfea73.html" title="Last updated on Mar 1, 2021, 3:02 AM UTC (ddfea73)">Diff</a>