### PR TITLE
Fix improperly URI Encoded values in DID parameters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -929,7 +929,7 @@ did:example:123#agent
 
         <pre class="example nohighlight"
              title="A resource external to a DID Document">
-did:example:123?service=agent&amp;relativeRef=%2Fcredentials%23degree
+did:example:123?service=agent&amp;relativeRef=/credentials%23degree
         </pre>
 
         <p class="note"
@@ -963,12 +963,12 @@ identifier for a <a>resource</a>.
 
         <pre class="example nohighlight"
           title="A DID URL with a 'versionTime' DID parameter">
-did:example:123?versionTime=2021-05-10T17%3A00%3A00Z
+did:example:123?versionTime=2021-05-10T17:00:00Z
         </pre>
 
         <pre class="example nohighlight"
           title="A DID URL with a 'service' and a 'relativeRef' DID parameter">
-did:example:123?service=files&amp;relativeRef=%2Fresume.pdf
+did:example:123?service=files&amp;relativeRef=/resume.pdf
         </pre>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -929,7 +929,7 @@ did:example:123#agent
 
         <pre class="example nohighlight"
              title="A resource external to a DID Document">
-did:example:123?service=agent&amp;relativeRef=/credentials#degree
+did:example:123?service=agent&amp;relativeRef=%2Fcredentials%23degree
         </pre>
 
         <p class="note"
@@ -963,12 +963,12 @@ identifier for a <a>resource</a>.
 
         <pre class="example nohighlight"
           title="A DID URL with a 'versionTime' DID parameter">
-did:example:123?versionTime=2021-05-10T17:00:00Z
+did:example:123?versionTime=2021-05-10T17%3A00%3A00Z
         </pre>
 
         <pre class="example nohighlight"
           title="A DID URL with a 'service' and a 'relativeRef' DID parameter">
-did:example:123?service=files&amp;relativeRef=/resume.pdf
+did:example:123?service=files&amp;relativeRef=%2Fresume.pdf
         </pre>
 
         <p>


### PR DESCRIPTION
The DID parameter values that we had in the specification were never properly URI Encoded per the rules for query parameters in RFC3986 (which is what we normatively reference). This PR fixes that, and is an editorial change (because it only updates examples). We got the normative reference right, but flubbed on the DID parameter examples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/813.html" title="Last updated on Aug 15, 2024, 6:45 PM UTC (aa14fcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/813/d20b7c7...aa14fcd.html" title="Last updated on Aug 15, 2024, 6:45 PM UTC (aa14fcd)">Diff</a>