### PR TITLE
Fix JSON syntax in simple DID document

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@ to cryptographically <a>authenticate</a> a <a>DID controller</a>.
   "@context": [
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1"
-  ]
+  ],
   "id": "did:example:123456789abcdefghi",
   "authentication": [{
     <span class="comment">// used to authenticate as did:...fghi</span>


### PR DESCRIPTION
I found a small syntax error in the first JSON example. Here is the fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wagner-daniel/did-core/pull/824.html" title="Last updated on Jun 16, 2022, 5:23 PM UTC (6d1ddd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/824/d20b7c7...wagner-daniel:6d1ddd4.html" title="Last updated on Jun 16, 2022, 5:23 PM UTC (6d1ddd4)">Diff</a>