### PR TITLE
editorial: fix typo in services

### DIFF
--- a/index.html
+++ b/index.html
@@ -2365,7 +2365,7 @@ The value of the <code>type</code> property MUST be a <a
 data-cite="INFRA#string">string</a> or a <a
 data-cite="INFRA#ordered-set">set</a> of <a
 data-cite="INFRA#string">strings</a>. In order to maximize interoperability,
-the <a>verification method</a> type and  its associated properties SHOULD be
+the <a>service</a> type and its associated properties SHOULD be
 registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
           </dd>
           <dt><dfn>serviceEndpoint</dfn></dt>


### PR DESCRIPTION
Affects normative language, but is definitely a copy-paste induced typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/706.html" title="Last updated on Mar 1, 2021, 3:11 PM UTC (f4f39f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/706/4f4a7b1...f4f39f8.html" title="Last updated on Mar 1, 2021, 3:11 PM UTC (f4f39f8)">Diff</a>