### PR TITLE
Add warning about publicKeyMultibase

### DIFF
--- a/index.html
+++ b/index.html
@@ -1934,10 +1934,10 @@ public key.
             </p>
             <p class="advisement">
 Note that the [[?MULTIBASE]] specification is not yet a standard and is 
-subject to change. There might be some data format use cases where 
-<code><b>public</b>KeyMultibase</code> is defined to express keys 
-publicly, but <code><b>private</b>KeyMultibase</code> is not in order 
-to protect against accidentally leaking secret keys.
+subject to change. There might be some use cases for this data format
+where <code><b>public</b>KeyMultibase</code> is defined, to allow for
+expression of public keys, but <code><b>private</b>KeyMultibase</code>
+is not defined, to protect against accidental leakage of secret keys.
             </p>
           </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -1933,7 +1933,7 @@ data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
 public key.
             </p>
             <p class="advisement">
-There might be some cases where <code><b>public</b>KeyMultibase</code> can
+Note that publicKeyMultibase is not a standard and is therefore subject to change. There might be some cases where <code><b>public</b>KeyMultibase</code> can
 be represented although <code><b>private</b>KeyMultibase</code> cannot.
             </p>
           </dd>

--- a/index.html
+++ b/index.html
@@ -1933,9 +1933,9 @@ data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
 public key.
             </p>
             <p class="advisement">
-              Representations of <code>privateKeyMultibase</code> might not 
-              be possible in some cases where <code>publicKeyMultibase</code> can be
-              represented.
+Representations of <code>privateKeyMultibase</code> might not 
+be possible in some cases where <code>publicKeyMultibase</code> can be
+represented.
             </p>
           </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -1933,8 +1933,11 @@ data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
 public key.
             </p>
             <p class="advisement">
-Note that publicKeyMultibase is not a standard and is therefore subject to change. There might be some cases where <code><b>public</b>KeyMultibase</code> can
-be represented although <code><b>private</b>KeyMultibase</code> cannot.
+Note that the [[?MULTIBASE]] specification is not yet a standard and is 
+subject to change. There might be some data format use cases where 
+<code><b>public</b>KeyMultibase</code> is defined to express keys 
+publicly, but <code><b>private</b>KeyMultibase</code> is not in order 
+to protect against accidentally leaking secret keys.
             </p>
           </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -1933,9 +1933,8 @@ data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
 public key.
             </p>
             <p class="advisement">
-Representations of <code>privateKeyMultibase</code> might not 
-be possible in some cases where <code>publicKeyMultibase</code> can be
-represented.
+There might be some cases where <code><b>public</b>KeyMultibase</code> can
+be represented although <code><b>private</b>KeyMultibase</code> cannot.
             </p>
           </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -1908,15 +1908,6 @@ Two supported verification material properties are listed below:
         </p>
 
         <dl>
-          <dt><dfn>publicKeyMultibase</dfn></dt>
-          <dd>
-            <p>
-The <code>publicKeyMultibase</code> property is OPTIONAL. This feature is
-non-normative. If present, the value MUST be a <a
-data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
-public key.
-            </p>
-          </dd>
           <dt><dfn>publicKeyJwk</dfn></dt>
           <dd>
             <p>
@@ -1931,6 +1922,20 @@ their <a href="#fragment">fragment identifier</a>. It is RECOMMENDED that JWK
 <code>kid</code> values are set to the public key fingerprint [[RFC7638]]. See
 the first key in <a href="#example-various-verification-method-types"></a> for
 an example of a public key with a compound key identifier.
+            </p>
+          </dd>
+          <dt><dfn>publicKeyMultibase</dfn></dt>
+          <dd>
+            <p>
+The <code>publicKeyMultibase</code> property is OPTIONAL. This feature is
+non-normative. If present, the value MUST be a <a
+data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
+public key.
+            </p>
+            <p class="advisement">
+              Representations of <code>privateKeyMultibase</code> might not 
+              be possible in some cases where <code>publicKeyMultibase</code> can be
+              represented.
             </p>
           </dd>
       </dl>


### PR DESCRIPTION
This PR:

1. changes the order of verification material so that the "non-normative" feature is defined after the normative one.
2. adds a warning about `privateKeyMultibase` representations potentially not existing.

https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/772.html#dfn-publickeymultibase


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/772.html" title="Last updated on Jul 14, 2021, 9:49 PM UTC (6c4fbfc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/772/cd6ee48...6c4fbfc.html" title="Last updated on Jul 14, 2021, 9:49 PM UTC (6c4fbfc)">Diff</a>