### PR TITLE
Update Editors, Authors, and Acknowledgements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,13 +68,7 @@
     postProcess: [/*add_reqlist_button*/, restrictRefs],
 
     // list of specification editors
-    editors: [{
-        name: "Drummond Reed",
-        url: "https://www.linkedin.com/in/drummondreed/",
-        company: "Evernym",
-        companyURL: "https://www.evernym.com/",
-        w3cid: 3096
-      },
+    editors: [
       {
         name: "Manu Sporny",
         url: "http://manu.sporny.org/",
@@ -83,11 +77,23 @@
         w3cid: 41758
       },
       {
+        name: "Amy Guy",
+        url: "http://rhiaro.co.uk/",
+        company: "Digital Bazaar",
+        companyURL: "https://digitalbazaar.com/"
+      },
+      {
         name: "Markus Sabadello",
         url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
         company: "Danube Tech",
         companyURL: "https://danubetech.com/",
         w3cid: 46729
+      }, {
+        name: "Drummond Reed",
+        url: "https://www.linkedin.com/in/drummondreed/",
+        company: "Evernym",
+        companyURL: "https://www.evernym.com/",
+        w3cid: 3096
       }
     ],
 
@@ -114,25 +120,25 @@
         w3cid: 48025
       },
       {
+        name: "Markus Sabadello",
+        url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
+        company: "Danube Tech",
+        companyURL: "https://danubetech.com/",
+        w3cid: 46729
+      },
+      {
+        name: "Orie Steele",
+        url: "https://www.linkedin.com/in/or13b/",
+        company: "Transmute",
+        companyURL: "https://www.transmute.industries/"
+      },
+      {
         name: "Christopher Allen",
         url: "https://www.linkedin.com/in/christophera",
         company: "Blockchain Commons",
         companyURL: "https://www.BlockchainCommons.com",
         w3cid: 85560
       },
-      {
-        name: "Ryan Grant",
-        url: "",
-        company: "",
-        companyURL: ""
-      },
-      {
-        name: "Markus Sabadello",
-        url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
-        company: "Danube Tech",
-        companyURL: "https://danubetech.com/",
-        w3cid: 46729
-      }
     ],
     otherLinks: [{
       key: "Related Documents",
@@ -6342,9 +6348,29 @@ An acknowledgements section.
   <section class="appendix">
     <h2>Acknowledgements</h2>
     <p>
-The Working Group thanks the following individuals for their contributions
-to this specification: <span class="issue">The final list of acknowledgements
-will be compiled at the end of the Candidate Recommendation phase.</span>
+The Working Group thanks the following individuals for their contributions to
+this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
+Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan
+Benet, BigBlueHat, Dan Bolser, Chris Boscolo, W3C Bot, Pelle Braendgaard, Daniel
+Buchner, Daniel Burnett, By_caballero, Tim Cappalli, Melvin Carvalho, David
+Chadwick, Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van
+Deventer, Kim Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson
+Farmer, Nikos Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian
+Gropper, Amy Guy, Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan
+Herman, Michael Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones,
+Andrew Jones, Tom Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael
+Klein, Paul Knowles, David I. Lehn, Charles Lehner, Michael Lodder, Dave
+Longley, Tobias Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant
+Noble, Mark Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche,
+Praveen, Mike Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin
+Richer, Rieks, Mikeal Rogers, Evstifeev Roman, Troy Ronda, Leonard Rosenthol,
+Michael Ruminer, Markus Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy
+Seltzer, Mehran Shakeri, Jaehoon (Ace) Shim, Samuel Smith, James M Snell,
+SondreB, Manu Sporny, Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, Oliver
+Terbu, Joel Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley, Kaliya -
+Identity Woman, Fuqiao Xue, @Yue, Dmitri Zagidulin, Brent Zundel, cabo,
+ewagner70, ewelton, gimly-jack, gjgd, kdenhartog-sybil1, ktobich, mooreT1881,
+oare, pukkamustard, rknobloch, ssstolk, tahpot, and zhanb.
     </p>
     <p>
 Portions of the work on this specification have been funded by the United States

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
       },
       {
         name: "Amy Guy",
-        url: "http://rhiaro.co.uk/",
+        url: "https://rhiaro.co.uk/",
         company: "Digital Bazaar",
         companyURL: "https://digitalbazaar.com/"
       },
@@ -6389,14 +6389,14 @@ The Working Group thanks the following individuals for their contributions to
 this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
 Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan
 Benet, BigBlueHat, Dan Bolser, Chris Boscolo, Pelle Braendgaard, Daniel Buchner,
-Daniel Burnett, By_caballero, Tim Cappalli, Melvin Carvalho, David Chadwick,
+Daniel Burnett, Juan Caballero, Tim Cappalli, Melvin Carvalho, David Chadwick,
 Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van Deventer, Kim
 Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson Farmer, Nikos
 Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian Gropper, Amy Guy,
 Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan Herman, Michael
 Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones, Andrew Jones, Tom
 Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael Klein, Paul
-Knowles, David I. Lehn, Charles Lehner, Michael Lodder, Dave Longley, Tobias
+Knowles, David I. Lehn, Charles E. Lehner, Michael Lodder, Dave Longley, Tobias
 Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant Noble, Mark
 Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche, Praveen, Mike
 Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin Richer, Rieks,

--- a/index.html
+++ b/index.html
@@ -6388,26 +6388,26 @@ Christopher Allen, Heather Vescent, and Wayne Chang.
 The Working Group thanks the following individuals for their contributions to
 this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
 Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan
-Benet, BigBlueHat, Dan Bolser, Chris Boscolo, W3C Bot, Pelle Braendgaard, Daniel
-Buchner, Daniel Burnett, By_caballero, Tim Cappalli, Melvin Carvalho, David
-Chadwick, Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van
-Deventer, Kim Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson
-Farmer, Nikos Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian
-Gropper, Amy Guy, Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan
-Herman, Michael Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones,
-Andrew Jones, Tom Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael
-Klein, Paul Knowles, David I. Lehn, Charles Lehner, Michael Lodder, Dave
-Longley, Tobias Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant
-Noble, Mark Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche,
-Praveen, Mike Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin
-Richer, Rieks, Mikeal Rogers, Evstifeev Roman, Troy Ronda, Leonard Rosenthol,
-Michael Ruminer, Markus Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy
-Seltzer, Mehran Shakeri, Jaehoon (Ace) Shim, Samuel Smith, James M Snell,
-SondreB, Manu Sporny, Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, Oliver
-Terbu, Joel Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley, Kaliya -
-Identity Woman, Fuqiao Xue, @Yue, Dmitri Zagidulin, Brent Zundel, cabo,
-ewagner70, ewelton, gimly-jack, gjgd, kdenhartog-sybil1, ktobich, mooreT1881,
-oare, pukkamustard, rknobloch, ssstolk, tahpot, and zhanb.
+Benet, BigBlueHat, Dan Bolser, Chris Boscolo, Pelle Braendgaard, Daniel Buchner,
+Daniel Burnett, By_caballero, Tim Cappalli, Melvin Carvalho, David Chadwick,
+Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van Deventer, Kim
+Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson Farmer, Nikos
+Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian Gropper, Amy Guy,
+Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan Herman, Michael
+Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones, Andrew Jones, Tom
+Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael Klein, Paul
+Knowles, David I. Lehn, Charles Lehner, Michael Lodder, Dave Longley, Tobias
+Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant Noble, Mark
+Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche, Praveen, Mike
+Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin Richer, Rieks,
+Mikeal Rogers, Evstifeev Roman, Troy Ronda, Leonard Rosenthol, Michael Ruminer,
+Markus Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy Seltzer, Mehran
+Shakeri, Jaehoon (Ace) Shim, Samuel Smith, James M Snell, SondreB, Manu Sporny,
+Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, Oliver Terbu, Joel
+Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley, Kaliya "Identity
+Woman" Young, Eric Welton, Fuqiao Xue, @Yue, Dmitri Zagidulin, Brent Zundel,
+cabo, ewagner70, gimly-jack, gjgd, kdenhartog-sybil1, ktobich, mooreT1881, oare,
+pukkamustard, rknobloch, ssstolk, tahpot, and zhanb.
     </p>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -6356,31 +6356,6 @@ standards process.
     </p>
 
     <p>
-The Working Group thanks the following individuals for their contributions to
-this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
-Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan
-Benet, BigBlueHat, Dan Bolser, Chris Boscolo, W3C Bot, Pelle Braendgaard, Daniel
-Buchner, Daniel Burnett, By_caballero, Tim Cappalli, Melvin Carvalho, David
-Chadwick, Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van
-Deventer, Kim Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson
-Farmer, Nikos Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian
-Gropper, Amy Guy, Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan
-Herman, Michael Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones,
-Andrew Jones, Tom Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael
-Klein, Paul Knowles, David I. Lehn, Charles Lehner, Michael Lodder, Dave
-Longley, Tobias Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant
-Noble, Mark Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche,
-Praveen, Mike Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin
-Richer, Rieks, Mikeal Rogers, Evstifeev Roman, Troy Ronda, Leonard Rosenthol,
-Michael Ruminer, Markus Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy
-Seltzer, Mehran Shakeri, Jaehoon (Ace) Shim, Samuel Smith, James M Snell,
-SondreB, Manu Sporny, Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, Oliver
-Terbu, Joel Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley, Kaliya -
-Identity Woman, Fuqiao Xue, @Yue, Dmitri Zagidulin, Brent Zundel, cabo,
-ewagner70, ewelton, gimly-jack, gjgd, kdenhartog-sybil1, ktobich, mooreT1881,
-oare, pukkamustard, rknobloch, ssstolk, tahpot, and zhanb.
-    </p>
-    <p>
 Portions of the work on this specification have been funded by the United States
 Department of Homeland Security's (US DHS) Science and Technology Directorate
 under contracts HSHQDC-16-R00012-H-SB2016-1-002, and HSHQDC-17-C-00019, as well
@@ -6407,6 +6382,32 @@ Reed, Joe Andrieu, and Heather Vescent. Development of this specification has
 also been supported by the <a href="https://w3c-ccg.github.io/">W3C Credentials
 Community Group</a>, which has been Chaired by Kim Hamilton Duffy, Joe Andrieu,
 Christopher Allen, Heather Vescent, and Wayne Chang.
+    </p>
+
+    <p>
+The Working Group thanks the following individuals for their contributions to
+this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
+Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan
+Benet, BigBlueHat, Dan Bolser, Chris Boscolo, W3C Bot, Pelle Braendgaard, Daniel
+Buchner, Daniel Burnett, By_caballero, Tim Cappalli, Melvin Carvalho, David
+Chadwick, Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van
+Deventer, Kim Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson
+Farmer, Nikos Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian
+Gropper, Amy Guy, Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan
+Herman, Michael Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones,
+Andrew Jones, Tom Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael
+Klein, Paul Knowles, David I. Lehn, Charles Lehner, Michael Lodder, Dave
+Longley, Tobias Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant
+Noble, Mark Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche,
+Praveen, Mike Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin
+Richer, Rieks, Mikeal Rogers, Evstifeev Roman, Troy Ronda, Leonard Rosenthol,
+Michael Ruminer, Markus Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy
+Seltzer, Mehran Shakeri, Jaehoon (Ace) Shim, Samuel Smith, James M Snell,
+SondreB, Manu Sporny, Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, Oliver
+Terbu, Joel Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley, Kaliya -
+Identity Woman, Fuqiao Xue, @Yue, Dmitri Zagidulin, Brent Zundel, cabo,
+ewagner70, ewelton, gimly-jack, gjgd, kdenhartog-sybil1, ktobich, mooreT1881,
+oare, pukkamustard, rknobloch, ssstolk, tahpot, and zhanb.
     </p>
 
   </section>

--- a/index.html
+++ b/index.html
@@ -6348,6 +6348,14 @@ An acknowledgements section.
   <section class="appendix">
     <h2>Acknowledgements</h2>
     <p>
+The Working Group extends deep appreciation and heartfelt thanks to our
+Chairs Brent Zundel and Dan Burnett, as well as our W3C Staff Contact, Ivan
+Herman, for their tireless work in keeping the Working Group headed in a
+productive direction and navigating the deep and dangerous waters of the
+standards process.
+    </p>
+
+    <p>
 The Working Group thanks the following individuals for their contributions to
 this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
 Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan

--- a/index.html
+++ b/index.html
@@ -1895,7 +1895,7 @@ data-cite="INFRA#string">string</a> representation of a [[?MULTIBASE]] encoded
 public key.
             </p>
             <p class="advisement">
-Note that the [[?MULTIBASE]] specification is not yet a standard and is 
+Note that the [[?MULTIBASE]] specification is not yet a standard and is
 subject to change. There might be some use cases for this data format
 where <code><b>public</b>KeyMultibase</code> is defined, to allow for
 expression of public keys, but <code><b>private</b>KeyMultibase</code>
@@ -6386,28 +6386,29 @@ Christopher Allen, Heather Vescent, and Wayne Chang.
 
     <p>
 The Working Group thanks the following individuals for their contributions to
-this specification (in alphabetical order): Denis Ah-Kang, Nacho Alamillo,
-Christopher Allen, Joe Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan
-Benet, BigBlueHat, Dan Bolser, Chris Boscolo, Pelle Braendgaard, Daniel Buchner,
-Daniel Burnett, Juan Caballero, Tim Cappalli, Melvin Carvalho, David Chadwick,
-Wayne Chang, Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van Deventer, Kim
-Hamilton Duffy, Arnaud Durand, Ken Ebert, Veikko Eeva, Carson Farmer, Nikos
-Fotiou, Gabe, Gayan, Ryan Grant, Peter Grassberger, Adrian Gropper, Amy Guy,
-Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan Herman, Michael
-Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones, Andrew Jones, Tom
-Jones, jonnycrunch, Ted Thibodeau Jr, Gregg Kellogg, Michael Klein, Paul
-Knowles, David I. Lehn, Charles E. Lehner, Michael Lodder, Dave Longley, Tobias
-Looker, Wolf McNally, Robert Mitwicki, Mircea Nistor, Grant Noble, Mark
-Nottingham, Darrell O'Donnell, Vinod Panicker, Dirk Porsche, Praveen, Mike
-Prorock, Drummond Reed, Julian Reschke, Yancy Ribbens, Justin Richer, Rieks,
-Mikeal Rogers, Evstifeev Roman, Troy Ronda, Leonard Rosenthol, Michael Ruminer,
-Markus Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy Seltzer, Mehran
-Shakeri, Jaehoon (Ace) Shim, Samuel Smith, James M Snell, SondreB, Manu Sporny,
-Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, Oliver Terbu, Joel
-Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley, Kaliya "Identity
-Woman" Young, Eric Welton, Fuqiao Xue, @Yue, Dmitri Zagidulin, Brent Zundel,
-cabo, ewagner70, gimly-jack, gjgd, kdenhartog-sybil1, ktobich, mooreT1881, oare,
-pukkamustard, rknobloch, ssstolk, tahpot, and zhanb.
+this specification (in alphabetical order, Github handles start with `@` and
+are sorted as last names): Denis Ah-Kang, Nacho Alamillo, Christopher Allen, Joe
+Andrieu, Antonio, Phil Archer, George Aristy, Baha, Juan Benet, BigBlueHat, Dan
+Bolser, Chris Boscolo, Pelle Braendgaard, Daniel Buchner, Daniel Burnett, Juan
+Caballero, @cabo, Tim Cappalli, Melvin Carvalho, David Chadwick, Wayne Chang,
+Sam Curren, Hai Dang, Tim Daubenschütz, Oskar van Deventer, Kim Hamilton Duffy,
+Arnaud Durand, Ken Ebert, Veikko Eeva, @ewagner70, Carson Farmer, Nikos Fotiou,
+Gabe, Gayan, @gimly-jack, @gjgd, Ryan Grant, Peter Grassberger, Adrian Gropper,
+Amy Guy, Daniel Hardman, Kyle Den Hartog, Philippe Le Hegaret, Ivan Herman,
+Michael Herman, Alen Horvat, Dave Huseby, Marcel Jackisch, Mike Jones, Andrew
+Jones, Tom Jones, jonnycrunch, Gregg Kellogg, Michael Klein, @kdenhartog-sybil1,
+Paul Knowles, @ktobich, David I. Lehn, Charles E. Lehner, Michael Lodder,
+@mooreT1881, Dave Longley, Tobias Looker, Wolf McNally, Robert Mitwicki, Mircea
+Nistor, Grant Noble, Mark Nottingham, @oare, Darrell O'Donnell, Vinod Panicker,
+Dirk Porsche, Praveen, Mike Prorock, @pukkamustard, Drummond Reed, Julian
+Reschke, Yancy Ribbens, Justin Richer, Rieks, @rknobloch,  Mikeal Rogers,
+Evstifeev Roman, Troy Ronda, Leonard Rosenthol, Michael Ruminer, Markus
+Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy Seltzer, Mehran Shakeri,
+Jaehoon (Ace) Shim, Samuel Smith, James M Snell, SondreB, Manu Sporny, @ssstolk,
+Orie Steele, Shigeya Suzuki, Sammotic Switchyarn, @tahpot, Oliver Terbu,  Ted
+Thibodeau Jr., Joel Thorstensson, Tralcan, Henry Tsai, Rod Vagg, Mike Varley,
+Kaliya "Identity Woman" Young, Eric Welton, Fuqiao Xue, @Yue, Dmitri Zagidulin,
+@zhanb, and Brent Zundel.
     </p>
 
   </section>


### PR DESCRIPTION
This is the final **PROPOSED** list of Editors, Authors, and Acknowledgements. It was generated by pulling data from a variety of places (trying to be as data driven as possible). 

The Acknowledgements include every individual, in alphabetical order, that ever made a comment on an issue or PR over the years in Github.

The Editors are pulled directly from the contributor graph. The people in the top contributors by commits and lines changed are the Editors. There is a significant drop off in contribution after the 3rd person in the list for the DID Core specification.

https://github.com/w3c/did-core/graphs/contributors

The Authors list is a little more squishy. It's an amalgamation of contributions over the years that provided multiple significant architectural foundations as well as more recent and significant issue/PR feedback. 

I didn't include data from mailing list traffic, as the group didn't do most of its work via the mailing list. The data for issue/PR contributions are below. The `score` is the number of comments an individual made plus another score point for each 1KB of text that they wrote -- this is done in an attempt to balance out the contributions of people that write A LOT vs. those that fire off one liners):

                user |  score |   comments |    bytes |
              -----------------------------------------
             msporny |   1934 |       1363 |   585467 |
                OR13 |   1300 |        760 |   553464 |
         peacekeeper |    834 |        552 |   289422 |
             iherman |    637 |        401 |   241832 |
            dlongley |    509 |        248 |   267589 |
            jandrieu |    493 |        188 |   312979 |
          csuwildcat |    418 |        247 |   175584 |
          kdenhartog |    410 |        229 |   186056 |
             dhh1128 |    319 |        134 |   189907 |
            talltree |    319 |        174 |   149343 |
            agropper |    294 |        118 |   181040 |
              rhiaro |    280 |        186 |    97084 |
        SmithSamuelM |    245 |        110 |   138927 |
             TallTed |    209 |        124 |    87079 |
             ewelton |    204 |         60 |   147872 |
          selfissued |    200 |        149 |    52254 |
         brentzundel |    196 |        163 |    33888 |
             shigeya |    115 |         86 |    30619 |
             jricher |    107 |         74 |    34389 |
         jonnycrunch |    101 |         75 |    27493 |
        ChristopherA |     99 |         53 |    47702 |
               awoie |     78 |         49 |    29990 |
     dmitrizagidulin |     72 |         54 |    19185 |
            burnburn |     69 |         49 |    21166 |
            tplooker |     67 |         43 |    25161 |
      Oskar-Deventer |     64 |         42 |    22986 |
          philarcher |     57 |         25 |    33224 |
                 wyc |     50 |         32 |    19145 |
                 oed |     42 |         30 |    12512 |
              pknowl |     38 |         26 |    13107 |
            cboscolo |     31 |         21 |    10420 |
             Baha-sk |     27 |         13 |    14746 |
         mikelodder7 |     23 |         16 |     7767 |
             dhuseby |     20 |          8 |    12736 |
           CholoTook |     18 |         11 |     7698 |
      melvincarvalho |     18 |         10 |     8367 |
           davidlehn |     17 |         14 |     3762 |
           llorllale |     17 |         12 |     5904 |
          veikkoeeva |     17 |          6 |    11295 |
     darrellodonnell |     15 |          4 |    11765 |
           nalamillo |     14 |         11 |     3640 |
                gjgd |     13 |          8 |     5267 |
           troyronda |     12 |          9 |     4095 |
              mikeal |     11 |          7 |     4693 |
          grantnoble |     10 |          9 |     1462 |
           ewagner70 |     10 |          7 |     3806 |
        yancyribbens |      9 |          8 |     1700 |
         bumblefudge |      9 |          6 |     3659 |
          lrosenthol |      9 |          6 |     3365 |
              w3cbot |      9 |          9 |      774 |
        Crenshinibon |      8 |          7 |     1120 |
             clehner |      8 |          3 |     5687 |
             TimDaub |      8 |          3 |     5193 |
              mitfik |      7 |          3 |     5080 |
             DurandA |      7 |          5 |     2291 |
           TomCJones |      7 |          5 |     2537 |
              tahpot |      7 |          4 |     3352 |
              jbenet |      6 |          3 |     3441 |
        carsonfarmer |      6 |          5 |     1152 |
              deniak |      5 |          4 |     1787 |
            mavarley |      5 |          3 |     2122 |
             nikosft |      5 |          4 |     1838 |
              RieksJ |      4 |          2 |     2133 |
             glcohen |      4 |          3 |     1928 |
        mwherman2000 |      4 |          3 |     1243 |
                cabo |      4 |          3 |     1541 |
                mnot |      4 |          3 |     1667 |
        kimdhamilton |      3 |          3 |      348 |
           aljones15 |      3 |          2 |     1576 |
          BigBlueHat |      3 |          3 |      871 |
             jasnell |      3 |          2 |     1028 |
           marceljay |      3 |          2 |     1400 |
                 xfq |      3 |          3 |      478 |
                Fak3 |      3 |          3 |      117 |
             cihanss |      3 |          2 |     1901 |
           YueJing95 |      2 |          2 |      614 |
         PeterTheOne |      2 |          2 |      288 |
             mwklein |      2 |          2 |      763 |
         TelegramSam |      2 |          2 |      574 |
            gkellogg |      2 |          2 |      756 |
         timcappalli |      2 |          1 |     1142 |
            tralcanx |      2 |          2 |      600 |
               rvagg |      2 |          1 |     1683 |
             reschke |      2 |          2 |      117 |
          gimly-jack |      2 |          2 |      251 |
             ssstolk |      2 |          2 |      574 |
         samu-gataca |      2 |          1 |     1526 |
        thehenrytsai |      1 |          1 |      155 |
    kdenhartog-sybil1|      1 |          1 |       47 |
           azaroth42 |      1 |          1 |      950 |
               pelle |      1 |          1 |      255 |
            pensivej |      1 |          1 |      295 |
      David-Chadwick |      1 |          1 |      724 |
           ken-ebert |      1 |          1 |      476 |
           mirceanis |      1 |          1 |      584 |
           rknobloch |      1 |          1 |      182 |
       panickervinod |      1 |          1 |      215 |
                oare |      1 |          1 |      451 |
           haidedang |      1 |          1 |      127 |
       Identitywoman |      1 |          1 |      195 |
       mehranshakeri |      1 |          1 |       66 |
            sammotic |      1 |          1 |       98 |
         wolfmcnally |      1 |          1 |      163 |
          mooreT1881 |      1 |          1 |      824 |
            mprorock |      1 |          1 |      289 |
        pukkamustard |      1 |          1 |      101 |
             rxgrant |      1 |          1 |      924 |
            wseltzer |      1 |          1 |      343 |
     manicprogrammer |      1 |          1 |       31 |
            plehegar |      1 |          1 |      164 |
               zhanb |      1 |          1 |      151 |
          Diiaablo95 |      1 |          1 |      166 |
       praveensankar |      1 |          1 |      122 |
             ktobich |      1 |          1 |      368 |
             sondreb |      1 |          1 |      868 |
          Kalanamith |      1 |          1 |      282 |
          alenhorvat |      1 |          1 |      323 |

... and the spec contributor data at the time of the authoring of this PR:

![image](https://user-images.githubusercontent.com/108611/125364553-b50ef300-e340-11eb-84c4-0454f36ac8be.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/780.html" title="Last updated on Jul 17, 2021, 7:50 PM UTC (ae5c53c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/780/65078db...ae5c53c.html" title="Last updated on Jul 17, 2021, 7:50 PM UTC (ae5c53c)">Diff</a>