### PR TITLE
docs: add notes to nudge implementors towards common DID URL patterns

### DIFF
--- a/index.html
+++ b/index.html
@@ -3548,8 +3548,9 @@ input is REQUIRED.
 
         <p class="note" title="DID URL dereferencer patterns">
 While it is valid for any <code>didUrl</code> to be passed to a DID URL
-dereferencer, implementors are expected to refer to [[?DID-RESOLUTION]] to
-identify common patterns of how a <a>DID URL</a> is expected to be dereferenced.
+dereferencer, implementers are expected to refer to [[?DID-RESOLUTION]] to
+further understand common patterns for how a <a>DID URL</a> is expected 
+to be dereferenced.
         </p>
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -1023,7 +1023,7 @@ function the same way across all <a>DID methods</a>. Support for all
         </p>
 
         <p class="note">
-It's generally expected that DID URL dereferencer implementations should
+It's generally expected that DID URL dereferencer implementations will
 reference [[?DID-RESOLUTION]] for additional implementation details. The scope
 of this specification was expected to only define the contract of the most
 common query parameters.

--- a/index.html
+++ b/index.html
@@ -3548,8 +3548,8 @@ input is REQUIRED.
 
         <p class="note" title="DID URL dereferencer patterns">
 While it's valid for any <code>didUrl</code> to be passed to a DID URL
-dereferencer, implementors should reference [[?DID-RESOLUTION]] to identify
-common patterns of how a <a>DID URL</a> is expected to be dereferenced.
+dereferencer, implementors are expected to refer to [[?DID-RESOLUTION]] to
+identify common patterns of how a <a>DID URL</a> is expected to be dereferenced.
         </p>
         </dd>
         <dt>

--- a/index.html
+++ b/index.html
@@ -1023,7 +1023,7 @@ function the same way across all <a>DID methods</a>. Support for all
         </p>
 
         <p class="note">
-It's generally expected that DID URL dereferencer implementations will
+It is generally expected that DID URL dereferencer implementations will
 reference [[?DID-RESOLUTION]] for additional implementation details. The scope
 of this specification was expected to only define the contract of the most
 common query parameters.

--- a/index.html
+++ b/index.html
@@ -1025,8 +1025,8 @@ function the same way across all <a>DID methods</a>. Support for all
         <p class="note">
 It is generally expected that DID URL dereferencer implementations will
 reference [[?DID-RESOLUTION]] for additional implementation details. The scope
-of this specification was expected to only define the contract of the most
-common query parameters.
+of this specification only defines the contract of the most common 
+query parameters.
         </p>
         <table class="simple">
           <thead>

--- a/index.html
+++ b/index.html
@@ -1022,6 +1022,12 @@ function the same way across all <a>DID methods</a>. Support for all
 <a href="#did-parameters">DID Parameters</a> is OPTIONAL.
         </p>
 
+        <p class="note">
+It's generally expected that DID URL dereferencer implementations should
+reference [[?DID-RESOLUTION]] for additional implementation details. The scope
+of this specification was expected to only define the contract of the most
+common query parameters.
+        </p>
         <table class="simple">
           <thead>
             <tr>
@@ -3539,6 +3545,12 @@ A conformant <a>DID URL</a> as a single <a data-cite="INFRA#string">string</a>.
 This is the <a>DID URL</a> to dereference. To dereference a <a>DID fragment</a>,
 the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be used. This
 input is REQUIRED.
+
+        <p class="note" title="DID URL dereferencer patterns">
+While it's valid for any <code>didUrl</code> to be passed to a DID URL
+dereferencer, implementors should reference [[?DID-RESOLUTION]] to identify
+common patterns of how a <a>DID URL</a> is expected to be dereferenced.
+        </p>
         </dd>
         <dt>
 dereferencingOptions

--- a/index.html
+++ b/index.html
@@ -3547,7 +3547,7 @@ the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be used. This
 input is REQUIRED.
 
         <p class="note" title="DID URL dereferencer patterns">
-While it's valid for any <code>didUrl</code> to be passed to a DID URL
+While it is valid for any <code>didUrl</code> to be passed to a DID URL
 dereferencer, implementors are expected to refer to [[?DID-RESOLUTION]] to
 identify common patterns of how a <a>DID URL</a> is expected to be dereferenced.
         </p>


### PR DESCRIPTION
This is an initial set of text proposal to address issue #708


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/764.html" title="Last updated on Jun 27, 2021, 11:09 PM UTC (245e020)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/764/5ffbdd1...245e020.html" title="Last updated on Jun 27, 2021, 11:09 PM UTC (245e020)">Diff</a>