### PR TITLE
 Add detailed description for two diagrams

### DIFF
--- a/index.html
+++ b/index.html
@@ -3617,10 +3617,58 @@ external resources.
         " >
         <figcaption>
 Overview of DID URL dereference
+See also: <a class="longdesc-link"
+             href="#did-url-dereference-overview-longdesc">narrative description</a>.
         </figcaption>
     </figure>
 
-      <p>
+        <div class="longdesc" id="did-url-dereference-overview-longdesc">
+            <p>
+                The top left part of the diagram contains a rectangle with black outline, labeled "DID".
+            </p>
+            <p>
+                The bottom left part of the diagram contains a rectangle with black outline, labeled "DID URL".
+                This rectangle contains four smaller black-outlined rectangles, aligned in a horizontal row adjacent to
+                each other. These smaller rectangles are labeled, in order, "DID", "path", "query", and "fragment.
+            </p>
+            <p>
+                The top right part of the diagram contains a rectangle with black outline, labeled "DID document".
+                This rectangle contains three smaller black-outlined rectangles. These smaller rectangles are
+                labeled "id", "(property X)", and "(property Y)", and are surrounded by multiple series of three
+                dots (ellipses). A curved black arrow, labeled "DID document - relative fragment dereference", extends
+                from the rectangle labeled "(property X)", and points to the rectangle labeled "(property Y)".
+            </p>
+            <p>
+                The bottom right part of the diagram contains an oval shape with black outline, labeled "Resource".
+            </p>
+            <p>
+                A black arrow, labeled "resolves to a DID document", extends from the rectangle in the top left part of
+                the diagram, labeled "DID", and points to the rectangle in the top right part of diagram, labeled
+                "DID document".
+            </p>
+            <p>
+                A black arrow, labeled "refers to", extends from the rectangle in the top right part of the diagram,
+                labeled "DID document", and points to the oval shape in the bottom right part of diagram, labeled
+                "Resource".
+            </p>
+            <p>
+                A black arrow, labeled "contains", extends from the small rectangle labeled "DID" inside the
+                rectangle in the bottom left part of the diagram, labeled "DID URL", and points to the rectangle
+                in the top left part of diagram, labeled "DID".
+            </p>
+            <p>
+                A black arrow, labeled "dereferences to a DID document", extends from the rectangle in the bottom left
+                part of the diagram, labeled "DID URL", and points to the rectangle in the top right part of diagram,
+                labeled "DID document".
+            </p>
+            <p>
+                A black arrow, labeled "dereferences to a resource", extends from the rectangle in the bottom left
+                part of the diagram, labeled "DID URL", and points to the oval shape in the bottom right part of diagram,
+                labeled "Resource".
+            </p>
+        </div>
+
+        <p>
 All conforming <a>DID resolvers</a> implement
 the following function which has the following abstract form:
       </p>

--- a/index.html
+++ b/index.html
@@ -3146,7 +3146,7 @@ href="#resolve-resolverepresentation-longdesc">narrative description</a>.
         <div class="longdesc" id="resolve-resolverepresentation-longdesc">
             <p>
                 The upper middle part of the diagram contains a rectangle with dashed grey outline, containing two
-                blue-outlined rectangles, one above the other, as follows.
+                blue-outlined rectangles, one above the other.
                 The upper, larger rectangle is labeled, in blue, "Core Properties", and contains the following [INFRA]
                 notation:
             </p>

--- a/index.html
+++ b/index.html
@@ -3147,8 +3147,8 @@ href="#resolve-resolverepresentation-longdesc">narrative description</a>.
             <p>
                 The upper middle part of the diagram contains a rectangle with dashed grey outline, containing two
                 blue-outlined rectangles, one above the other.
-                The upper, larger rectangle is labeled, in blue, "Core Properties", and contains the following [INFRA]
-                notation:
+                The upper, larger rectangle is labeled, in blue, "Core Properties", and contains the following
+                <a data-cite="INFRA#maps">INFRA</a> notation:
             </p>
             <pre>
 «[
@@ -3166,7 +3166,7 @@ href="#resolve-resolverepresentation-longdesc">narrative description</a>.
             </pre>
             <p>
             The lower, smaller rectangle is labeled, in blue, "Core Representation-specific Entries (JSON-LD)", and
-                contains the following monospaced [INFRA] notation:
+                contains the following monospaced <a data-cite="INFRA#maps">INFRA</a> notation:
             </p>
             <pre>
 «[ "@context" → "https://www.w3.org/ns/did/v1" ]»

--- a/index.html
+++ b/index.html
@@ -3138,8 +3138,94 @@ conformant representations; conversion is possible using production and
 consumption rules.">
         <figcaption>
 Functions resolve() and resolveRepresentation().
+See also: <a class="longdesc-link"
+href="#resolve-resolverepresentation-longdesc">narrative description</a>.
         </figcaption>
       </figure>
+
+        <div class="longdesc" id="resolve-resolverepresentation-longdesc">
+            <p>
+                The upper middle part of the diagram contains a rectangle with dashed grey outline, containing two
+                blue-outlined rectangles, one above the other, as follows.
+                The upper, larger rectangle is labeled, in blue, "Core Properties", and contains the following [INFRA]
+                notation:
+            </p>
+            <pre>
+«[
+  "id" → "example:123",
+  "verificationMethod" → « «[
+    "id": "did:example:123#keys-1",
+    "controller": "did:example:123",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+  ]» »,
+  "authentication" → «
+    "did:example:123#keys-1"
+  »
+]»
+            </pre>
+            <p>
+            The lower, smaller rectangle is labeled, in blue, "Core Representation-specific Entries (JSON-LD)", and
+                contains the following monospaced [INFRA] notation:
+            </p>
+            <pre>
+«[ "@context" → "https://www.w3.org/ns/did/v1" ]»
+        </pre>
+            <p>
+                From the grey-outlined rectangle, three pairs of arrows extend to three
+                different black-outlined rectangles, aligned in a horizontal row side-by-side, in the bottom half
+                of the diagram. Each pair of arrows consists of
+                one blue arrow pointing from the grey-outlined rectangle to the respective
+                black-outlined rectangle, labeled "produce", and one red arrow pointing in the
+                reverse direction, labeled "consume". The first black-outlined rectangle in the row
+                is labeled "application/did+ld+json", and contains
+                the following JSON-LD data:
+            </p>
+            <pre>
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "did:example:123#keys-1",
+    "controller": "did:example:123",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+  }],
+  "authentication": [
+    "did:example:123#keys-1"
+  ]
+}
+            </pre>
+            <p>
+                The second rectangle in the row is labeled "application/did+json" and contains the following
+                JSON data:
+            </p>
+            <pre>
+{
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "did:example:123#keys-1",
+    "controller": "did:example:123",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+  }],
+  "authentication": [
+    "did:example:123#keys-1"
+  ]
+}
+            </pre>
+            <p>
+                The third rectangle in the row is labeled "application/did+cbor", and contains hexadecimal data.
+            </p>
+            <p>
+                In the left part of the diagram, in the middle, there is a box, with black outline and light gray
+                background. This box is labeled "VERIFIABLE DATA REGISTRY" and contains a symbol representing a graph
+                with nodes and arcs. From this box, one arrow, labeled "resolve()", extends upwards and points to the
+                top half of the diagram where the grey-outlined rectangle is located. Another arrow, labeled
+                "resolveRepresentation()", extends downwards and points to the bottom half of the diagram, where the
+                row of three black-outlined rectangles is located.
+            </p>
+        </div>
 
       <p>
 The input variables


### PR DESCRIPTION
This adds long descriptions for additional two diagrams:

- https://www.w3.org/TR/did-core/#resolve-resolverepresentation
- https://www.w3.org/TR/did-core/#did-url-dereference-overview

This uses the same approach as in https://github.com/w3c/did-core/pull/781, and partially re-uses @clehner 's content from that PR for a similar diagram here.

Partially addresses https://github.com/w3c/did-core/issues/625.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/785.html" title="Last updated on Jul 14, 2021, 4:01 PM UTC (8c3b32f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/785/b57167a...8c3b32f.html" title="Last updated on Jul 14, 2021, 4:01 PM UTC (8c3b32f)">Diff</a>