### PR TITLE
Add brief historical perspective in acknowledgements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6352,8 +6352,8 @@ standards process.
 The Editors gratefully acknowledge the work that led to the creation of this
 specification, and extend a sincere appreciation to those individuals that
 worked on technologies and specifications that deeply influenced this Working
-Group. Namely, the work of Phil Zimmerman, Jon Callas, Lutz Donnerhacke, Hal
-Finney, David Shaw, and Rodney Thayer on <a
+Group. In particular, this includes the work of Phil Zimmerman, Jon Callas,
+Lutz Donnerhacke, Hal Finney, David Shaw, and Rodney Thayer on <a
 href="https://en.wikipedia.org/wiki/Pretty_Good_Privacy"> Pretty Good Privacy
 (PGP)</a> in the 1990s and 2000s.
     </p>

--- a/index.html
+++ b/index.html
@@ -6360,29 +6360,30 @@ href="https://en.wikipedia.org/wiki/Pretty_Good_Privacy"> Pretty Good Privacy
 
     <p>
 In the mid-2010s, preliminary implementations of what would become Decentralized
-Identifiers were <a
-href="https://web-payments.org/minutes/2014-05-07/#topic-1">built</a> in
-collaboration with Jeremie Miller's Telehash project and the W3C Web Payments
-Community Group's work led by Dave Longley and Manu Sporny.
-Around a year later, the XDI.org Registry Working Group <a href="https://docs.google.com/document/d/1EP-KhH60y-nl4xkEzoeSf3DjmjLomfboF4p2umF51FA/">began exploring</a> decentralized
-technologies for replacing its existing identifier registry.
-Some of the first <a
-href="https://github.com/WebOfTrustInfo/rwot1-sf/blob/master/final-documents/dpki.pdf">written</a> <a
-href="https://github.com/WebOfTrustInfo/rwot2-id2020/blob/master/final-documents/requirements-for-dids.pdf">papers</a> exploring the concept of Decentralized Identifiers can be
-traced back to the first several Rebooting the Web of Trust workshops convened
-by Christopher Allen. That work led to a key collaboration between Christopher
-Allen, Drummond Reed, Les Chasen, Manu Sporny, and Anil John. Anil saw promise
-in the technology and allocated the initial set of government funding to explore
-the space. Without the support of Anil John and his guidance through the years,
-it is unlikely that Decentralized Identifiers would be where they are today.
-Further refinement at the Rebooting the Web of Trust workshops led to the <a
+Identifiers were <a href="https://web-payments.org/minutes/2014-05-07/#topic-1">
+built</a> in collaboration with Jeremie Miller's Telehash project and the W3C
+Web Payments Community Group's work led by Dave Longley and Manu Sporny. Around
+a year later, the XDI.org Registry Working Group
+<a href="https://docs.google.com/document/d/1EP-KhH60y-nl4xkEzoeSf3DjmjLomfboF4p2umF51FA/">
+began exploring</a> decentralized technologies for replacing its existing
+identifier registry. Some of the first
+<a href="https://github.com/WebOfTrustInfo/rwot1-sf/blob/master/final-documents/dpki.pdf">written</a>
+<a href="https://github.com/WebOfTrustInfo/rwot2-id2020/blob/master/final-documents/requirements-for-dids.pdf">papers</a>
+exploring the concept of Decentralized Identifiers can be traced back to the
+first several Rebooting the Web of Trust workshops convened by Christopher
+Allen. That work led to a key collaboration between Christopher Allen, Drummond
+Reed, Les Chasen, Manu Sporny, and Anil John. Anil saw promise in the technology
+and allocated the initial set of government funding to explore the space.
+Without the support of Anil John and his guidance through the years, it is
+unlikely that Decentralized Identifiers would be where they are today. Further
+refinement at the Rebooting the Web of Trust workshops led to the <a
 href="https://github.com/WebOfTrustInfo/rwot3-sf/blob/master/final-documents/did-implementer-draft-10.pdf">first
-implementers documentation</a>, edited by Drummond Reed, Les Chasen, Christopher Allen, 
-and Ryan Grant. Contributors included Manu Sporny, Dave Longley, Jason Law, Daniel Hardman,
-Markus Sabadello, Christian Lundkvist, and Jonathan Endersby. 
-This initial work was then merged into the W3C Credentials
-Community Group, incubated further, and then transitioned to the W3C
-Decentralized Identifiers Working Group for global standardization.
+implementers documentation</a>, edited by Drummond Reed, Les Chasen, Christopher
+Allen, and Ryan Grant. Contributors included Manu Sporny, Dave Longley, Jason
+Law, Daniel Hardman, Markus Sabadello, Christian Lundkvist, and Jonathan
+Endersby. This initial work was then merged into the W3C Credentials Community
+Group, incubated further, and then transitioned to the W3C Decentralized
+Identifiers Working Group for global standardization.
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -6412,7 +6412,11 @@ Weller, Betty Dhamers, Kaliya Young, Kim Hamilton Duffy, Manu Sporny, Drummond
 Reed, Joe Andrieu, and Heather Vescent. Development of this specification has
 also been supported by the <a href="https://w3c-ccg.github.io/">W3C Credentials
 Community Group</a>, which has been Chaired by Kim Hamilton Duffy, Joe Andrieu,
-Christopher Allen, Heather Vescent, and Wayne Chang.
+Christopher Allen, Heather Vescent, and Wayne Chang. The participants in the
+Internet Identity Workshop, facilitated by Phil Windley, Kaliya Young, Doc
+Searls, and Heidi Nobantu Saul, also supported this work through numerous
+working sessions designed to debate, improve, and educate participants about
+this specification.
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -6350,7 +6350,7 @@ standards process.
 
     <p>
 The Editors gratefully acknowledge the work that led to the creation of this
-specification, and extend a sincere appreciation to those individuals that
+specification, and extend sincere appreciation to those individuals that
 worked on technologies and specifications that deeply influenced this Working
 Group. In particular, this includes the work of Phil Zimmerman, Jon Callas,
 Lutz Donnerhacke, Hal Finney, David Shaw, and Rodney Thayer on <a

--- a/index.html
+++ b/index.html
@@ -6341,19 +6341,18 @@ An acknowledgements section.
   <section class="appendix">
     <h2>Acknowledgements</h2>
     <p>
-The Working Group extends deep appreciation and heartfelt thanks to our
-Chairs Brent Zundel and Dan Burnett, as well as our W3C Staff Contact, Ivan
-Herman, for their tireless work in keeping the Working Group headed in a
-productive direction and navigating the deep and dangerous waters of the
-standards process.
+The Working Group extends deep appreciation and heartfelt thanks to our Chairs
+Brent Zundel and Dan Burnett, as well as our W3C Staff Contact, Ivan Herman, for
+their tireless work in keeping the Working Group headed in a productive
+direction and navigating the deep and dangerous waters of the standards process.
     </p>
 
     <p>
-The Editors gratefully acknowledge the work that led to the creation of this
-specification, and extend sincere appreciation to those individuals that
-worked on technologies and specifications that deeply influenced this Working
-Group. In particular, this includes the work of Phil Zimmerman, Jon Callas,
-Lutz Donnerhacke, Hal Finney, David Shaw, and Rodney Thayer on <a
+The Working Group gratefully acknowledges the work that led to the creation of
+this specification, and extends sincere appreciation to those individuals that
+worked on technologies and specifications that deeply influenced our work. In
+particular, this includes the work of Phil Zimmerman, Jon Callas, Lutz
+Donnerhacke, Hal Finney, David Shaw, and Rodney Thayer on <a
 href="https://en.wikipedia.org/wiki/Pretty_Good_Privacy"> Pretty Good Privacy
 (PGP)</a> in the 1990s and 2000s.
     </p>
@@ -6436,7 +6435,7 @@ Paul Knowles, @ktobich, David I. Lehn, Charles E. Lehner, Michael Lodder,
 @mooreT1881, Dave Longley, Tobias Looker, Wolf McNally, Robert Mitwicki, Mircea
 Nistor, Grant Noble, Mark Nottingham, @oare, Darrell O'Donnell, Vinod Panicker,
 Dirk Porsche, Praveen, Mike Prorock, @pukkamustard, Drummond Reed, Julian
-Reschke, Yancy Ribbens, Justin Richer, Rieks, @rknobloch,  Mikeal Rogers,
+Reschke, Yancy Ribbens, Justin Richer, Rieks, @rknobloch, Mikeal Rogers,
 Evstifeev Roman, Troy Ronda, Leonard Rosenthol, Michael Ruminer, Markus
 Sabadello, Cihan Saglam, Samu, Rob Sanderson, Wendy Seltzer, Mehran Shakeri,
 Jaehoon (Ace) Shim, Samuel Smith, James M Snell, SondreB, Manu Sporny, @ssstolk,

--- a/index.html
+++ b/index.html
@@ -6364,6 +6364,8 @@ Identifiers were <a
 href="https://web-payments.org/minutes/2014-05-07/#topic-1">built</a> in
 collaboration with Jeremie Miller's Telehash project and the W3C Web Payments
 Community Group's work led by Dave Longley and Manu Sporny.
+Around a year later, the XDI.org Registry Working Group <a href="https://docs.google.com/document/d/1EP-KhH60y-nl4xkEzoeSf3DjmjLomfboF4p2umF51FA/">began exploring</a> decentralized
+technologies for replacing its existing identifier registry.
 Some of the <a
 href="https://github.com/WebOfTrustInfo/rwot2-id2020/blob/master/final-documents/requirements-for-dids.pdf">first
 written papers</a> exploring the concept of Decentralized Identifiers can be

--- a/index.html
+++ b/index.html
@@ -6349,6 +6349,41 @@ standards process.
     </p>
 
     <p>
+The Editors gratefully acknowledge the work that led to the creation of this
+specification, and extend a sincere appreciation to those individuals that
+worked on technologies and specifications that deeply influenced this Working
+Group. Namely, the work of Phil Zimmerman, Jon Callas, Lutz Donnerhacke, Hal
+Finney, David Shaw, and Rodney Thayer on <a
+href="https://en.wikipedia.org/wiki/Pretty_Good_Privacy"> Pretty Good Privacy
+(PGP)</a> in the 1990s and 2000s.
+    </p>
+
+    <p>
+In the mid-2010s, preliminary implementations of what would become Decentralized
+Identifiers were <a
+href="https://web-payments.org/minutes/2014-05-07/#topic-1">built</a> in
+collaboration with Jeremie Miller's Telehash project and the W3C Web Payments
+Community Group's work led by Dave Longley and Manu Sporny.
+Some of the <a
+href="https://github.com/WebOfTrustInfo/rwot2-id2020/blob/master/final-documents/requirements-for-dids.pdf">first
+written papers</a> exploring the concept of Decentralized Identifiers can be
+traced back to the first several Rebooting the Web of Trust workshops convened
+by Christopher Allen. That work led to a key collaboration between Christopher
+Allen, Drummond Reed, Les Chasen, Manu Sporny, and Anil John. Anil saw promise
+in the technology and allocated the initial set of government funding to explore
+the space. Without the support of Anil John and his guidance through the years,
+it is unlikely that Decentralized Identifiers would be where they are today.
+Further refinement at the Rebooting the Web of Trust workshops led to Drummond
+Reed producing the <a
+href="https://github.com/WebOfTrustInfo/rwot3-sf/blob/master/topics-and-advance-readings/did-spec-working-draft-03.md">first
+implementers documentation</a> with contributions from Les Chasen, Christopher
+Allen, Ryan Grant, Manu Sporny, Dave Longley, Jason Law, Daniel Hardman, and
+Markus Sabadello. This initial work was then merged into the W3C Credentials
+Community Group, incubated further, and then transitioned to the W3C
+Decentralized Identifiers Working Group for global standardization.
+    </p>
+
+    <p>
 Portions of the work on this specification have been funded by the United States
 Department of Homeland Security's (US DHS) Science and Technology Directorate
 under contracts HSHQDC-16-R00012-H-SB2016-1-002, and HSHQDC-17-C-00019, as well

--- a/index.html
+++ b/index.html
@@ -6373,12 +6373,12 @@ Allen, Drummond Reed, Les Chasen, Manu Sporny, and Anil John. Anil saw promise
 in the technology and allocated the initial set of government funding to explore
 the space. Without the support of Anil John and his guidance through the years,
 it is unlikely that Decentralized Identifiers would be where they are today.
-Further refinement at the Rebooting the Web of Trust workshops led to Drummond
-Reed producing the <a
-href="https://github.com/WebOfTrustInfo/rwot3-sf/blob/master/topics-and-advance-readings/did-spec-working-draft-03.md">first
-implementers documentation</a> with contributions from Les Chasen, Christopher
-Allen, Ryan Grant, Manu Sporny, Dave Longley, Jason Law, Daniel Hardman, and
-Markus Sabadello. This initial work was then merged into the W3C Credentials
+Further refinement at the Rebooting the Web of Trust workshops led to the <a
+href="https://github.com/WebOfTrustInfo/rwot3-sf/blob/master/final-documents/did-implementer-draft-10.pdf">first
+implementers documentation</a>, edited by Drummond Reed, Les Chasen, Christopher Allen, 
+and Ryan Grant. Contributors included Manu Sporny, Dave Longley, Jason Law, Daniel Hardman,
+Markus Sabadello, Christian Lundkvist, and Jonathan Endersby. 
+This initial work was then merged into the W3C Credentials
 Community Group, incubated further, and then transitioned to the W3C
 Decentralized Identifiers Working Group for global standardization.
     </p>

--- a/index.html
+++ b/index.html
@@ -6366,9 +6366,9 @@ collaboration with Jeremie Miller's Telehash project and the W3C Web Payments
 Community Group's work led by Dave Longley and Manu Sporny.
 Around a year later, the XDI.org Registry Working Group <a href="https://docs.google.com/document/d/1EP-KhH60y-nl4xkEzoeSf3DjmjLomfboF4p2umF51FA/">began exploring</a> decentralized
 technologies for replacing its existing identifier registry.
-Some of the <a
-href="https://github.com/WebOfTrustInfo/rwot2-id2020/blob/master/final-documents/requirements-for-dids.pdf">first
-written papers</a> exploring the concept of Decentralized Identifiers can be
+Some of the first <a
+href="https://github.com/WebOfTrustInfo/rwot1-sf/blob/master/final-documents/dpki.pdf">written</a> <a
+href="https://github.com/WebOfTrustInfo/rwot2-id2020/blob/master/final-documents/requirements-for-dids.pdf">papers</a> exploring the concept of Decentralized Identifiers can be
 traced back to the first several Rebooting the Web of Trust workshops convened
 by Christopher Allen. That work led to a key collaboration between Christopher
 Allen, Drummond Reed, Les Chasen, Manu Sporny, and Anil John. Anil saw promise


### PR DESCRIPTION
This adds a brief historical perspective on the specification before it entered the DID WG and acknowledges/appreciates the individuals that worked on the proto-documents that led to the DID Specification.

See the new text here: https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/790.html#acknowledgements


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/790.html" title="Last updated on Sep 11, 2021, 10:21 PM UTC (77dab87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/790/c672e55...77dab87.html" title="Last updated on Sep 11, 2021, 10:21 PM UTC (77dab87)">Diff</a>