### PR TITLE
Use `publicKeyMultibase` instead of `publicKeyBase58` field in all examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -2601,7 +2601,7 @@ and contains the following <a data-cite="INFRA#maps">INFRA</a> notation:
     "id": "did:example:123#keys-1",
     "controller": "did:example:123",
     "type": "Ed25519VerificationKey2018",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVA"
   ]» »,
   "authentication" → «
     "did:example:123#keys-1"
@@ -2632,7 +2632,7 @@ the following JSON data:
     "id": "did:example:123#keys-1",
     "controller": "did:example:123",
     "type": "Ed25519VerificationKey2018",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVA"
   }],
   "authentication": [
     "did:example:123#keys-1"
@@ -2651,7 +2651,7 @@ contains the following JSON-LD data:
     "id": "did:example:123#keys-1",
     "controller": "did:example:123",
     "type": "Ed25519VerificationKey2018",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVA"
   }],
   "authentication": [
     "did:example:123#keys-1"
@@ -2814,7 +2814,7 @@ applications such as described in <a href="#did-resolution-metadata"></a>.
     "id": "did:example:123456789abcdefghi#keys-1",
     "type": "Ed25519VerificationKey2018",
     "controller": "did:example:123456789abcdefghi",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
   }]
 }
       </pre>
@@ -3151,7 +3151,7 @@ href="#resolve-resolverepresentation-longdesc">narrative description</a>.
     "id": "did:example:123#keys-1",
     "controller": "did:example:123",
     "type": "Ed25519VerificationKey2018",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVA"
   ]» »,
   "authentication" → «
     "did:example:123#keys-1"
@@ -3183,7 +3183,7 @@ href="#resolve-resolverepresentation-longdesc">narrative description</a>.
     "id": "did:example:123#keys-1",
     "controller": "did:example:123",
     "type": "Ed25519VerificationKey2018",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVA"
   }],
   "authentication": [
     "did:example:123#keys-1"
@@ -3201,7 +3201,7 @@ href="#resolve-resolverepresentation-longdesc">narrative description</a>.
     "id": "did:example:123#keys-1",
     "controller": "did:example:123",
     "type": "Ed25519VerificationKey2018",
-    "publicKeyBase58": "H3C2AVvLMv6gmMNam3uVA"
+    "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVA"
   }],
   "authentication": [
     "did:example:123#keys-1"
@@ -5470,19 +5470,19 @@ purposes.
       "id": "did:example:123#key-0",
       "type": "Ed25519VerificationKey2018",
       "controller": "did:example:123",
-      "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J" // external (property name)
+      "publicKeyMultibase": "z3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J" // external (property name)
     },
     {
       "id": "did:example:123#key-1",
       "type": "X25519KeyAgreementKey2019",
       "controller": "did:example:123",
-      "publicKeyBase58": "FbQWLPRhTH95MCkQUeFYdiSoQt8zMwetqfWoxqPgaq7x" // external (property name)
+      "publicKeyMultibase": "zFbQWLPRhTH95MCkQUeFYdiSoQt8zMwetqfWoxqPgaq7x" // external (property name)
     },
     {
       "id": "did:example:123#key-2",
       "type": "EcdsaSecp256k1VerificationKey2019",
       "controller": "did:example:123",
-      "publicKeyBase58": "ns2aFDq25fEV1NUd3wZ65sgj5QjFW8JCAHdUJfLwfodt" // external (property name)
+      "publicKeyMultibase": "zns2aFDq25fEV1NUd3wZ65sgj5QjFW8JCAHdUJfLwfodt" // external (property name)
     },
     {
       "id": "did:example:123#key-3",


### PR DESCRIPTION
Hi, I believe that some examples were by mistake using `publicKeyBase58` rather than `publicKeyMultibase` - I've updated the examples. Let me know if I am missing something.

Cheers


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Patrik-Stas/did-core/pull/852.html" title="Last updated on Jul 7, 2024, 7:58 PM UTC (7edae25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/852/a8ddc80...Patrik-Stas:7edae25.html" title="Last updated on Jul 7, 2024, 7:58 PM UTC (7edae25)">Diff</a>