### PR TITLE
Use https for did-core links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5650,7 +5650,7 @@ See <a data-cite="RFC8259#section-12">RFC&nbsp;8259, section 12</a> [[RFC8259]].
         <dt>Interoperability considerations:</dt>
         <dd>Not Applicable</dd>
         <dt>Published specification:</dt>
-        <dd>http://www.w3.org/TR/did-core/</dd>
+        <dd>https://www.w3.org/TR/did-core/</dd>
         <dt>Applications that use this media type:</dt>
         <dd>
 Any application that requires an identifier that is decentralized, persistent,
@@ -5727,7 +5727,7 @@ See <a data-cite="JSON-LD11#security">JSON-LD 1.1, Security Considerations</a>
         <dt>Interoperability considerations:</dt>
         <dd>Not Applicable</dd>
         <dt>Published specification:</dt>
-        <dd>http://www.w3.org/TR/did-core/</dd>
+        <dd>https://www.w3.org/TR/did-core/</dd>
         <dt>Applications that use this media type:</dt>
         <dd>
 Any application that requires an identifier that is decentralized, persistent,


### PR DESCRIPTION
did-core lists a https link as the "Latest published version" so seems that should be used here too?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/did-core/pull/784.html" title="Last updated on Jul 13, 2021, 6:17 PM UTC (ffd3e0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/784/b57167a...davidlehn:ffd3e0d.html" title="Last updated on Jul 13, 2021, 6:17 PM UTC (ffd3e0d)">Diff</a>