### PR TITLE
Export terms from DID Core

### DIFF
--- a/index.html
+++ b/index.html
@@ -935,7 +935,7 @@ Anything can be a DID subject: person, group, organization, physical thing,
 digital thing, logical thing, etc.
       </dd>
 
-      <dt><dfn class="export" data-lt="DID URLs|DID URL">DID URL</dfn></dt>
+      <dt><dfn class="export" data-lt="DID URLs">DID URL</dfn></dt>
 
       <dd>
 A [=DID=] plus any additional syntactic component that conforms to the


### PR DESCRIPTION
In order to address https://github.com/w3c/did-resolution/issues/232 we will first  need to export out some terms from DID Core as well as add some aliases for some of the terms. After this PR is merged, the changes in DID resolution to remove duplicate terms can be done.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did/pull/913.html" title="Last updated on Dec 11, 2025, 8:34 PM UTC (c1c9766)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did/913/9123d4f...ottomorac:c1c9766.html" title="Last updated on Dec 11, 2025, 8:34 PM UTC (c1c9766)">Diff</a>