### PR TITLE
chore: Remove at risk note for nextUpdate and nextVersionId

### DIFF
--- a/index.html
+++ b/index.html
@@ -3646,12 +3646,6 @@ but if included, MUST have the boolean value <code>false</code>.
 
           <dt><dfn>nextUpdate</dfn></dt>
           <dd>
-            <p class="issue atrisk">
-The DID Working Group is seeking implementer feedback on this feature. If there
-is not enough implementation experience with this feature at the end of the
-Candidate Recommendation period, it will be removed from the specification.
-            </p>
-
 <a>DID document</a> metadata MAY include a <code>nextUpdate</code> property if
 the resolved document version is not the latest version of the document. It
 indicates the timestamp of the next <a href="#method-operations">Update
@@ -3669,12 +3663,6 @@ property MUST be an <a data-lt="ascii string">ASCII string</a>.
 
           <dt><dfn>nextVersionId</dfn></dt>
           <dd>
-            <p class="issue atrisk">
-The DID Working Group is seeking implementer feedback on this feature. If there
-is not enough implementation experience with this feature at the end of the
-Candidate Recommendation period, it will be removed from the specification.
-            </p>
-
 <a>DID document</a> metadata MAY include a <code>nextVersionId</code> property
 if the resolved document version is not the latest version of the document. It
 indicates the version of the next <a href="#method-operations">Update


### PR DESCRIPTION
This PR removes the "AT RISK" notes for `nextUpdate` and `nextVersionId`.

According to https://github.com/w3c/did-core/issues/667#issuecomment-781359169 this can be done now that there are tests and two independent implementations of these features (`did:3` and `did:ethr`).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/oed/did-core/pull/722.html" title="Last updated on Apr 21, 2021, 7:58 AM UTC (4fc23ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/722/10487e0...oed:4fc23ae.html" title="Last updated on Apr 21, 2021, 7:58 AM UTC (4fc23ae)">Diff</a>