### PR TITLE
Post-CR Changes on ECHIDNA (DO NOT MERGE THIS BEFORE CR PUBLICATION)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   - echo "ok"
  
 after_success:
-  - test $TRAVIS_PULL_REQUEST = false && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN" --data="editorial=true"
+  - test $TRAVIS_PULL_REQUEST = false && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   - echo "ok"
  
 after_success:
-  - test $TRAVIS_PULL_REQUEST = false && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"
+  - test $TRAVIS_PULL_REQUEST = false && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN" --data="editorial=true"

--- a/ECHIDNA
+++ b/ECHIDNA
@@ -1,5 +1,5 @@
 # ECHIDNA configuration
-index.html?specStatus=CR&shortName=did-core respec
+index.html?specStatus=CRD&shortName=did-core respec
 diagrams/diagram-did-document-entries.png
 diagrams/diagram-did-document-entries.svg
 diagrams/diagram-production-consumption.png

--- a/ECHIDNA
+++ b/ECHIDNA
@@ -1,5 +1,5 @@
 # ECHIDNA configuration
-index.html?specStatus=WD&shortName=did-core respec
+index.html?specStatus=CR&shortName=did-core respec
 diagrams/diagram-did-document-entries.png
 diagrams/diagram-did-document-entries.svg
 diagrams/diagram-production-consumption.png


### PR DESCRIPTION
With the CR publication, the usage of ECHIDNA changes (see [separate ECHIDNA page](https://github.com/w3c/echidna/wiki/CR-publication-workflow)):

1. Any editorial CR update can be made on a CR via ECHIDNA
2. A substantial CR update must require a Director's approval, and has to go through the staff contact and the W3C Webmaster

This PR makes the necessary changes on the ECHIDNA setup.