### PR TITLE
remove link to wrong controller definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1512,7 +1512,7 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules in
             </td>
           </tr>
           <tr>
-            <td><code><a>controller</a></code></td>
+            <td><code>controller</code></td>
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a> that conforms to the rules in

--- a/index.html
+++ b/index.html
@@ -1504,7 +1504,7 @@ A <a data-cite="INFRA#ordered-set">set</a> of <a>Service Endpoint</a>
         </thead>
         <tbody>
           <tr>
-            <td><code>id</code></td>
+            <td><code><a href="#prop-verificationMethod-id" class="internalDFN">id</a></code></td>
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a> that conforms to the rules in
@@ -1512,7 +1512,7 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules in
             </td>
           </tr>
           <tr>
-            <td><code>controller</code></td>
+            <td><code><a href="#prop-verificationMethod-controller" class="internalDFN">controller</a></code></td>
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a> that conforms to the rules in
@@ -1520,7 +1520,7 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules in
             </td>
           </tr>
           <tr>
-            <td><code>type</code></td>
+            <td><code><a href="#prop-verificationMethod-type" class="internalDFN">type</a></code></td>
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a>.
@@ -1561,7 +1561,7 @@ A <a data-cite="INFRA#string">string</a> that conforms to a
         </thead>
         <tbody>
           <tr>
-            <td><code>id</code></td>
+            <td><code><a href="#prop-service-id" class="internalDFN">id</a></code></td>
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a> that conforms to the rules of
@@ -1569,7 +1569,7 @@ A <a data-cite="INFRA#string">string</a> that conforms to the rules of
             </td>
           </tr>
           <tr>
-            <td><code>type</code></td>
+            <td><code><a href="#prop-service-type" class="internalDFN">type</a></code></td>
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a> or a
@@ -1769,7 +1769,7 @@ in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
           </p>
 
           <dl>
-            <dt>id</dt>
+            <dt id="prop-verificationMethod-id">id</dt>
             <dd>
               <p>
 The value of the <code><a>id</a></code> property for a <a>verification
@@ -1777,7 +1777,7 @@ method</a> MUST be a <a data-cite="INFRA#string">string</a> that conforms to the
 rules in Section <a href="#did-url-syntax"></a>.
               </p>
             </dd>
-            <dt>type</dt>
+            <dt id="prop-verificationMethod-type">type</dt>
             <dd>
 The value of the <code>type</code> property MUST be a <a
 data-cite="INFRA#string">string</a> that references exactly one <a>verification
@@ -1785,7 +1785,7 @@ method</a> type. In order to maximize global interoperability, the
 <a>verification method</a> type SHOULD be registered in the DID Specification
 Registries [[?DID-SPEC-REGISTRIES]].
             </dd>
-            <dt>controller</dt>
+            <dt id="prop-verificationMethod-controller">controller</dt>
             <dd>
 The value of the <code>controller</code> property MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the rules in <a
@@ -2366,7 +2366,7 @@ which is described below:
       </p>
 
       <dl>
-        <dt>service</dt>
+        <dt><dfn>service</dfn></dt>
         <dd>
           <p>
 The <code>service</code> property is OPTIONAL. If present, the associated value
@@ -2379,7 +2379,7 @@ include additional properties and MAY further restrict the properties associated
 with the extension.
           </p>
           <dl>
-            <dt>id</dt>
+            <dt id="prop-service-id">id</dt>
             <dd>
 The value of the <code>id</code> property MUST be a <a>URI</a> conforming to
 [[RFC3986]]. A <a>conforming producer</a> MUST NOT produce
@@ -2387,7 +2387,7 @@ multiple <code>service</code> entries with the same <code>id</code>.
 A <a>conforming consumer</a> MUST produce an error if it detects
 multiple <code>service</code> entries with the same <code>id</code>.
             </dd>
-          <dt>type</dt>
+          <dt id="prop-service-type">type</dt>
           <dd>
 The value of the <code>type</code> property MUST be a <a
 data-cite="INFRA#string">string</a> or a <a


### PR DESCRIPTION
addresses issue #819 by removing the wrong link from `VerificationMethod::controller` to the definition of `DIDDocument::controller`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/820.html" title="Last updated on Mar 2, 2022, 11:57 AM UTC (decb9e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/820/d20b7c7...decb9e8.html" title="Last updated on Mar 2, 2022, 11:57 AM UTC (decb9e8)">Diff</a>