### PR TITLE
Add missing "of" word

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,8 +414,8 @@ Description
 Decentralization
             </td>
             <td>
-Eliminate the requirement for centralized authorities or single point failure in
-identifier management, including the registration of globally unique
+Eliminate the requirement for centralized authorities or single points of
+failure in identifier management, including the registration of globally unique
 identifiers, public verification keys, <a>services</a>, and other information.
             </td>
           </tr>


### PR DESCRIPTION
Fixes https://github.com/w3c/did-core/issues/816.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/817.html" title="Last updated on Feb 3, 2022, 3:46 PM UTC (e2fba44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/817/d20b7c7...e2fba44.html" title="Last updated on Feb 3, 2022, 3:46 PM UTC (e2fba44)">Diff</a>