### PR TITLE
Add section on Evaluating Competing Considerations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5036,11 +5036,11 @@ This specification does not require or suggest the use of any specific type of
 requirements. Different requirements might suggest different considerations with different
 trade-offs. For example, trade-offs between computation (energy usage), trust
 (deference to authority), coordination (network bandwidth), or memory (physical
-storage) might or might not be appropriate, for any given use case. Other use cases
+storage) might or might not be appropriate for any given use case. Other use cases
 might not make the same trade-offs. Those that need to consider different criteria
 for their use case are directed to the <a
 href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a>, which provides
-evaluation criteria to help decision makers evaluate whether or not a particular
+evaluation criteria to help decision makers determine whether or not a particular
 <a>DID Method</a> is appropriate for their use cases.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -5026,6 +5026,24 @@ as described in <a href="#extensibility"></a>, and where <a
 href="#privacy-considerations"></a> is applicable for such extensions.
       </p>
     </section>
+
+    <section>
+      <h2>Resource Usage Trade-offs</h2>
+
+      <p>
+This specification does not require or suggest the use of any specific type of
+<a>verifiable data registry</a>. Different use cases might result in different
+requirements. Different requirements might suggest different resource usage
+trade-offs. For example, trade-offs between computation (energy usage), trust
+(deference to authority), coordination (network bandwidth), or memory (physical
+storage) might be appropriate for a certain threat model. Other threat models
+might not make the same trade-offs. Those that need to consider resource usage
+trade-offs for their threat models are directed to the <a
+href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a>, which provides
+evaluation criteria to help decision makers evaluate whether or not a particular
+<a>verifiable data registry</a> is appropriate for their use cases.
+      </p>
+    </section>
   </section>
 
   <section class="informative">

--- a/index.html
+++ b/index.html
@@ -5027,7 +5027,7 @@ href="#privacy-considerations"></a> is applicable for such extensions.
       </p>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Resource Usage Trade-offs</h2>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -5028,20 +5028,20 @@ href="#privacy-considerations"></a> is applicable for such extensions.
     </section>
 
     <section class="informative">
-      <h2>Resource Usage Trade-offs</h2>
+      <h2>Evaluating Competing Considerations</h2>
 
       <p>
 This specification does not require or suggest the use of any specific type of
 <a>verifiable data registry</a>. Different use cases might result in different
-requirements. Different requirements might suggest different resource usage
+requirements. Different requirements might suggest different considerations with different
 trade-offs. For example, trade-offs between computation (energy usage), trust
 (deference to authority), coordination (network bandwidth), or memory (physical
-storage) might be appropriate for a certain threat model. Other threat models
-might not make the same trade-offs. Those that need to consider resource usage
-trade-offs for their threat models are directed to the <a
+storage) might or might not be appropriate, for any given use case. Other use cases
+might not make the same trade-offs. Those that need to consider different criteria
+for their use case are directed to the <a
 href="https://www.w3.org/TR/did-rubric/">DID Method Rubric</a>, which provides
 evaluation criteria to help decision makers evaluate whether or not a particular
-<a>verifiable data registry</a> is appropriate for their use cases.
+<a>DID Method</a> is appropriate for their use cases.
       </p>
     </section>
   </section>


### PR DESCRIPTION
This PR adds a non-normative appendix section on resource usage trade-offs and points readers to the DID Rubric for further evaluation criteria.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: connect ETIMEDOUT 128.30.52.89:443 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 6, 2021, 12:46 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fdid-core%2Fe95f2b33d16606bb6a4ea211082f4b9e8e68f235%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-core%23799.)._
</details>
