### PR TITLE
Fix reference to maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -2402,7 +2402,7 @@ The value of the <code>serviceEndpoint</code> property MUST be a <a
 data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#string">map</a>, or
 a <a data-cite="INFRA#ordered-set">set</a> composed of one or more <a
 data-cite="INFRA#string">strings</a> and/or <a
-data-cite="INFRA#string">maps</a>. All <a data-cite="INFRA#string">string</a>
+data-cite="INFRA#maps">maps</a>. All <a data-cite="INFRA#string">string</a>
 values MUST be valid <a>URIs</a> conforming to [[RFC3986]] and normalized
 according to the <a data-cite="RFC3986#section-6">Normalization and Comparison
 rules in RFC3986</a> and to any normalization rules in its applicable <a>URI</a>


### PR DESCRIPTION
The INFRA citations for maps in `serviceEndpoint` were for string instead of map. This PR updates the citations to correspond with the text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clehner/did-core/pull/815.html" title="Last updated on Jan 26, 2022, 7:20 PM UTC (16b7c8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/815/d20b7c7...clehner:16b7c8f.html" title="Last updated on Jan 26, 2022, 7:20 PM UTC (16b7c8f)">Diff</a>