### PR TITLE
Fix JSON formatting for DID document

### DIFF
--- a/index.html
+++ b/index.html
@@ -1112,7 +1112,7 @@ relative URLs to reduce the storage size of <a>DID documents</a>.
   "@context": [
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1"
-  ]
+  ],
   "id": "did:example:123456789abcdefghi",
   "verificationMethod": [{
     "id": "did:example:123456789abcdefghi#key-1",
@@ -1781,7 +1781,7 @@ authenticate the <a>verification method</a>.
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/jws-2020/v1"
     "https://w3id.org/security/suites/ed25519-2020/v1"
-  ]
+  ],
   "id": "did:example:123456789abcdefghi",
   <span class="comment">...</span>
   "verificationMethod": [{
@@ -1898,7 +1898,7 @@ both properties above is shown below.
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/jws-2020/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1"
-  ]
+  ],
   "id": "did:example:123456789abcdefghi",
   <span class="comment">...</span>
   "verificationMethod": [{


### PR DESCRIPTION
A comprehensive update of https://github.com/w3c/did-core/pull/824 by fixing all relevant examples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/denkeni/did-core/pull/856.html" title="Last updated on Jul 18, 2024, 5:37 PM UTC (ae7c621)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/856/c620ce9...denkeni:ae7c621.html" title="Last updated on Jul 18, 2024, 5:37 PM UTC (ae7c621)">Diff</a>