### PR TITLE
Add links to use cases document. Consolidate other useful links.

### DIFF
--- a/common.js
+++ b/common.js
@@ -39,18 +39,6 @@ var ccg = {
       status: "FPWD",
       publisher: "Verifiable Claims Working Group"
     },
-    "DID-USE-CASES": {
-      title: "Decentralized Identifier Use Cases",
-      href: "https://www.w3.org/TR/did-use-cases/",
-      authors: [
-        "Joe Andrieu",
-        "Kim Hamilton Duffy",
-        "Ryan Grant",
-        "Adrian Gropper"
-      ],
-      status: "ED",
-      publisher: "Decentralized Identifier Working Group"
-    },
     // aliases to known references
     "HTTP-SIGNATURES": {
       aliasOf: "http-signatures"

--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
     specStatus: "WD",
 
     // W3C Candidate Recommendation information
-    //crEnd: "2021-07-13",
-    //implementationReportURI: "https://w3c.github.io/did-test-suite/",
+    crEnd: "2021-07-13",
+    implementationReportURI: "https://w3c.github.io/did-test-suite/",
 
     // Editor's Draft URL
     edDraftURI: "https://w3c.github.io/did-core/",
@@ -47,8 +47,8 @@
 
     // previously published draft, uncomment this and set its
     // YYYY-MM-DD date and its maturity status
-    //previousPublishDate:  "2021-06-16",
-    //previousMaturity:  "CR",
+    previousPublishDate:  "2021-06-16",
+    previousMaturity:  "CR",
 
     // automatically allow term pluralization
     pluralize: true,

--- a/index.html
+++ b/index.html
@@ -394,6 +394,7 @@ support interactions with other people, institutions, or systems that require
 entities to identify themselves, or things they control, while providing control
 over how much personal or private data should be revealed, all without depending
 on a central authority to guarantee the continued existence of the identifier.
+These ideas are explored in the DID Use Cases document [[DID-USE-CASES]].
     </p>
     <p>
 This specification does not presuppose any particular technology or cryptography

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
 
     // previously published draft, uncomment this and set its
     // YYYY-MM-DD date and its maturity status
-    previousPublishDate:  "2021-06-16",
-    previousMaturity:  "CR",
+    //previousPublishDate:  "2021-06-16",
+    //previousMaturity:  "CR",
 
     // automatically allow term pluralization
     pluralize: true,

--- a/index.html
+++ b/index.html
@@ -433,7 +433,7 @@ methods, that conform to the ecosystem described by this document.
     <p>
 In addition to this specification, readers might find the
 Use Cases and Requirements for Decentralized Identifiers [[DID-USE-CASES]]
-useful.
+document useful.
     </p>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
     // W3C Candidate Recommendation information
     //crEnd: "2021-07-13",
-    implementationReportURI: "https://w3c.github.io/did-test-suite/",
+    //implementationReportURI: "https://w3c.github.io/did-test-suite/",
 
     // Editor's Draft URL
     edDraftURI: "https://w3c.github.io/did-core/",
@@ -133,7 +133,20 @@
         companyURL: "https://danubetech.com/",
         w3cid: 46729
       }
-    ]
+    ],
+    otherLinks: [{
+      key: "Related Documents",
+      data: [{
+        value: "DID Use Cases and Requirements",
+        href: "https://www.w3.org/TR/did-use-cases/"
+      }, {
+        value: "DID Specification Registries",
+        href: "https://www.w3.org/TR/did-spec-registries/"
+      }, {
+        value: "DID Core Implementation Report",
+        href: "https://w3c.github.io/did-test-suite/"
+      }]
+    }]
     };
   </script>
   <style>
@@ -416,6 +429,12 @@ Specification authors that want to create new DID infrastructures, known as DID
 methods, that conform to the ecosystem described by this document.
       </li>
     </ul>
+
+    <p>
+In addition to this specification, readers might find the
+Use Cases and Requirements for Decentralized Identifiers [[DID-USE-CASES]]
+useful.
+    </p>
 
     <section class="informative">
       <h2>A Simple Example</h2>


### PR DESCRIPTION
I did it guys! 
I'm not completely inept. :P 
...after 5 long years, the DID specification finally links to its use cases document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/774.html" title="Last updated on Jul 12, 2021, 1:59 PM UTC (b6e0136)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/774/b57167a...b6e0136.html" title="Last updated on Jul 12, 2021, 1:59 PM UTC (b6e0136)">Diff</a>