### PR TITLE
Add comment about intermediate DID documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -2795,6 +2795,13 @@ out-of-band mechanism, instead.
         </li>
       </ul>
 
+      <p>
+        When executing method operations, a [=DID method=] can use any data structures
+        it requires, including intermediate, partial, or temporary [=DID documents=], as
+        long as they are kept internal to the DID method, and the DID documents returned
+        by the method operations are fully conformant, as defined in [[[#conformance]]].
+      </p>
+
     </section>
 
     <section>


### PR DESCRIPTION
This is similar to https://github.com/w3c/did/pull/894, but I thought it makes sense to also mention in a generic way that DID methods can internally use intermediate forms of DID documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/900.html" title="Last updated on Jul 17, 2025, 8:00 AM UTC (06a0a12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/900/3e5e5ab...06a0a12.html" title="Last updated on Jul 17, 2025, 8:00 AM UTC (06a0a12)">Diff</a>