### PR TITLE
Ensure publicKeyMultibase values are valid.

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@ to cryptographically <a>authenticate</a> a <a>DID controller</a>.
     "id": "did:example:123456789abcdefghi#keys-1",
     "type": "Ed25519VerificationKey2020",
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
   }]
 }
       </pre>
@@ -1143,7 +1143,7 @@ relative URLs to reduce the storage size of <a>DID documents</a>.
     "id": "did:example:123456789abcdefghi#key-1",
     "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
   }, ...],
   "authentication": [
 <span class="comment">    // a relative DID URL used to reference a verification method above</span>
@@ -1935,7 +1935,7 @@ both properties above is shown below.
     "id": "did:example:123456789abcdefghi#keys-1",
     "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
     "controller": "did:example:pqrstuvwxyz0987654321",
-    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
   }],
   <span class="comment">...</span>
 }
@@ -1978,7 +1978,7 @@ is done by dereferencing the URL and searching the resulting <a>resource</a> for
       "id": "did:example:123456789abcdefghi#keys-2",
       "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
       "controller": "did:example:123456789abcdefghi",
-      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+      "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
     }
   ],
 
@@ -2067,7 +2067,7 @@ referenced.
       "id": "did:example:123456789abcdefghi#keys-2",
       "type": "Ed25519VerificationKey2020",
       "controller": "did:example:123456789abcdefghi",
-      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+      "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
     }
   ],
   <span class="comment">...</span>
@@ -2154,7 +2154,7 @@ corresponding <a>DID document</a>.
       "id": "did:example:123456789abcdefghi#keys-2",
       "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
       "controller": "did:example:123456789abcdefghi",
-      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+      "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
     }
   ],
   <span class="comment">...</span>
@@ -2205,7 +2205,7 @@ decryption key for the recipient.
       "id": "did:example:123#zC9ByQ8aJs8vrNXyDhPHHNNMSHPcaSgNpjjsBYpMMjsTdS",
       "type": "X25519KeyAgreementKey2019", <span class="comment">// external (property value)</span>
       "controller": "did:example:123",
-      "publicKeyMultibase": "z9hFgmPVfmBZwRvFEyniQDBkz9LmV7gDEqytWyGZLmDXE"
+      "publicKeyMultibase": "z6LSn6p3HRxx1ZZk1dT9VwcfTBCYgtNWdzdDMKPZjShLNWG7"
     }
   ],
   <span class="comment">...</span>
@@ -2272,7 +2272,7 @@ protected resource.
     "id": "did:example:123456789abcdefghi#keys-2",
     "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
     }
   ],
   <span class="comment">...</span>
@@ -2330,7 +2330,7 @@ example described in <a href="#capability-invocation"></a>.
     "id": "did:example:123456789abcdefghi#keys-2",
     "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
     }
   ],
   <span class="comment">...</span>
@@ -5328,34 +5328,34 @@ purposes.
     "id": "did:example:123",
     "authentication": [
       {
-        "id": "did:example:123#z6MkecaLyHuYWkayBDLw5ihndj3T1m6zKTGqau3A51G7RBf3",
+        "id": "did:example:123#z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu",
         "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
         "controller": "did:example:123",
-        "publicKeyMultibase": "zAKJP3f7BD6W4iWEQ9jwndVTCBq8ua2Utt8EEjJ6Vxsf"
+        "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
       }
     ],
     "capabilityInvocation": [
       {
-        "id": "did:example:123#z6MkhdmzFu659ZJ4XKj31vtEDmjvsi5yDZG5L7Caz63oP39k",
+        "id": "did:example:123#z6Mkvtac9bidSz9bBttzn7Yg3oCDHvMY2FtkFLs6SXRQGdQR",
         "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
         "controller": "did:example:123",
-        "publicKeyMultibase": "z4BWwfeqdp1obQptLLMvPNgBw48p7og1ie6Hf9p5nTpNN"
+        "publicKeyMultibase": "z6Mkvtac9bidSz9bBttzn7Yg3oCDHvMY2FtkFLs6SXRQGdQR"
       }
     ],
     "capabilityDelegation": [
       {
-        "id": "did:example:123#z6Mkw94ByR26zMSkNdCUi6FNRsWnc2DFEeDXyBGJ5KTzSWyi",
+        "id": "did:example:123#z6MknxsdF4CGVxhRNsx6TvXPFczaHEkajKBBwu75uwBmgpom",
         "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
         "controller": "did:example:123",
-        "publicKeyMultibase": "zHgo9PAmfeoxHG8Mn2XHXamxnnSwPpkyBHAMNF3VyXJCL"
+        "publicKeyMultibase": "z6MknxsdF4CGVxhRNsx6TvXPFczaHEkajKBBwu75uwBmgpom"
       }
     ],
     "assertionMethod": [
       {
-        "id": "did:example:123#z6MkiukuAuQAE8ozxvmahnQGzApvtW7KT5XXKfojjwbdEomY",
+        "id": "did:example:123#z6MkgYhVuWq4hyc7ZKBGhsY7pb5Bc8V6VPXGPG3EPja8JBFR",
         "type": "Ed25519VerificationKey2020", <span class="comment">// external (property value)</span>
         "controller": "did:example:123",
-        "publicKeyMultibase": "z5TVraf9itbKXrRvt2DSS95Gw4vqU3CHAdetoufdcKazA"
+        "publicKeyMultibase": "z6MkgYhVuWq4hyc7ZKBGhsY7pb5Bc8V6VPXGPG3EPja8JBFR"
       }
     ]
 }


### PR DESCRIPTION
This PR fixes the `publicKeyMultibase` values in the specification to ensure that they're correctly encoded.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/807.html" title="Last updated on Dec 8, 2021, 8:51 PM UTC (685b441)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/807/d20b7c7...685b441.html" title="Last updated on Dec 8, 2021, 8:51 PM UTC (685b441)">Diff</a>