### PR TITLE
Normalize period spacing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6123,7 +6123,7 @@ Description</a>
         </figure>
         <div class="longdesc" id="independent-did-controllers-longdesc">
 Three black circles appear on the left, vertically, each labeled "DID
-Controller".  From each of these circles, a pair of green arrows extends towards
+Controller". From each of these circles, a pair of green arrows extends towards
 the center of the diagram, to a single rectangle, labeled "DID Document". The
 rectangle has the lower right corner cut and bent inward to form a small
 triangle, as if to represent a physical piece of paper with curled corner. Each
@@ -6163,11 +6163,11 @@ href="#group-did-controllers-longdesc"> narrative description</a>.
 On the left are three black filled circles, labeled "DID Controller Group" by a
 brace on the left. From each of these three circles, a green arrow extends to
 the center right. These three arrows converge towards a single filled white
-circle.  A pair of horizontal green arrows connects this white circle on its
+circle. A pair of horizontal green arrows connects this white circle on its
 right to a rectangle shaped like a page with a curled corner, labeled "DID
-Document".  The upper arrow points right, from the white circle to the
-rectangle, and is labeled "Controls".  The lower arrow points left, from the
-rectangle to the white circle, and is labeled "Controller".  From the right of
+Document". The upper arrow points right, from the white circle to the
+rectangle, and is labeled "Controls". The lower arrow points left, from the
+rectangle to the white circle, and is labeled "Controller". From the right of
 the rectangle extends a blue arrow, labeled "Describes", pointing to a black
 circle, labeled "DID Subject".
         </div>


### PR DESCRIPTION
Use common doc style of a single space after periods.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/did-core/pull/782.html" title="Last updated on Jul 13, 2021, 4:48 PM UTC (1a79fc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/782/b57167a...davidlehn:1a79fc8.html" title="Last updated on Jul 13, 2021, 4:48 PM UTC (1a79fc8)">Diff</a>