### PR TITLE
Fix link to INFRA#maps in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1582,10 +1582,10 @@ A <a data-cite="INFRA#string">string</a> or a
             <td>yes</td>
             <td>
 A <a data-cite="INFRA#string">string</a> that conforms to the rules of
-[[RFC3986]] for <a>URIs</a>, a <a data-cite="INFRA#string">map</a>, or a
+[[RFC3986]] for <a>URIs</a>, a <a data-cite="INFRA#maps">map</a>, or a
 <a data-cite="INFRA#ordered-set">set</a> composed of a one or more
 <a data-cite="INFRA#string">strings</a> that conform to the rules of
-[[RFC3986]] for <a>URIs</a> and/or <a data-cite="INFRA#string">maps</a>.
+[[RFC3986]] for <a>URIs</a> and/or <a data-cite="INFRA#maps">maps</a>.
             </td>
           </tr>
         </tbody>
@@ -2399,10 +2399,10 @@ registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
           <dt><dfn>serviceEndpoint</dfn></dt>
           <dd>
 The value of the <code>serviceEndpoint</code> property MUST be a <a
-data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#string">map</a>, or
+data-cite="INFRA#string">string</a>, a <a data-cite="INFRA#maps">map</a>, or
 a <a data-cite="INFRA#ordered-set">set</a> composed of one or more <a
 data-cite="INFRA#string">strings</a> and/or <a
-data-cite="INFRA#string">maps</a>. All <a data-cite="INFRA#string">string</a>
+data-cite="INFRA#maps">maps</a>. All <a data-cite="INFRA#string">string</a>
 values MUST be valid <a>URIs</a> conforming to [[RFC3986]] and normalized
 according to the <a data-cite="RFC3986#section-6">Normalization and Comparison
 rules in RFC3986</a> and to any normalization rules in its applicable <a>URI</a>


### PR DESCRIPTION
Just fixing some links


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/FabioPinheiro/did-core/pull/840.html" title="Last updated on Apr 5, 2023, 12:32 AM UTC (2c7886b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/840/e9959f9...FabioPinheiro:2c7886b.html" title="Last updated on Apr 5, 2023, 12:32 AM UTC (2c7886b)">Diff</a>