### PR TITLE
remove PR-related paragraph from REC

### DIFF
--- a/REC/2022-07-19/index.html
+++ b/REC/2022-07-19/index.html
@@ -597,12 +597,6 @@ of resolving DIDs to the resources that they represent.
       https://www.w3.org/TR/.</em></p>
 
     <p>
-The <abbr title="World Wide Web Consortium">W3C</abbr> Decentralized Identifier Working Group has published this document as a
-<abbr title="World Wide Web Consortium">W3C</abbr> Proposed Recommendation and is requesting that interested parties
-review this specification by August 26th, 2021.
-    </p>
-
-    <p>
 At the time of publication, there existed
 <a href="https://w3c.github.io/did-spec-registries/#did-methods">103
 experimental DID Method specifications</a>, 32 experimental DID Method driver


### PR DESCRIPTION
@msporny I also took the liberty of applying this change directly
on the version hosted on w3.org/TR ,
as I notived this paragraph was not on the REC dated 2022-06-30.

I don't know why/how it popped back...