### PR TITLE
Add internalError to the list of DID Resolution Metadata errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3410,6 +3410,13 @@ This error code is returned if the <a>representation</a> requested via the
 <code>accept</code> input metadata property is not supported by the <a>DID
 method</a> and/or <a>DID resolver</a> implementation.
               </dd>
+              <dt>
+internalError
+              </dt>
+              <dd>
+This error code is returned if the <a>DID resolver</a> function had an
+unexpected error.
+              </dd>
             </dl>
           </dd>
         </dl>


### PR DESCRIPTION
Adds an internalError to the list of DID Resolution Metadata errors.

The use case here is to provide a generalized error when a more specific one can not be determined.
Should probably be used in cases such as Database time outs, errors in supporting key libraries, etc.

I'm not an active part of this working group so this is a draft. If consensus is, this is needed I will mark it as ready and add it to the `did-spec-registries`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/did-core/pull/818.html" title="Last updated on Feb 10, 2022, 9:48 PM UTC (54f8daa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/818/d20b7c7...aljones15:54f8daa.html" title="Last updated on Feb 10, 2022, 9:48 PM UTC (54f8daa)">Diff</a>