### PR TITLE
Reference RFC9110 which obsoletes RFC7230 and RFC7231.

### DIFF
--- a/index.html
+++ b/index.html
@@ -989,10 +989,10 @@ any resource might serve as a [=DID subject=] identified by a [=DID=].
         <dt><dfn data-lt="representations">representation</dfn></dt>
 
       <dd>
-A concrete expression of a [=resource=], as defined by [[RFC7231]]: "information
+A concrete expression of a [=resource=], as defined by [[RFC9110]]: "information
 that is intended to reflect a past, current, or desired state of a given
-resource, in a format that can be readily communicated via the protocol, and
-that consists of a set of representation metadata and a potentially unbounded
+resource, in a format that can be readily communicated via the protocol. A
+representation consists of a set of representation metadata and a potentially unbounded
 stream of representation data." A [=DID document=] is a representation of
 information describing a [=DID subject=]. See <a href="#representations"></a>.
       </dd>
@@ -2632,7 +2632,7 @@ system.
 HTTP clients and servers use media types associated with [=DID documents=] in
 `Accept:` headers and when indicating content types. Implementers are warned that
 HTTP servers might ignore the `Accept:` header and return another content type, or
-return an error code such as <a data-cite="RFC7231#status.415">`415
+return an error code such as <a data-cite="RFC9110#status.415">`415
 Unsupported Media Type`</a>.
         </p>
       </section>
@@ -2654,7 +2654,7 @@ implementations of the same [=DID method=].
 Conceptually, the relationship between this specification and a [=DID
 method=] specification is similar to the relationship between the IETF generic
 [=URI=] specification [[?RFC3986]] and a specific [=URI=] scheme
-[[?IANA-URI-SCHEMES]], such as the `http` scheme [[?RFC7230]]. In
+[[?IANA-URI-SCHEMES]], such as the `http` scheme [[?RFC9110]]. In
 addition to defining a specific [=DID scheme=], a [=DID method=]
 specification also defines the mechanisms for creating, resolving, updating, and
 deactivating [=DIDs=] and [=DID documents=] using a specific type of


### PR DESCRIPTION
See https://github.com/w3c/did-resolution/pull/176 and https://github.com/w3c/did-resolution/issues/153


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did/pull/902.html" title="Last updated on Aug 7, 2025, 1:57 PM UTC (0628670)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/902/fb3cfd2...0628670.html" title="Last updated on Aug 7, 2025, 1:57 PM UTC (0628670)">Diff</a>