### PR TITLE
Fix serviceEndpoints maps link

### DIFF
--- a/REC/2022-07-19/index.html
+++ b/REC/2022-07-19/index.html
@@ -2305,10 +2305,10 @@ A <a href="https://infra.spec.whatwg.org/#string">string</a> or a
             <td>yes</td>
             <td>
 A <a href="https://infra.spec.whatwg.org/#string">string</a> that conforms to the rules of
-[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] for <a href="#dfn-uri" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-uri-13">URIs</a>, a <a href="https://infra.spec.whatwg.org/#string">map</a>, or a
+[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] for <a href="#dfn-uri" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-uri-13">URIs</a>, a <a href="https://infra.spec.whatwg.org/#maps">map</a>, or a
 <a href="https://infra.spec.whatwg.org/#ordered-set">set</a> composed of a one or more
 <a href="https://infra.spec.whatwg.org/#string">strings</a> that conform to the rules of
-[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] for <a href="#dfn-uri" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-uri-14">URIs</a> and/or <a href="https://infra.spec.whatwg.org/#string">maps</a>.
+[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] for <a href="#dfn-uri" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-uri-14">URIs</a> and/or <a href="https://infra.spec.whatwg.org/#maps">maps</a>.
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
Similar to https://github.com/w3c/did-core/pull/840

It was unclear to me if these should be maps (as they are) or [ordered maps](https://infra.spec.whatwg.org/#ordered-map)?