### PR TITLE
Consolidate media types to `application/did`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -907,7 +907,7 @@ interpreted in the same way across non-JSON <a>representations</a>.
         <p>
 Additional semantics for fragment identifiers, which are compatible with and
 layered upon the semantics in this section, are described for JSON-LD
-representations in <a href="#application-did-ld-json"></a>. For information
+representations in <a href="#application-did"></a>. For information
 about how to dereference a <a>DID fragment</a>, see [[?DID-RESOLUTION]].
         </p>
 


### PR DESCRIPTION
This PR is an attempt to address issue #863 by registering a single media type for both the JSON and JSON-LD serializations of the core data model.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/pull/868.html" title="Last updated on Nov 15, 2024, 3:42 PM UTC (d6a7bf6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/868/b405914...d6a7bf6.html" title="Last updated on Nov 15, 2024, 3:42 PM UTC (d6a7bf6)">Diff</a>