### PR TITLE
Add detailed description for three diagrams

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,8 +642,9 @@ rectangle. An arrow from the "DID" rectangle, labeled "refers to", points left
 to the "DID subject" oval. An arrow from the "DID controller" oval, labeled
 "controls", points right to the "DID document" rectangle. An arrow from the
 "DID" rectangle, labeled "recorded on", points downards to the right, to the
-"Verifiable Data Registry" cylinder. An arrow from the "DID document" rectangle
-points upwards to the right to the "Verifiable Data Registry" cylinder.
+"Verifiable Data Registry" cylinder. An arrow from the "DID document" rectangle,
+labeled "recorded on", points upwards to the right to the "Verifiable Data
+Registry" cylinder.
         </p>
       </div>
 
@@ -2721,7 +2722,7 @@ From the grey-outlined rectangle, three pairs of arrows extend to three
 different black-outlined rectangles, one on the upper right of the diagram, one
 in the lower right, and one in the lower left. Each pair of arrows consists of
 one blue arrow pointing from the grey-outlined rectangle to the respective
-black-outlined rectangle, labeled "produced", and one red arrow pointing in the
+black-outlined rectangle, labeled "produce", and one red arrow pointing in the
 reverse direction, labeled "consume". The black-outlined rectangle in the upper
 right is labeled, "application/did+cbor" and contains hexadecimal data. The
 rectangle in the lower right is labeled "application/did+json", and contains

--- a/index.html
+++ b/index.html
@@ -614,8 +614,38 @@ fragments or external resources.
         " >
         <figcaption>
 Overview of DID architecture and the relationship of the basic components.
+See also: <a class="longdesc-link"
+href="#brief-architecture-overview-longdesc">narrative description</a>.
         </figcaption>
       </figure>
+
+      <div class="longdesc" id="brief-architecture-overview-longdesc">
+        <p>
+Six internally-labeled shapes appear in the diagram, with labeled arrows
+between them, as follows. In the center of the diagram is a rectangle labeled
+DID URL, containing small typewritten text "did:example:123/path/to/rsrc". At
+the center top of the diagram is a rectangle labeled, "DID", containing small
+typewritten text "did:example:123". At the top left of the diagram is an oval,
+labeled "DID Subject". At the bottom center of the diagram is a rectangle
+labeled, "DID document". At the bottom left is an oval, labeled, "DID
+Controller". On the center right of the diagram is a two-dimensional rendering
+of a cylinder, labeled, "Verifiable Data Registry".
+        </p>
+        <p>
+From the top of the "DID URL" rectangle, an arrow, labeled "contains", extends
+upwards, pointing to the "DID" rectangle. From the bottom of the "DID URL"
+rectangle, an arrow, labeled "refers, and
+<strong><em>dereferences</em></strong>, to", extends downward, pointing to the
+"DID document" rectangle. An arrow from the "DID" rectangle, labeled
+"<strong><em>resolves</em></strong> to", points down to the "DID document"
+rectangle. An arrow from the "DID" rectangle, labeled "refers to", points left
+to the "DID subject" oval. An arrow from the "DID controller" oval, labeled
+"controls", points right to the "DID document" rectangle. An arrow from the
+"DID" rectangle, labeled "recorded on", points downards to the right, to the
+"Verifiable Data Registry" cylinder. An arrow from the "DID document" rectangle
+points upwards to the right to the "Verifiable Data Registry" cylinder.
+        </p>
+      </div>
 
       <dl>
         <dt>
@@ -1265,8 +1295,33 @@ and representation-specific entries; some entries are defined by this
 specification; others are defined by registered or unregistered extensions.">
       <figcaption>
 The entries in a DID document.
+See also: <a class="longdesc-link"
+href="#did-document-entries-longdesc">narrative description</a>.
       </figcaption>
     </figure>
+
+    <div class="longdesc" id="did-document-entries-longdesc">
+The diagram is titled, "Entries in the DID Document map". A dotted grey line
+runs horizontally through the center of the diagram. The space above the line
+is labeled "Properties", and the space below it, "Representation-specific
+entries". Six labeled rectangles appear in the diagram, three lying above the
+dotted grey line and three below it. A large green rectangle, labeled "DID
+Specification Registries", encloses the four leftmost rectangles (upper left,
+upper center, lower left, and lower center). The two leftmost rectangles
+(upper left and lower left) are outlined in blue and labeled in blue, as
+follows. The upper left rectangle is labeled "Core Properties", and contains
+text "id, alsoKnownAs, controller, authentication, verificationMethod, service,
+serviceEndpoint, ...". The lower left rectangle is labeled "Core
+Representation-specific Entries", and contains text "@context". The four
+rightmost rectangles (upper center, upper right, lower center, and lower right)
+are outlined in grey and labeled in black, as follows. The upper center
+rectangle is labeled, "Property Extensions", and contains text
+"ethereumAddress". The lower center rectangle is labeled,
+"Representation-specific Entry Extensions", and contains no other text. The
+upper right rectangle is labeled, "Unregistered Property Extensions", and
+contains text "foo". The lower right rectangle is labeled "Unregistered
+Representation-specific Entry Extensions", and contains text "%YAML, xmlns".
+    </div>
 
     <p>
 All entry keys in the <a>DID document</a> data model are <a
@@ -2629,8 +2684,83 @@ Diagram illustrating how representations of the data model are produced
 and consumed, including in JSON and JSON-LD.">
         <figcaption>
 Production and consumption of representations.
+See also: <a class="longdesc-link"
+href="#production-consumption-longdesc">narrative description</a>.
         </figcaption>
       </figure>
+
+      <div class="longdesc" id="production-consumption-longdesc">
+        <p>
+The upper left quadrant of the diagram contains a rectangle with dashed grey
+outline, containing two blue-outlined rectangles, one above the other, as
+follows. The upper, larger rectangle is labeled, in blue, "Core Properties",
+and contains the following <a data-cite="INFRA#maps">INFRA</a> notation:
+        </p>
+        <pre>
+«[
+  "id" → "example:123",
+  "verificationMethod" → « «[
+    "id": "did:example:123#keys-1",
+    "controller": "did:example:123",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+  ]» »,
+  "authentication" → «
+    "did:example:123#keys-1"
+  »
+]»
+        </pre>
+The lower, smaller rectangle is labeled, in blue, "Core Representation-specific
+Entries (JSON-LD)", and contains the following monospaced <a
+data-cite="INFRA#maps">INFRA</a> notation:
+        <pre>
+«[ "@context" → "https://www.w3.org/ns/did/v1" ]»
+        </pre>
+        <p>
+From the grey-outlined rectangle, three pairs of arrows extend to three
+different black-outlined rectangles, one on the upper right of the diagram, one
+in the lower right, and one in the lower left. Each pair of arrows consists of
+one blue arrow pointing from the grey-outlined rectangle to the respective
+black-outlined rectangle, labeled "produced", and one red arrow pointing in the
+reverse direction, labeled "consume". The black-outlined rectangle in the upper
+right is labeled, "application/did+cbor" and contains hexadecimal data. The
+rectangle in the lower right is labeled "application/did+json", and contains
+the following JSON:
+        </p>
+        <pre>
+{
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "did:example:123#keys-1",
+    "controller": "did:example:123",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+  }],
+  "authentication": [
+    "did:example:123#keys-1"
+  ]
+}
+        </pre>
+        <p>
+The rectangle in the lower left is labeled, "application/did+ld+json", and
+contains the following JSON-LD data:
+        </p>
+        <pre>
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "did:example:123#keys-1",
+    "controller": "did:example:123",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+  }],
+  "authentication": [
+    "did:example:123#keys-1"
+  ]
+}
+        </pre>
+      </div>
 
       <p class="note" title="Conversion between representations">
 An implementation is expected to convert between <a>representations</a> by using

--- a/index.html
+++ b/index.html
@@ -2724,9 +2724,9 @@ in the lower right, and one in the lower left. Each pair of arrows consists of
 one blue arrow pointing from the grey-outlined rectangle to the respective
 black-outlined rectangle, labeled "produce", and one red arrow pointing in the
 reverse direction, labeled "consume". The black-outlined rectangle in the upper
-right is labeled, "application/did+cbor" and contains hexadecimal data. The
+right is labeled "application/did+cbor", and contains hexadecimal data. The
 rectangle in the lower right is labeled "application/did+json", and contains
-the following JSON:
+the following JSON data:
         </p>
         <pre>
 {
@@ -2743,7 +2743,7 @@ the following JSON:
 }
         </pre>
         <p>
-The rectangle in the lower left is labeled, "application/did+ld+json", and
+The rectangle in the lower left is labeled "application/did+ld+json", and
 contains the following JSON-LD data:
         </p>
         <pre>

--- a/index.html
+++ b/index.html
@@ -2693,8 +2693,8 @@ href="#production-consumption-longdesc">narrative description</a>.
       <div class="longdesc" id="production-consumption-longdesc">
         <p>
 The upper left quadrant of the diagram contains a rectangle with dashed grey
-outline, containing two blue-outlined rectangles, one above the other, as
-follows. The upper, larger rectangle is labeled, in blue, "Core Properties",
+outline, containing two blue-outlined rectangles, one above the other.
+The upper, larger rectangle is labeled, in blue, "Core Properties",
 and contains the following <a data-cite="INFRA#maps">INFRA</a> notation:
         </p>
         <pre>


### PR DESCRIPTION
This adds descriptions for the following three diagrams, for #625, in the style of #771 as modified by 6ada0def45b0df7cb52c3587d5fce5ce6a32dfc5 and b57167a705549a7587d2617391f66257ea3f16f7.

section|figure id|image
-|-|-
1.3 | [`brief-architecture-overview`](https://www.w3.org/TR/did-core/#brief-architecture-overview) | [`diagrams/did_brief_architecture_overview.svg`](https://github.com/w3c/did-core/blob/b57167a705549a7587d2617391f66257ea3f16f7/diagrams/did_brief_architecture_overview.svg)
4   | [`did-document-entries`](https://www.w3.org/TR/did-core/#did-document-entries) | [`diagrams/diagram-did-document-entries.svg`](https://github.com/w3c/did-core/blob/b57167a705549a7587d2617391f66257ea3f16f7/diagrams/diagram-did-document-entries.svg)
6.1 | [`production-consumption`](https://www.w3.org/TR/did-core/#production-consumption) | [`diagrams/diagram-production-consumption.svg`](https://github.com/w3c/did-core/blob/b57167a705549a7587d2617391f66257ea3f16f7/diagrams/diagram-production-consumption.svg)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clehner/did-core/pull/781.html" title="Last updated on Jul 14, 2021, 3:37 PM UTC (63b89a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/781/b57167a...clehner:63b89a2.html" title="Last updated on Jul 14, 2021, 3:37 PM UTC (63b89a2)">Diff</a>