### PR TITLE
removes normative reference discussed in #868

### DIFF
--- a/index.html
+++ b/index.html
@@ -5563,8 +5563,7 @@ See <a data-cite="RFC8259#section-11">RFC&nbsp;8259, section 11</a>.
         </dd>
         <dt>Security considerations:</dt>
         <dd>
-See <a data-cite="DID-CORE#security-considerations">DID Core v1.1, Security Considerations</a>
-[[DID-CORE]].
+See <a data-cite="DID-CORE#security-considerations">DID Core v1.1, Security Considerations</a>.
         </dd>
         <dt>Interoperability considerations:</dt>
         <dd>Not Applicable</dd>


### PR DESCRIPTION
See https://github.com/w3c/did-core/pull/868/files#r1844058199

The reference wasn't removed by that PR, and it remained in [main](https://github.com/w3c/did-core/blob/308b4c1b349060e5304f818ab47a8d16d480a817/index.html#L5566-L5567) at the time I created this PR to remove it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/did-core/pull/871.html" title="Last updated on Nov 15, 2024, 3:51 PM UTC (1521ab7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/871/308b4c1...TallTed:1521ab7.html" title="Last updated on Nov 15, 2024, 3:51 PM UTC (1521ab7)">Diff</a>