### PR TITLE
add a missing comma in example 1 json

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@ to cryptographically <a>authenticate</a> a <a>DID controller</a>.
   "@context": [
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1"
-  ]
+  ],
   "id": "did:example:123456789abcdefghi",
   "authentication": [{
     <span class="comment">// used to authenticate as did:...fghi</span>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gobengo/did-core/pull/848.html" title="Last updated on Dec 11, 2023, 12:53 AM UTC (548c7ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/848/a8ddc80...gobengo:548c7ac.html" title="Last updated on Dec 11, 2023, 12:53 AM UTC (548c7ac)">Diff</a>