### PR TITLE
Remove at risk note for equivalentId and canonicalId

### DIFF
--- a/index.html
+++ b/index.html
@@ -3331,11 +3331,6 @@ string">ASCII string</a>.
 
           <dt><dfn>equivalentId</dfn></dt>
           <dd>
-            <p class="issue atrisk">
-The DID Working Group is seeking implementer feedback on this feature. If there
-is not enough implementation experience with this feature at the end of the
-Candidate Recommendation period, it will be removed from the specification.
-            </p>
             <p>
 A <a>DID method</a> can define different forms of a <a>DID</a> that are
 logically equivalent. An example is when a <a>DID</a> takes one form prior to
@@ -3388,11 +3383,6 @@ directives related to this metadata property.
           </dd>
           <dt><dfn>canonicalId</dfn></dt>
           <dd>
-            <p class="issue atrisk">
-The DID Working Group is seeking implementer feedback on this feature. If there
-is not enough implementation experience with this feature at the end of the
-Candidate Recommendation period, it will be removed from the specification.
-            </p>
             <p>
 The <code><a>canonicalId</a></code> property is identical to the
 <code><a>equivalentId</a></code> property except: a) it is associated with a


### PR DESCRIPTION
Removes the "at risk" notes.

Tests for two implementations are now in the DID test suite:

- did:ion - https://github.com/w3c/did-test-suite/blob/cff8582/packages/did-core-test-server/suites/implementations/did-ion.json#L65-L68
- did:orb - https://github.com/w3c/did-test-suite/blob/cff8582/packages/did-core-test-server/suites/implementations/did-orb.json#L501-L505


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/troyronda/did-core/pull/756.html" title="Last updated on May 27, 2021, 1:18 PM UTC (91702ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/756/435a304...troyronda:91702ba.html" title="Last updated on May 27, 2021, 1:18 PM UTC (91702ba)">Diff</a>