### PR TITLE
Chair's decision for ordering author's list

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,13 +103,6 @@
 
     // list of specification authors
     authors: [{
-        name: "Drummond Reed",
-        url: "https://www.linkedin.com/in/drummondreed/",
-        company: "Evernym",
-        companyURL: "https://www.evernym.com/",
-        w3cid: 3096
-      },
-      {
         name: "Manu Sporny",
         url: "http://manu.sporny.org/",
         company: "Digital Bazaar",
@@ -129,6 +122,13 @@
         company: "Danube Tech",
         companyURL: "https://danubetech.com/",
         w3cid: 46729
+      },
+      {
+        name: "Drummond Reed",
+        url: "https://www.linkedin.com/in/drummondreed/",
+        company: "Evernym",
+        companyURL: "https://www.evernym.com/",
+        w3cid: 3096
       },
       {
         name: "Orie Steele",


### PR DESCRIPTION
The chairs have decided the ordering of the author's list should be: Manu Sporny, Dave Longley, Markus Sabadello, Drummond Reed, Orie Steele, Christopher Allen. This PR makes that change.
Signed-off-by: Brent Zundel <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/did-spec/pull/788.html" title="Last updated on Jul 19, 2021, 11:12 PM UTC (073bc53)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/788/69677ff...brentzundel:073bc53.html" title="Last updated on Jul 19, 2021, 11:12 PM UTC (073bc53)">Diff</a>