### PR TITLE
remove at-risk marker for alsoKnownAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1744,14 +1744,6 @@ and attack vectors.
       <section>
         <h3>Also Known As</h3>
 
-        <p class="issue atrisk" title="Implementation of alsoKnownAs">
-The DID Working Group is seeking implementer feedback regarding
-the alsoKnownAs feature. If there is not enough
-implementer interest in implementing this feature, it will be removed
-from this specification and placed into the DID Specification Registries
-[[?DID-SPEC-REGISTRIES]] as an extension.
-        </p>
-
         <p>
 A <a>DID subject</a> can have multiple identifiers for different purposes, or
 at different times. The assertion that two or more <a>DIDs</a> (or other types


### PR DESCRIPTION
Removes at-risk marker for `alsoKnownAs`.
Raised as an alternative to #776 and as an addition to #775, in an attempt to make @msporny life a tad easier should implementers meet the deadline set in the DID WG meeting 7/13/21.

Should only be merged if that deadline is met.

(Can also be closed without prejudice if Manu's life is easier without it)

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/did-spec/pull/783.html" title="Last updated on Jul 13, 2021, 5:00 PM UTC (789dc36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/783/b57167a...brentzundel:789dc36.html" title="Last updated on Jul 13, 2021, 5:00 PM UTC (789dc36)">Diff</a>