### PR TITLE
Add relative DID URL DID Document example

### DIFF
--- a/index.html
+++ b/index.html
@@ -4525,6 +4525,35 @@ purposes.
 }
       </pre>
 
+      <pre class="example" title="DID Document that uses relative DID URLs">
+        {
+          "@context": "https://www.w3.org/ns/did/v1.1",
+          "id": "did:example:123",
+          "verificationMethod": [
+            {
+              <span class="comment">// A relative DID URL, that will be transformed to the absolute DID URL value did:example:123#key-1</span>
+              "id": "#key-1", 
+              "type": "Ed25519VerificationKey2020", 
+              "controller": "did:example:123",
+              "publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
+            }
+          ],
+          "authentication": [
+            "#key-1"
+          ],
+          "capabilityInvocation": [
+            "#key-1"
+          ],
+          "capabilityDelegation": [
+            "#key-1"
+          ],
+          "assertionMethod": [
+            <span class="comment">// Using relative DID URL #key-1 is equivalent to using the absolute DID URL value did:example:123#key-1</span>
+            "did:example:123#key-1" 
+          ]
+      }
+      </pre>
+
     </section>
 
     <section class="informative">


### PR DESCRIPTION
Addresses #860

Let me know if the comments I added to the example are overkill. Happy to remove.

I also note that [example 9](https://www.w3.org/TR/did-core/#example-an-example-of-a-relative-did-url) does capture some of this. I wanted to add an example that shows a relative DID URL being used as a verificationMethod ID.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-core/pull/874.html" title="Last updated on Jan 3, 2025, 10:20 AM UTC (5c2d5de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-core/874/3fa1d8d...wip-abramson:5c2d5de.html" title="Last updated on Jan 3, 2025, 10:20 AM UTC (5c2d5de)">Diff</a>