### PR TITLE
Update the IANA guidance due to IETF mediaman WG.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3048,18 +3048,6 @@ document</a>, a <a>conforming producer</a> MUST specify a media type of
 described in <a href="#did-resolution-metadata"></a>.
         </p>
 
-        <p class="issue atrisk" title="IETF did+ld+json media type registration">
-Use of the media type <code>application/did+ld+json</code> is pending
-clarification over the registration of
-<a href="https://datatracker.ietf.org/doc/html/draft-w3cdidwg-media-types-with-multiple-suffixes">
-media types with multiple suffixes</a>. Depending on the outcome of the
-discussion with the IETF Application and Real Time (ART) Media Type group,
-the media type might change, sections involving the media type might change,
-or other changes related to the media type might be applied to this
-specification. See also <a href="https://github.com/w3c/did-core/issues/208">
-Issue 208</a>.
-        </p>
-
       </section>
 
       <section>
@@ -6463,17 +6451,19 @@ the rules defined in <a href="#fragment"></a>.
     <section>
       <h2>application/did+ld+json</h2>
 
-      <p class="issue atrisk" title="IETF Structured Media Types">
-Use of the media type <code>application/did+ld+json</code> is pending
-clarification over the registration of
-<a href="https://datatracker.ietf.org/doc/html/draft-w3cdidwg-media-types-with-multiple-suffixes">
-media types with multiple suffixes</a>. Depending on the outcome of the
-discussion with the IETF Application and Real Time (ART) Media Type group,
-the media type might change, sections involving the media type might change,
-or other changes related to the media type might be applied to this
-specification. Discussion is happening in the
-<a href="https://mailarchive.ietf.org/arch/msg/media-types/Sv8oT38p1nWHPYZQmnL_9GPjeic/">
-IETF media-types mailing list</a>.
+      <p class="note" title="IETF Structured Media Types">
+The Candidate Recommendation phase for this specification received a significant
+number of implementations for the <code>application/did+ld+json</code> media
+type. Registration of the media type <code>application/did+ld+json</code> at
+IANA is pending resolution of the <a
+href="https://datatracker.ietf.org/doc/html/draft-w3cdidwg-media-types-with-multiple-suffixes">
+Media Types with Multiple Suffixes</a> issue. Work is expected to continue in
+the <a href="https://datatracker.ietf.org/wg/mediaman/about/">IETF Media Type
+Maintenance Working Group</a> with a registration of the
+<code>application/did+ld+json</code> media type by W3C following shortly after
+the publication of the <a
+href="https://datatracker.ietf.org/doc/html/draft-w3cdidwg-media-types-with-multiple-suffixes">
+Media Types with Multiple Suffixes</a> RFC.
       </p>
 
       <dl>


### PR DESCRIPTION
This PR updates the IANA guidance for `application/did+ld+json` to make it clear that the media type is safe to use (based on implementation experience), provides the current state of affairs with the IETF mediaman WG, and an expected outcome and registration expectation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/778.html" title="Last updated on Jul 17, 2021, 6:20 PM UTC (5d87659)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/778/0319f89...5d87659.html" title="Last updated on Jul 17, 2021, 6:20 PM UTC (5d87659)">Diff</a>