### PR TITLE
Handling a respec/specref error

### DIFF
--- a/common.js
+++ b/common.js
@@ -177,6 +177,26 @@ var ccg = {
       ],
       status: "Internet-Draft",
       publisher: "IETF"
+    },
+    "JSON-LD11": {
+      title: "JSON-LD 1.1",
+      date: "2020-07-16",
+      authors: [
+        "Gregg Kellogg", "Pierre-Antoine Champin", "Dave Longley"
+      ],
+      status: "W3C Recommendation",
+      publisher: "W3C",
+      href: "https://www.w3.org/TR/json-ld11/"
+    },
+    "VC-DATA-MODEL": {
+      title: "Verifiable Credentials Data Model 1.0",
+      date: "2019-11-19",
+      authors: [
+        "Manu Sporny", "Grant Noble", "Dave Longley", "Daniel Burnett", "Brent Zundel"
+      ],
+      status: "W3C Recommendation",
+      publisher: "W3C",
+      href: "https://www.w3.org/TR/vc-data-model/"
     }
   }
 };


### PR DESCRIPTION
There is a mysterious bug in respec and/or specref, which means that the JSON-LD11 and VC Data model references are wrong: they refer to a WD and a PR, respectively. Mainly the first one is an issue for a CR publication.

Have tried to track down the bug to yield a proper error report on specref or respec, but it does not seem to be easy (on a simple example it works correctly). As a temporary measure, to make the publication of the CR possible, I have modified, in this branch, the local biblio structure on common.js by adding both of those explicitly with the right parameters. We should use this for the CR publication.

Sigh...